### PR TITLE
Implement visual indicators for machine operation inputs/outputs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npm run format"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/woodworking-features-brainstorm.md
+++ b/docs/woodworking-features-brainstorm.md
@@ -1,0 +1,360 @@
+# Woodworking Features Brainstorm
+
+## Core Woodworking Systems
+
+### Joinery System
+- **Abstracted joinery types** required for different projects
+  - Box joints / Dovetails for boxes and drawers
+  - Mortise & tenon for furniture frames
+  - Dado joints for shelving
+  - Rabbet joints for cabinet backs
+- Implementation: Convert boards into specific "component parts" that imply the joinery
+  - Example: "jewelry box sides" implies box joints have been cut
+  - Different projects require different joint types, adding complexity
+
+### Surface Preparation & Finishing
+- **Sanding system** (simplified)
+  - Boards can be: Rough → Sanded → Finished
+  - Single "sanding" operation rather than multiple grits
+  - Required before finishing for quality products
+- **Finishing system**
+  - Basic: Hand-rubbed finish (slower, entry-level)
+  - Advanced: Spray finish (faster, requires spray booth?)
+  - Affects final product value and quality
+
+### Lumber Processing Tiers
+- **Rough sawn** → **S2S** (surfaced 2 sides) → **S4S** (surfaced 4 sides)
+- Each tier requires different machines and processing
+- Higher tiers cost more but save processing time
+
+## Machine Ecosystem
+
+### Primary Machines (in rough order of acquisition)
+1. **Miter Saw** ✓ (already implemented)
+   - Cutting to length
+   - Clean crosscuts
+
+2. **Table Saw**
+   - Ripping boards to width
+   - Edge jointing (with jig)
+   - Dados, rabbets, grooves
+   - Crosscuts (with sled jig)
+   - Tenons (with tenoning jig)
+
+3. **Band Saw**
+   - Curved cuts
+   - Template creation
+   - Resawing (making thinner boards)
+
+4. **Planer**
+   - Thickness adjustment
+   - Surface preparation (with jointer)
+
+5. **Jointer**
+   - Flattening faces
+   - Squaring edges
+   - Works in tandem with planer
+
+6. **Router Table**
+   - Edge profiles (roundovers, chamfers, ogees)
+   - Template routing
+   - Some joinery operations
+
+7. **Lathe**
+   - Turning round components (legs, spindles)
+   - Bowl turning specialization path?
+
+8. **CNC Router** (end-game)
+   - Automated complex cuts
+   - Batch production
+   - Can run unattended
+
+### Jigs & Fixtures
+Essential upgrades for machines:
+- **Crosscut sled** (table saw) - safer, more accurate crosscuts
+- **Tenoning jig** (table saw) - consistent tenon cuts
+- **Tapering jig** (table saw) - angled cuts for legs
+- **Box joint jig** (table saw/router) - perfect box joints
+- **Circle cutting jig** (band saw/router)
+
+### Tool Upgrades for Workspace
+Hand tools as workspace upgrades rather than individual items:
+- **Basic hand tools** (included with workspace)
+- **Chisel set upgrade** - enables hand-cut dovetails
+- **Hand plane upgrade** - fine finishing capability
+- **Measuring upgrade** - reduces waste, improves accuracy
+- **Clamping upgrade** - enables larger glue-ups
+
+## Product Progression System
+
+### Progression Axes
+1. **Complexity progression** (same item, more advanced)
+   - Simple cutting board → Edge grain cutting board → End grain cutting board
+   - Basic shelf → Adjustable shelf → Floating shelf with hidden mounting
+
+2. **Category progression** (increasingly complex items)
+   - Cutting board → Jewelry box → Shelf → Stool → Chair → Table → Cabinet
+
+3. **Volume progression** (scaling production)
+   - Single items → Small batches → Mass production
+   - Unlocks batch operations and assembly line setups
+
+### Component System
+Multi-level assembly for complex projects:
+```
+Example: Dining Table
+├── Tabletop
+│   ├── Boards (glued into panel)
+│   └── Edge banding
+├── Apron assembly
+│   ├── Apron pieces (4x)
+│   └── Corner blocks
+└── Legs (4x)
+    ├── Turned on lathe
+    └── Sanded & finished
+```
+
+### Glue-Up Operations
+- Simple time-based operation (like other machine operations)
+- Multiple boards → panels
+- Component assembly → final products
+- No complex clamp management - just time to dry
+
+## Business & Resource Management
+
+### Waste Management System
+- **Sawdust generation**
+  - Visual particle effects during operations
+  - Accumulates requiring periodic cleanup?
+  - Can sell to particle board manufacturers
+  - Advanced: Dust collection system upgrade
+- **Offcuts & scraps**
+  - Can be used for small projects (coasters, small boxes)
+  - Sell as kindling/firewood
+  - Feed into chip production?
+
+### Machine Maintenance
+- Machines gradually lose efficiency over time
+- Maintenance restores to 100% efficiency
+- Could be automatic with hired help later?
+- Visual indicators (dust buildup, worn blades)
+
+### Commission System Evolution
+- Start with simple, single-operation items
+- Progress to multi-component assemblies
+- Custom requests with specific requirements
+  - Wood species preferences
+  - Size specifications
+  - Finish requirements
+- Reputation affects commission quality/complexity
+
+## Production Optimization
+
+### Templates & Repeatability
+- **Templates are essential for non-rectangular identical parts**
+  - Required when a project needs multiple curved/shaped pieces
+  - Create template → use with router/bandsaw to duplicate
+  - Reusable across multiple projects
+  - Example: 4 identical curved chair backs, shaped table legs
+- **Template routing process**
+  - Make master template (bandsaw, careful hand work)
+  - Rough cut pieces close to shape
+  - Template route to exact match
+
+### Alternative Production Paths
+Allow multiple ways to achieve the same result:
+- **Example: Creating a mortise**
+  - Drill press + chisel (slow, early game)
+  - Mortising machine (dedicated, fast)
+  - Router with jig (versatile)
+  - CNC router (automated)
+
+### Batch Processing
+- Set up jigs once, run multiple pieces
+- Assembly line organization
+- Efficiency bonuses for repeated operations
+
+### Material Flow Optimization
+- Shop layout affects efficiency
+- Material staging areas
+- Tool/jig storage accessibility
+- Finishing area separation (dust-free zone)
+
+## Potential Specialization Paths
+
+### Furniture Making
+- Focus on large pieces
+- Complex joinery
+- Upholstery integration?
+
+### Fine Woodworking
+- Jewelry boxes, decorative items
+- Inlay work?
+- Exotic wood usage
+
+### Production Woodworking
+- Batch production focus
+- Jigs and templates
+- CNC integration
+
+### Wood Turning
+- Lathe specialization
+- Bowls, vases, spindles
+- Different wood preparation needs
+
+## UI/UX Considerations
+
+### Visual Feedback Systems
+- Sawdust particles during cuts
+- Wood shavings for planing
+- Progress bars for multi-step operations
+- Quality indicators on finished products
+
+### Information Display
+- Material requirements preview
+- Operation time estimates
+- Efficiency metrics
+- Waste generation warnings
+
+## Future Expansion Ideas
+
+### Seasonal/Special Events
+- Holiday ornament commissions
+- Craft fair preparations
+- Custom order rushes
+
+### Advanced Materials
+- Exotic woods with special properties
+- Reclaimed wood with unique character
+- Live edge slabs for premium products
+
+### Business Expansion
+- **Employee/Apprentice System**
+  - Hire workers to operate machines
+  - Assign tasks while you work elsewhere
+  - Scale up production capacity
+  - Training system to improve employee efficiency?
+- Opening a showroom
+- Online sales integration
+- Teaching classes for passive income
+
+## Skill & Progression Systems
+
+### Player Skill System
+- **Skill point system** (preferred over passive experience)
+  - Earn experience points from completing projects
+  - Spend skill points on perks/upgrades
+  - Potential skill trees for different specializations
+- **Possible skill perks:**
+  - Faster operation speeds for specific machine types
+  - Reduced material waste
+  - Ability to eyeball measurements (skip some layout steps?)
+  - Batch operation bonuses
+  - Better commission negotiation (higher prices)
+  - Unlock advanced techniques
+  - Quality bonuses that increase sale value
+  - Employee training speed bonuses
+
+## Machine Tier System
+
+### Progressive Machine Upgrades
+Each machine type has multiple tiers representing quality/capability:
+
+**Table Saw Evolution:**
+- **Jobsite saw** (120V, portable, limited power)
+  - Basic ripping and crosscutting
+  - Limited width capacity
+  - Slower, less precise
+- **Contractor/Hybrid saw** (220V)
+  - Better fence system
+  - More power for hardwoods
+  - Dust collection hookups
+- **Cabinet saw** (220V, professional)
+  - Precise, repeatable cuts
+  - Large capacity
+  - Faster operation
+- **Industrial saw** (3-phase, production)
+  - Continuous operation
+  - Highest speed/precision
+  - Advanced safety features
+
+### Power Requirements Drive Shop Progression
+- **Garage (120V only)**: Limits to entry-level machines
+- **Hobby Shop (120V + 220V)**: Enables serious equipment
+- **Pro Shop (3-phase power)**: Industrial machinery unlocked
+
+## Advanced Material Challenges
+
+### Working with Slabs
+- **Unique slab challenges:**
+  - Flattening operations (router sled, hand planes)
+  - Dealing with irregular edges
+  - Crack filling with epoxy?
+  - Much heavier/harder to move
+- Live edge products command premium prices
+- Requires special handling and storage
+
+### Size Complexity Scaling
+- **Larger pieces = longer operation times**
+  - Exponential scaling on basic tools
+  - Linear scaling on professional tools
+  - Negligible impact on industrial/CNC
+- Examples:
+  - Cutting a 2" thick slab on jobsite saw: 3x time
+  - Same cut on industrial saw: 1.2x time
+  - Moving large pieces between machines takes longer
+
+## Storage & Organization Systems
+
+### Material Storage
+- **Limited carrying capacity** (replace infinite inventory)
+- **Storage solutions:**
+  - Lumber racks (vertical/horizontal)
+  - Offcut bins
+  - Hardware organizers
+  - Finishing supplies cabinet
+- **Organization affects efficiency:**
+  - Searching for materials wastes time
+  - Good organization provides speed bonuses
+  - Visual indicators for full/empty storage
+
+### Material Handling
+- **Weight/size considerations:**
+  - Can only carry limited quantity
+  - Large pieces require special handling
+  - May need helper or equipment for big items
+- **Material carts/dollies** as upgrades
+- **Overhead crane** for industrial shop?
+
+## Questions Resolved
+
+1. ~~How detailed should the glue-up system be?~~ → Simple time-based operation
+2. ~~Should finishing have quality levels?~~ → No, complexity comes from simple vs advanced product variants
+3. ~~Hardware (hinges, pulls, etc.)?~~ → Purchase complete, install during assembly
+4. ~~Should templates be reusable?~~ → Yes, essential for making identical non-rectangular parts
+5. ~~Machine maintenance?~~ → Skip this, not fun
+6. ~~Skill/experience system?~~ → Yes, skill points for perks/upgrades
+7. ~~Wood movement/seasonal changes?~~ → Skip this
+8. Integration of non-wood materials (glass, metal, upholstery)?
+
+## Implementation Priority
+
+### Phase 1: Core Systems
+- Sanding & finishing
+- Basic joinery abstractions
+- Table saw with basic operations
+
+### Phase 2: Expansion
+- Component assembly system
+- Glue-ups
+- Additional machines (planer, jointer, band saw)
+
+### Phase 3: Advanced Features
+- Jigs and fixtures
+- Alternative production paths
+- CNC and automation
+
+### Phase 4: Polish
+- Sawdust/waste system
+- Maintenance mechanics
+- Specialization paths

--- a/package-lock.json
+++ b/package-lock.json
@@ -4786,9 +4786,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001588",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001588.tgz",
-      "integrity": "sha512-+hVY9jE44uKLkH0SrUTqxjxqNTOWHsbnQDIKjwkZ3lNTzUUVdBLBGXtj/q5Mp5u98r3droaZAewQuEDzjQdZlQ==",
+      "version": "1.0.30001743",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001743.tgz",
+      "integrity": "sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==",
       "funding": [
         {
           "type": "opencollective",
@@ -4802,7 +4802,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",

--- a/src/components/current-cell-info/MachinesSection.tsx
+++ b/src/components/current-cell-info/MachinesSection.tsx
@@ -222,8 +222,8 @@ const MachineListItem: React.FC<{ machine: Machine }> = ({ machine }) => {
               onChange={(event) => {
                 const newParams = {
                   ...machine.selectedParameters,
-                  [param.id]: event.target.value.includes('"')
-                    ? parseInt(event.target.value)
+                  [param.id]: typeof param.values[0] === "number"
+                    ? Number(event.target.value)
                     : event.target.value,
                 };
                 applyAction(

--- a/src/components/current-cell-info/MaterialIcon.tsx
+++ b/src/components/current-cell-info/MaterialIcon.tsx
@@ -48,7 +48,10 @@ export const MaterialIcon: React.FC<{
   material: MaterialInstance;
   size?: keyof typeof sizeToScale;
   quantity?: number;
-}> = ({ material, size = "medium", quantity }) => {
+  placeholder?: boolean;
+  isValid?: boolean;
+  tooltip?: string;
+}> = ({ material, size = "medium", quantity, placeholder = false, isValid = true, tooltip }) => {
   switch (material.type) {
     // Make the board with SVG so we don't have to use Pixi to render it
     case "board": {
@@ -58,7 +61,7 @@ export const MaterialIcon: React.FC<{
       const depth = (board.thickness * PIXELS_PER_INCH) / 4;
 
       return (
-        <Wrapper size={size} quantity={quantity}>
+        <Wrapper size={size} quantity={quantity} isValid={isValid} tooltip={tooltip} placeholder={placeholder}>
           <svg
             viewBox={`0 0 ${PIXELS_PER_CELL} ${PIXELS_PER_CELL}`}
             className="w-full"
@@ -89,7 +92,7 @@ export const MaterialIcon: React.FC<{
       const depth = (board.thickness * PIXELS_PER_INCH) / 4;
 
       return (
-        <Wrapper size={size}>
+        <Wrapper size={size} isValid={isValid} tooltip={tooltip} placeholder={placeholder}>
           <svg
             viewBox={`0 0 ${PIXELS_PER_CELL} ${PIXELS_PER_CELL}`}
             className="w-full"
@@ -115,16 +118,18 @@ export const MaterialIcon: React.FC<{
 
     case "pallet":
       return (
-        <Wrapper size={size}>
+        <Wrapper size={size} isValid={isValid} tooltip={tooltip} placeholder={placeholder}>
           <img src="/images/pallet.png" />
         </Wrapper>
       );
 
     default:
       return (
-        <SimpleSpriteStage scale={sizeToScale[size]}>
-          <MaterialSprite material={material} />
-        </SimpleSpriteStage>
+        <Wrapper size={size} isValid={isValid} tooltip={tooltip} placeholder={placeholder}>
+          <SimpleSpriteStage scale={sizeToScale[size]}>
+            <MaterialSprite material={material} />
+          </SimpleSpriteStage>
+        </Wrapper>
       );
   }
 };
@@ -140,19 +145,43 @@ const Wrapper: React.FC<{
   children: ReactNode;
   size: keyof typeof sizeToClassname;
   quantity?: number;
-}> = ({ children, size, quantity }) => {
+  isValid?: boolean;
+  tooltip?: string;
+  placeholder?: boolean;
+}> = ({ children, size, quantity, isValid = true, tooltip, placeholder = false }) => {
+  // Determine border style based on state
+  const borderStyle = placeholder
+    ? "border-2 border-dashed border-zinc-600"
+    : isValid
+      ? "border border-zinc-600"
+      : "border-2 border-red-500";
+
+  const bgStyle = placeholder
+    ? "bg-zinc-800/50"
+    : isValid
+      ? "bg-zinc-700"
+      : "bg-red-900/20";
+
   return (
     <span
       className={classNames(
-        "rounded bg-zinc-700 inline-block overflow-hidden relative",
-        sizeToClassname[size]
+        "rounded inline-block overflow-hidden relative",
+        sizeToClassname[size],
+        borderStyle,
+        bgStyle,
+        placeholder ? "opacity-50" : ""
       )}
+      title={tooltip}
     >
       {children}
       {quantity && (
-        <span className="absolute bottom-0.5 right-0.5 text-xs select-none">
+        <span className="absolute bottom-0.5 right-0.5 text-xs select-none bg-black/70 px-1 rounded">
           {quantity}
         </span>
+      )}
+      {/* Validation indicator for invalid materials */}
+      {!isValid && !placeholder && (
+        <span className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full" />
       )}
     </span>
   );

--- a/src/components/shop-view/ShopKeyboardShortcuts.tsx
+++ b/src/components/shop-view/ShopKeyboardShortcuts.tsx
@@ -16,6 +16,8 @@ import { materialMeetsInput } from "../../game/material-helpers";
 import { mod } from "../../utils/mathUtils";
 import { useApplyGameAction, useGameState } from "../useGameState";
 import { useKeyDown } from "../useKeyDown";
+import { getOperationInputMaterials, isParameterizedOperation } from "../../game/operation-helpers";
+import { ParameterValues } from "../../game/Machine";
 
 export const ShopKeyboardShortcuts: React.FC = () => {
   const applyAction = useApplyGameAction();
@@ -101,8 +103,13 @@ export const ShopKeyboardShortcuts: React.FC = () => {
           const spacesLeft =
             machine.type.inputSpaces - machine.inputMaterials.length;
 
+          const inputMaterials = getOperationInputMaterials(
+            machine.selectedOperation,
+            machine.selectedParameters
+          );
+          
           const matchingMaterials = inventory.filter((material) =>
-            machine.selectedOperation.inputMaterials.some((input) =>
+            inputMaterials.some((input: any) =>
               materialMeetsInput(material, input)
             )
           );
@@ -153,11 +160,20 @@ export const ShopKeyboardShortcuts: React.FC = () => {
           operationIndex + (event.shiftKey ? -1 : 1),
           machine.type.operations.length
         );
+        
+        const nextOperation = machine.type.operations[nextOperationIndex];
+        let parameters: ParameterValues | undefined = undefined;
+        
+        // Set default parameters for parameterized operations
+        if (isParameterizedOperation(nextOperation)) {
+          parameters = {};
+          for (const param of nextOperation.parameters) {
+            parameters[param.id] = param.values[0];
+          }
+        }
+        
         return applyAction(
-          setMachineOperationAction(
-            machine,
-            machine.type.operations[nextOperationIndex]
-          )
+          setMachineOperationAction(machine, nextOperation, parameters)
         );
       }
     }

--- a/src/game/Machine.ts
+++ b/src/game/Machine.ts
@@ -10,7 +10,7 @@ export interface MachineType {
   readonly id: string;
   readonly name: string;
   readonly description: string;
-  readonly operations: ReadonlyArray<MachineOperation>;
+  readonly operations: ReadonlyArray<MachineOperation | ParameterizedOperation>;
   readonly cellsOccupied: ReadonlyArray<Vector>;
   readonly freeCellsNeeded: ReadonlyArray<Vector>;
   readonly operationPosition?: Vector;
@@ -55,6 +55,24 @@ export interface OperationOutput {
   outputs: ReadonlyArray<MaterialInstance>;
 }
 
+// Parameterized operation system
+export interface OperationParameter<T = number | string> {
+  readonly id: string;
+  readonly name: string;
+  readonly values: ReadonlyArray<T>;
+}
+
+export type ParameterValues = Record<string, number | string>;
+
+export interface ParameterizedOperation<TParams extends ParameterValues = ParameterValues> {
+  readonly id: string;
+  readonly name: string;
+  readonly duration: number;
+  readonly parameters: ReadonlyArray<OperationParameter>;
+  readonly getInputMaterials: (params: TParams) => ReadonlyArray<InputMaterialWithQuantity>;
+  readonly output: (materials: ReadonlyArray<MaterialInstance>, params: TParams) => OperationOutput;
+}
+
 export interface OperationProgress {
   readonly status: "notStarted" | "inProgress" | "finished";
   readonly ticksRemaining: number;
@@ -64,7 +82,8 @@ export interface Machine {
   readonly type: MachineType;
   readonly position: Vector;
   readonly rotation: Direction;
-  readonly selectedOperation: MachineOperation;
+  readonly selectedOperation: MachineOperation | ParameterizedOperation;
+  readonly selectedParameters?: ParameterValues;
   readonly operationProgress: OperationProgress;
   readonly inputMaterials: ReadonlyArray<MaterialInstance>;
   readonly processingMaterials: ReadonlyArray<MaterialInstance>;

--- a/src/game/Machine.ts
+++ b/src/game/Machine.ts
@@ -64,13 +64,20 @@ export interface OperationParameter<T = number | string> {
 
 export type ParameterValues = Record<string, number | string>;
 
-export interface ParameterizedOperation<TParams extends ParameterValues = ParameterValues> {
+export interface ParameterizedOperation<
+  TParams extends ParameterValues = ParameterValues,
+> {
   readonly id: string;
   readonly name: string;
   readonly duration: number;
   readonly parameters: ReadonlyArray<OperationParameter>;
-  readonly getInputMaterials: (params: TParams) => ReadonlyArray<InputMaterialWithQuantity>;
-  readonly output: (materials: ReadonlyArray<MaterialInstance>, params: TParams) => OperationOutput;
+  readonly getInputMaterials: (
+    params: TParams,
+  ) => ReadonlyArray<InputMaterialWithQuantity>;
+  readonly output: (
+    materials: ReadonlyArray<MaterialInstance>,
+    params: TParams,
+  ) => OperationOutput;
 }
 
 export interface OperationProgress {

--- a/src/game/Materials.ts
+++ b/src/game/Materials.ts
@@ -2,8 +2,10 @@
 
 import { Tuple } from "../utils/typeUtils";
 
-export const BOARD_DIMENSIONS = [1, 2, 3, 4, 5, 6, 7, 8] as const;
+export const BOARD_DIMENSIONS = [1, 2, 3, 4, 5, 6, 7, 8] as const; // either feet, inches, or quarters of an inch
+export const SHEET_THICKNESSES = [1, 2, 3, 4] as const; // in quarters of an inch
 export type BoardDimension = (typeof BOARD_DIMENSIONS)[number];
+export type SheetThickness = (typeof SHEET_THICKNESSES)[number];
 
 export const SPECIES = [
   "pallet",
@@ -28,9 +30,9 @@ export interface Board {
 }
 
 export type SheetGoodKind =
-  | "plywoodA"
-  | "plywoodB"
-  | "plywoodC"
+  | "plywoodA" // high quality
+  | "plywoodB" // medium quality
+  | "plywoodC" // low quality
   | "mdf"
   | "osb"
   | "particleBoard";
@@ -40,7 +42,7 @@ export interface SheetGood {
   readonly type: "plywood";
   readonly length: BoardDimension;
   readonly width: BoardDimension;
-  readonly thickness: 1 | 2 | 3 | 4; // 1/4", 1/2", 3/4", 1"
+  readonly thickness: SheetThickness;
   readonly kind: SheetGoodKind;
 }
 

--- a/src/game/Materials.ts
+++ b/src/game/Materials.ts
@@ -57,6 +57,16 @@ export type Pallet = {
   readonly stringerBoardsLeft: number;
 };
 
-export type MaterialInstance = Pallet | Board | SheetGood | FinishedProduct;
+export type UnknownMaterial = {
+  readonly id: string;
+  readonly type: "unknown";
+};
+
+export type MaterialInstance =
+  | Pallet
+  | Board
+  | SheetGood
+  | FinishedProduct
+  | UnknownMaterial;
 
 export type MaterialType = MaterialInstance["type"];

--- a/src/game/board-helpers.ts
+++ b/src/game/board-helpers.ts
@@ -8,7 +8,7 @@ export function board(
   species: Board["species"] = "pallet",
   length: Board["length"] = 1,
   width: Board["width"] = 1,
-  thickness: Board["thickness"] = 1
+  thickness: Board["thickness"] = 1,
 ): MaterialInstance & { type: "board" } {
   return makeMaterial({
     type: "board",
@@ -28,7 +28,7 @@ export function cutBoard(
   inputBoard: Board,
   outputSize: BoardDimension,
   dimension: "length" | "width" | "thickness",
-  waste: number = 0
+  waste: number = 0,
 ): OperationOutput {
   const startingDimension = inputBoard[dimension];
 

--- a/src/game/game-actions/tickAction.ts
+++ b/src/game/game-actions/tickAction.ts
@@ -1,5 +1,6 @@
 import { GameAction } from "../GameState";
 import { applyWorkItemAction } from "./work-item-actions";
+import { executeOperation } from "../operation-helpers";
 
 export const tickAction: GameAction = (gameState) => {
   gameState = {
@@ -45,8 +46,10 @@ export const tickAction: GameAction = (gameState) => {
     }
 
     // Operation completed - apply the transformation
-    const { inputs, outputs } = machine.selectedOperation.output(
-      machine.processingMaterials
+    const { inputs, outputs } = executeOperation(
+      machine.selectedOperation,
+      machine.processingMaterials,
+      machine.selectedParameters
     );
 
     return {

--- a/src/game/initialGameState.tsx
+++ b/src/game/initialGameState.tsx
@@ -1,7 +1,8 @@
 import { GameState } from "./GameState";
-import { MACHINE_TYPES, Machine, MachineType } from "./Machine";
+import { MACHINE_TYPES, Machine, MachineType, ParameterValues } from "./Machine";
 import { Direction } from "./Vectors";
 import { makePallet } from "./material-helpers";
+import { isParameterizedOperation } from "./operation-helpers";
 
 export const initialGameState: GameState = {
   tick: 0,
@@ -57,6 +58,17 @@ function machine(
   position: [number, number],
   rotation: Direction,
 ): Machine {
+  const firstOperation = type.operations[0];
+  let selectedParameters: ParameterValues | undefined;
+  
+  // If the first operation is parameterized, set default parameter values
+  if (isParameterizedOperation(firstOperation)) {
+    selectedParameters = {};
+    for (const param of firstOperation.parameters) {
+      selectedParameters[param.id] = param.values[0];
+    }
+  }
+  
   return {
     type,
     position,
@@ -64,7 +76,8 @@ function machine(
     inputMaterials: [],
     processingMaterials: [],
     outputMaterials: [],
-    selectedOperation: type.operations[0],
+    selectedOperation: firstOperation,
+    selectedParameters,
     operationProgress: {
       status: "notStarted",
       ticksRemaining: 0,

--- a/src/game/initialGameState.tsx
+++ b/src/game/initialGameState.tsx
@@ -1,5 +1,10 @@
 import { GameState } from "./GameState";
-import { MACHINE_TYPES, Machine, MachineType, ParameterValues } from "./Machine";
+import {
+  MACHINE_TYPES,
+  Machine,
+  MachineType,
+  ParameterValues,
+} from "./Machine";
 import { Direction } from "./Vectors";
 import { makePallet } from "./material-helpers";
 import { isParameterizedOperation } from "./operation-helpers";
@@ -32,7 +37,9 @@ export const initialGameState: GameState = {
   },
   commissions: [
     {
-      requiredMaterials: [{ type: ["rusticShelf"], species: ["pallet"], quantity: 1 }],
+      requiredMaterials: [
+        { type: ["rusticShelf"], species: ["pallet"], quantity: 1 },
+      ],
       rewardMoney: 150, // Enough to buy miter saw for next progression
       rewardReputation: 2,
     },
@@ -60,7 +67,7 @@ function machine(
 ): Machine {
   const firstOperation = type.operations[0];
   let selectedParameters: ParameterValues | undefined;
-  
+
   // If the first operation is parameterized, set default parameter values
   if (isParameterizedOperation(firstOperation)) {
     selectedParameters = {};
@@ -68,7 +75,7 @@ function machine(
       selectedParameters[param.id] = param.values[0];
     }
   }
-  
+
   return {
     type,
     position,

--- a/src/game/machine-helpers.ts
+++ b/src/game/machine-helpers.ts
@@ -7,10 +7,10 @@ export function machineCanOperate(machine: Machine): boolean {
   const inventory = [...machine.inputMaterials];
 
   const materialsToConsume: MaterialInstance[] = [];
-  
+
   const inputMaterials = getOperationInputMaterials(
     machine.selectedOperation,
-    machine.selectedParameters
+    machine.selectedParameters,
   );
 
   for (const inputMaterial of inputMaterials) {

--- a/src/game/machine-helpers.ts
+++ b/src/game/machine-helpers.ts
@@ -1,13 +1,19 @@
 import { Machine } from "./Machine";
 import { MaterialInstance } from "./Materials";
 import { materialMeetsInput } from "./material-helpers";
+import { getOperationInputMaterials } from "./operation-helpers";
 
 export function machineCanOperate(machine: Machine): boolean {
   const inventory = [...machine.inputMaterials];
 
   const materialsToConsume: MaterialInstance[] = [];
+  
+  const inputMaterials = getOperationInputMaterials(
+    machine.selectedOperation,
+    machine.selectedParameters
+  );
 
-  for (const inputMaterial of machine.selectedOperation.inputMaterials) {
+  for (const inputMaterial of inputMaterials) {
     for (let i = 0; i < inputMaterial.quantity; i++) {
       // TODO: Quantity
       const index = inventory.findIndex((m) =>

--- a/src/game/machines/jobsiteTableSaw.ts
+++ b/src/game/machines/jobsiteTableSaw.ts
@@ -1,9 +1,5 @@
-import {
-  InputMaterialWithQuantity,
-  MachineOperation,
-  MachineType,
-} from "../Machine";
-import { BOARD_DIMENSIONS, Board } from "../Materials";
+import { MachineType, ParameterizedOperation } from "../Machine";
+import { BOARD_DIMENSIONS, BoardDimension } from "../Materials";
 import { cutBoard, isBoard } from "../board-helpers";
 
 export const jobsiteTableSaw: MachineType = {
@@ -21,26 +17,31 @@ export const jobsiteTableSaw: MachineType = {
   toolStorage: 0,
   inputSpaces: 1,
   operations: [
-    ...BOARD_DIMENSIONS.map(
-      (width): MachineOperation => ({
-        name: `Rip Board - ${width}'`,
-        id: `ripBoard${width}`,
-        duration: 15,
-        inputMaterials: [
-          {
-            type: ["board"] as const,
-            width: BOARD_DIMENSIONS.filter((d) => d > width),
-            quantity: 1,
-          } satisfies InputMaterialWithQuantity<Board>,
-        ],
-        output: (materials) => {
-          const inputBoard = materials[0];
-          if (!isBoard(inputBoard)) {
-            throw new Error("Input material is not a board");
-          }
-          return cutBoard(inputBoard, width, "width");
+    {
+      id: "ripBoard",
+      name: "Rip Board",
+      duration: 15,
+      parameters: [
+        {
+          id: "targetWidth",
+          name: "Target Width",
+          values: BOARD_DIMENSIONS,
         },
-      })
-    ),
+      ],
+      getInputMaterials: (params) => [
+        {
+          type: ["board"],
+          width: BOARD_DIMENSIONS.filter((d) => d > (params.targetWidth as BoardDimension)),
+          quantity: 1,
+        },
+      ],
+      output: (materials, params) => {
+        const inputBoard = materials[0];
+        if (!isBoard(inputBoard)) {
+          throw new Error("Input material is not a board");
+        }
+        return cutBoard(inputBoard, params.targetWidth as BoardDimension, "width");
+      },
+    } as ParameterizedOperation,
   ],
 };

--- a/src/game/machines/miterSaw.ts
+++ b/src/game/machines/miterSaw.ts
@@ -1,5 +1,5 @@
-import { MachineOperation, MachineType } from "../Machine";
-import { BOARD_DIMENSIONS } from "../Materials";
+import { MachineType, ParameterizedOperation } from "../Machine";
+import { BOARD_DIMENSIONS, BoardDimension } from "../Materials";
 import { cutBoard, isBoard } from "../board-helpers";
 
 export const miterSaw: MachineType = {
@@ -14,26 +14,31 @@ export const miterSaw: MachineType = {
   toolStorage: 0,
   inputSpaces: 1,
   operations: [
-    ...BOARD_DIMENSIONS.map(
-      (length): MachineOperation => ({
-        name: `Cut Board ${length}"`,
-        id: `cutBoard${length}`,
-        duration: 15,
-        inputMaterials: [
-          {
-            type: ["board"],
-            length: BOARD_DIMENSIONS.filter((d) => d > length),
-            quantity: 1,
-          },
-        ],
-        output: (materials) => {
-          const inputBoard = materials[0];
-          if (!isBoard(inputBoard)) {
-            throw new Error("Input material is not a board");
-          }
-          return cutBoard(inputBoard, length, "length");
+    {
+      id: "cutBoard",
+      name: "Cut Board",
+      duration: 15,
+      parameters: [
+        {
+          id: "targetLength",
+          name: "Target Length",
+          values: BOARD_DIMENSIONS,
         },
-      })
-    ),
+      ],
+      getInputMaterials: (params) => [
+        {
+          type: ["board"],
+          length: BOARD_DIMENSIONS.filter((d) => d > (params.targetLength as BoardDimension)),
+          quantity: 1,
+        },
+      ],
+      output: (materials, params) => {
+        const inputBoard = materials[0];
+        if (!isBoard(inputBoard)) {
+          throw new Error("Input material is not a board");
+        }
+        return cutBoard(inputBoard, params.targetLength as BoardDimension, "length");
+      },
+    } as ParameterizedOperation,
   ],
 };

--- a/src/game/machines/workspace.ts
+++ b/src/game/machines/workspace.ts
@@ -2,7 +2,7 @@ import { array } from "../../utils/arrayUtils";
 import { board } from "../board-helpers";
 import { MachineType } from "../Machine";
 import { makeMaterial } from "../material-helpers";
-import { Pallet, FinishedProduct, Board } from "../Materials";
+import { Pallet, FinishedProduct, Board, MaterialInstance } from "../Materials";
 
 export const workspace: MachineType = {
   id: "workspace",
@@ -21,14 +21,14 @@ export const workspace: MachineType = {
       id: "dismantlePallet",
       duration: 4,
       inputMaterials: [{ type: ["pallet"], quantity: 1 }],
-      output: (materials) => {
+      output: (materials: ReadonlyArray<MaterialInstance>) => {
         const inputPallet = materials[0];
         if (inputPallet.type !== "pallet") {
           throw new Error("Input material is not a pallet");
         }
 
         const deckBoardsCount = inputPallet.deckBoards.filter(
-          (board) => board
+          (board: boolean) => board
         ).length;
         if (deckBoardsCount <= 1) {
           const stringers = array(3).map(() => board("pallet", 4, 6, 3));
@@ -43,7 +43,7 @@ export const workspace: MachineType = {
           const deckBoardsLeft = [
             ...inputPallet.deckBoards,
           ] as typeof inputPallet.deckBoards;
-          const index = deckBoardsLeft.findLastIndex((board) => board === true);
+          const index = deckBoardsLeft.findLastIndex((board: boolean) => board === true);
           deckBoardsLeft[index] = false;
           return {
             inputs: [
@@ -65,9 +65,9 @@ export const workspace: MachineType = {
         { type: ["board"], species: ["pallet"], width: [6], length: [4], quantity: 2 }, // stringers as shelves
         { type: ["board"], species: ["pallet"], width: [4], length: [3], quantity: 3 }, // deck boards as back support
       ],
-      output: (materials) => {
+      output: (materials: ReadonlyArray<MaterialInstance>) => {
         // Validate inputs
-        const boards = materials.filter((m): m is Board => m.type === "board");
+        const boards = materials.filter((m: MaterialInstance): m is Board => m.type === "board");
         if (boards.length !== 5) {
           throw new Error("Need exactly 5 boards to build a rustic shelf");
         }

--- a/src/game/material-helpers.ts
+++ b/src/game/material-helpers.ts
@@ -9,14 +9,13 @@ import {
   MaterialInstance,
   Pallet,
   SheetGood,
-  Species,
   UnknownMaterial,
 } from "./Materials";
 
 const makeId = idMaker();
 
 export function makeMaterial<T extends MaterialInstance>(
-  materialInitializer: Omit<T, "id">
+  materialInitializer: Omit<T, "id">,
 ): T {
   return {
     ...materialInitializer,
@@ -49,7 +48,7 @@ export function getMaterialName(material: MaterialInstance): string {
     case "board": {
       const { species, width, length, thickness } = material;
       return `${humanizeString(
-        species
+        species,
       )} Board (${length}'x${width}"x${thickness}/4)`;
     }
     default:
@@ -94,7 +93,7 @@ export function getMaterialInventorySize(material: MaterialInstance): number {
 }
 
 export function materialToInput<T extends MaterialInstance = MaterialInstance>(
-  material: T
+  material: T,
 ): InputMaterial<T> {
   const result: InputMaterial<T> = {};
   for (const key in material) {
@@ -107,7 +106,7 @@ export function materialToInput<T extends MaterialInstance = MaterialInstance>(
 
 export function materialMeetsInput(
   material: MaterialInstance,
-  inputMaterial: InputMaterial
+  inputMaterial: InputMaterial,
 ) {
   for (const key of Object.keys(inputMaterial)) {
     // Make sure to skip quantity, because that's not a property of the material
@@ -117,7 +116,7 @@ export function materialMeetsInput(
       return false;
     } else if (
       !(inputMaterial as Record<string, unknown[]>)[key].includes(
-        (material as Record<string, unknown>)[key]
+        (material as Record<string, unknown>)[key],
       )
     ) {
       return false;
@@ -128,7 +127,7 @@ export function materialMeetsInput(
 
 // Helper to create a mock material from a requirement for placeholder display
 export function createMockMaterial(
-  requirement: InputMaterialWithQuantity
+  requirement: InputMaterialWithQuantity,
 ): MaterialInstance {
   if (requirement.type === undefined || requirement.type.length === 0) {
     throw new Error("Requirement must specify at least one material type");
@@ -149,10 +148,10 @@ export function createMockMaterial(
       const r = requirement as InputMaterialWithQuantity<SheetGood>;
       return makeMaterial<SheetGood>({
         type: "plywood",
+        kind: r.kind?.[0] || "plywoodA",
         length: (r.length?.[0] || 8) as BoardDimension,
         width: (r.width?.[0] || 4) as BoardDimension,
-        thickness: (r.thickness?.[0] || 2) as BoardDimension,
-        species: (requirement.species?.[0] || "pine") as Species,
+        thickness: (r.thickness?.[0] || 2) as SheetGood["thickness"],
       });
     }
 
@@ -183,7 +182,7 @@ export function createMockMaterial(
         type: requirement.type[0],
         species:
           "species" in requirement
-            ? requirement.species?.[0] ?? "pine"
+            ? (requirement.species?.[0] ?? "pine")
             : "pine",
       });
 

--- a/src/game/operation-helpers.ts
+++ b/src/game/operation-helpers.ts
@@ -1,14 +1,28 @@
-import { InputMaterialWithQuantity, MachineOperation, OperationOutput, ParameterizedOperation, ParameterValues } from "./Machine";
-import { MaterialInstance, Board, Pallet, SheetGood, FinishedProduct, BoardDimension, Species } from "./Materials";
+import {
+  InputMaterialWithQuantity,
+  MachineOperation,
+  OperationOutput,
+  ParameterizedOperation,
+  ParameterValues,
+} from "./Machine";
+import {
+  MaterialInstance,
+  Board,
+  Pallet,
+  SheetGood,
+  FinishedProduct,
+  BoardDimension,
+  Species,
+} from "./Materials";
 import { makeMaterial } from "./material-helpers";
 
 /**
  * Type guard to check if an operation is parameterized
  */
 export function isParameterizedOperation(
-  operation: MachineOperation | ParameterizedOperation
+  operation: MachineOperation | ParameterizedOperation,
 ): operation is ParameterizedOperation {
-  return 'parameters' in operation && 'getInputMaterials' in operation;
+  return "parameters" in operation && "getInputMaterials" in operation;
 }
 
 /**
@@ -16,7 +30,7 @@ export function isParameterizedOperation(
  */
 export function getOperationInputMaterials(
   operation: MachineOperation | ParameterizedOperation,
-  params?: ParameterValues
+  params?: ParameterValues,
 ): ReadonlyArray<InputMaterialWithQuantity> {
   if (isParameterizedOperation(operation)) {
     if (!params) {
@@ -39,7 +53,7 @@ export function getOperationInputMaterials(
 export function executeOperation(
   operation: MachineOperation | ParameterizedOperation,
   materials: ReadonlyArray<MaterialInstance>,
-  params?: ParameterValues
+  params?: ParameterValues,
 ): OperationOutput {
   if (isParameterizedOperation(operation)) {
     if (!params) {
@@ -56,23 +70,25 @@ export function executeOperation(
  * Used for previewing what an operation will produce.
  */
 export function generateMockMaterials(
-  requirements: ReadonlyArray<InputMaterialWithQuantity>
+  requirements: ReadonlyArray<InputMaterialWithQuantity>,
 ): MaterialInstance[] {
   const results: MaterialInstance[] = [];
-  
+
   for (const req of requirements) {
     for (let i = 0; i < req.quantity; i++) {
       results.push(generateSingleMockMaterial(req));
     }
   }
-  
+
   return results;
 }
 
-function generateSingleMockMaterial(req: InputMaterialWithQuantity): MaterialInstance {
+function generateSingleMockMaterial(
+  req: InputMaterialWithQuantity,
+): MaterialInstance {
   // Determine material type
   const materialType = req.type?.[0] || "board";
-  
+
   switch (materialType) {
     case "board": {
       const reqAny = req as any; // Cast to access optional properties
@@ -86,28 +102,40 @@ function generateSingleMockMaterial(req: InputMaterialWithQuantity): MaterialIns
       });
       return board;
     }
-    
+
     case "pallet": {
       const pallet: Pallet = makeMaterial<Pallet>({
         type: "pallet",
-        deckBoards: [true, true, true, true, true, true, true, true, true, true, true],
+        deckBoards: [
+          true,
+          true,
+          true,
+          true,
+          true,
+          true,
+          true,
+          true,
+          true,
+          true,
+          true,
+        ],
         stringerBoardsLeft: 3,
       });
       return pallet;
     }
-    
+
     case "plywood": {
       const reqAny = req as any;
       const sheet: SheetGood = makeMaterial<SheetGood>({
         type: "plywood",
         length: (reqAny.length?.[0] || 8) as BoardDimension,
         width: (reqAny.width?.[0] || 4) as BoardDimension,
-        thickness: (reqAny.thickness?.[0] || 2) as (1 | 2 | 3 | 4),
+        thickness: (reqAny.thickness?.[0] || 2) as 1 | 2 | 3 | 4,
         kind: (reqAny.kind?.[0] || "plywoodA") as SheetGood["kind"],
       });
       return sheet;
     }
-    
+
     case "shelf":
     case "rusticShelf":
     case "jewelryBox":
@@ -119,9 +147,9 @@ function generateSingleMockMaterial(req: InputMaterialWithQuantity): MaterialIns
       });
       return product;
     }
-    
+
     default:
-      // Fallback to a basic board  
+      // Fallback to a basic board
       return makeMaterial<Board>({
         type: "board",
         length: 8 as BoardDimension,
@@ -138,7 +166,7 @@ function generateSingleMockMaterial(req: InputMaterialWithQuantity): MaterialIns
  */
 export function generateOperationPreview(
   operation: ParameterizedOperation,
-  params: ParameterValues
+  params: ParameterValues,
 ): {
   expectedInputs: ReadonlyArray<InputMaterialWithQuantity>;
   mockMaterials: ReadonlyArray<MaterialInstance>;
@@ -146,13 +174,13 @@ export function generateOperationPreview(
 } {
   // Get input requirements for these parameters
   const expectedInputs = operation.getInputMaterials(params);
-  
+
   // Generate mock materials that satisfy requirements
   const mockMaterials = generateMockMaterials(expectedInputs);
-  
+
   // Call the actual operation function to see what it produces
   const result = operation.output(mockMaterials, params);
-  
+
   return {
     expectedInputs,
     mockMaterials,

--- a/src/game/operation-helpers.ts
+++ b/src/game/operation-helpers.ts
@@ -1,0 +1,161 @@
+import { InputMaterialWithQuantity, MachineOperation, OperationOutput, ParameterizedOperation, ParameterValues } from "./Machine";
+import { MaterialInstance, Board, Pallet, SheetGood, FinishedProduct, BoardDimension, Species } from "./Materials";
+import { makeMaterial } from "./material-helpers";
+
+/**
+ * Type guard to check if an operation is parameterized
+ */
+export function isParameterizedOperation(
+  operation: MachineOperation | ParameterizedOperation
+): operation is ParameterizedOperation {
+  return 'parameters' in operation && 'getInputMaterials' in operation;
+}
+
+/**
+ * Get input materials for an operation, handling both regular and parameterized operations
+ */
+export function getOperationInputMaterials(
+  operation: MachineOperation | ParameterizedOperation,
+  params?: ParameterValues
+): ReadonlyArray<InputMaterialWithQuantity> {
+  if (isParameterizedOperation(operation)) {
+    if (!params) {
+      // Return requirements for first parameter value as default
+      const defaultParams: ParameterValues = {};
+      for (const param of operation.parameters) {
+        defaultParams[param.id] = param.values[0];
+      }
+      return operation.getInputMaterials(defaultParams);
+    }
+    return operation.getInputMaterials(params);
+  } else {
+    return operation.inputMaterials;
+  }
+}
+
+/**
+ * Execute an operation, handling both regular and parameterized operations
+ */
+export function executeOperation(
+  operation: MachineOperation | ParameterizedOperation,
+  materials: ReadonlyArray<MaterialInstance>,
+  params?: ParameterValues
+): OperationOutput {
+  if (isParameterizedOperation(operation)) {
+    if (!params) {
+      throw new Error("Parameters required for parameterized operation");
+    }
+    return operation.output(materials, params);
+  } else {
+    return operation.output(materials);
+  }
+}
+
+/**
+ * Generates mock materials that satisfy the given input requirements.
+ * Used for previewing what an operation will produce.
+ */
+export function generateMockMaterials(
+  requirements: ReadonlyArray<InputMaterialWithQuantity>
+): MaterialInstance[] {
+  const results: MaterialInstance[] = [];
+  
+  for (const req of requirements) {
+    for (let i = 0; i < req.quantity; i++) {
+      results.push(generateSingleMockMaterial(req));
+    }
+  }
+  
+  return results;
+}
+
+function generateSingleMockMaterial(req: InputMaterialWithQuantity): MaterialInstance {
+  // Determine material type
+  const materialType = req.type?.[0] || "board";
+  
+  switch (materialType) {
+    case "board": {
+      const reqAny = req as any; // Cast to access optional properties
+      const board: Board = makeMaterial<Board>({
+        type: "board",
+        // Use first valid value from constraints, or sensible defaults
+        length: (reqAny.length?.[0] || 8) as BoardDimension,
+        width: (reqAny.width?.[0] || 4) as BoardDimension,
+        thickness: (reqAny.thickness?.[0] || 2) as BoardDimension,
+        species: (reqAny.species?.[0] || "pine") as Species,
+      });
+      return board;
+    }
+    
+    case "pallet": {
+      const pallet: Pallet = makeMaterial<Pallet>({
+        type: "pallet",
+        deckBoards: [true, true, true, true, true, true, true, true, true, true, true],
+        stringerBoardsLeft: 3,
+      });
+      return pallet;
+    }
+    
+    case "plywood": {
+      const reqAny = req as any;
+      const sheet: SheetGood = makeMaterial<SheetGood>({
+        type: "plywood",
+        length: (reqAny.length?.[0] || 8) as BoardDimension,
+        width: (reqAny.width?.[0] || 4) as BoardDimension,
+        thickness: (reqAny.thickness?.[0] || 2) as (1 | 2 | 3 | 4),
+        kind: (reqAny.kind?.[0] || "plywoodA") as SheetGood["kind"],
+      });
+      return sheet;
+    }
+    
+    case "shelf":
+    case "rusticShelf":
+    case "jewelryBox":
+    case "simpleCuttingBoard": {
+      const reqAny = req as any;
+      const product: FinishedProduct = makeMaterial<FinishedProduct>({
+        type: materialType as FinishedProduct["type"],
+        species: (reqAny.species?.[0] || "pine") as Species,
+      });
+      return product;
+    }
+    
+    default:
+      // Fallback to a basic board  
+      return makeMaterial<Board>({
+        type: "board",
+        length: 8 as BoardDimension,
+        width: 4 as BoardDimension,
+        thickness: 2 as BoardDimension,
+        species: "pine" as Species,
+      });
+  }
+}
+
+/**
+ * Generates a preview of what an operation will produce given its parameters.
+ * Calls the actual operation function with mock materials.
+ */
+export function generateOperationPreview(
+  operation: ParameterizedOperation,
+  params: ParameterValues
+): {
+  expectedInputs: ReadonlyArray<InputMaterialWithQuantity>;
+  mockMaterials: ReadonlyArray<MaterialInstance>;
+  expectedOutputs: ReadonlyArray<MaterialInstance>;
+} {
+  // Get input requirements for these parameters
+  const expectedInputs = operation.getInputMaterials(params);
+  
+  // Generate mock materials that satisfy requirements
+  const mockMaterials = generateMockMaterials(expectedInputs);
+  
+  // Call the actual operation function to see what it produces
+  const result = operation.output(mockMaterials, params);
+  
+  return {
+    expectedInputs,
+    mockMaterials,
+    expectedOutputs: result.outputs,
+  };
+}

--- a/src/game/progression-helpers.ts
+++ b/src/game/progression-helpers.ts
@@ -21,12 +21,17 @@ export function shouldAdvanceTutorial(gameState: GameState): number | null {
   if (commissionsCompleted >= 2 && tutorialStage < 2) {
     return 2;
   }
-  
+
   return null; // No advancement needed
 }
 
 export function getNextMilestone(progression: ProgressionState): string | null {
-  const { commissionsCompleted, storeUnlocked, shopLayoutUnlocked, freeSelling } = progression;
+  const {
+    commissionsCompleted,
+    storeUnlocked,
+    shopLayoutUnlocked,
+    freeSelling,
+  } = progression;
 
   if (commissionsCompleted === 0) {
     return "Complete your first commission to unlock the Store";
@@ -41,7 +46,7 @@ export function getNextMilestone(progression: ProgressionState): string | null {
   }
 
   if (commissionsCompleted < 3) {
-    return `Complete ${3 - commissionsCompleted} more commission${3 - commissionsCompleted === 1 ? '' : 's'} to unlock all features`;
+    return `Complete ${3 - commissionsCompleted} more commission${3 - commissionsCompleted === 1 ? "" : "s"} to unlock all features`;
   }
 
   return null; // All milestones reached
@@ -60,18 +65,20 @@ export function getTutorialMessage(tutorialStage: number): string | null {
   }
 }
 
-export function getAllUnlockedFeatures(progression: ProgressionState): string[] {
+export function getAllUnlockedFeatures(
+  progression: ProgressionState,
+): string[] {
   const features: string[] = [];
-  if (progression.storeUnlocked) features.push('Store');
-  if (progression.shopLayoutUnlocked) features.push('Shop Layout');
-  if (progression.freeSelling) features.push('Free Selling');
+  if (progression.storeUnlocked) features.push("Store");
+  if (progression.shopLayoutUnlocked) features.push("Shop Layout");
+  if (progression.freeSelling) features.push("Free Selling");
   return features;
 }
 
 export function getRemainingFeatures(progression: ProgressionState): string[] {
   const features: string[] = [];
-  if (!progression.storeUnlocked) features.push('Store');
-  if (!progression.shopLayoutUnlocked) features.push('Shop Layout');
-  if (!progression.freeSelling) features.push('Free Selling');
+  if (!progression.storeUnlocked) features.push("Store");
+  if (!progression.shopLayoutUnlocked) features.push("Shop Layout");
+  if (!progression.freeSelling) features.push("Free Selling");
   return features;
 }


### PR DESCRIPTION
## Summary
Implements issue #28 by adding a crafting-style slot system that clearly shows what materials are required as inputs and produced as outputs for machine operations.

## Key Features
- **Crafting-style UI**: Input and output slots with placeholders showing exactly what's needed
- **Visual validation**: Red borders for incompatible materials, placeholders for empty slots
- **Real-time preview**: Shows exact outputs based on actual input materials
- **Parameterized operations**: Single "Cut Board" operation with parameters instead of 8 duplicates
- **Rich tooltips**: Hover to see material requirements and properties

## Technical Implementation
- Created `ParameterizedOperation` interface supporting operation parameters
- Built slot-based UI using existing `MaterialIcon` component (no duplicate rendering)
- Added mock material generation for placeholder display
- Converted all saw machines (miter saw, table saw, planer) to parameterized operations
- Single source of truth: same pure functions drive both preview and execution

## UI Flow
```
[Input Slot: Pallet placeholder] → [Output Slot: Board preview]
[Input Slot: Pine Board 8x4x2] → [Output Slot: 6" Board + 2" Offcut]
```

Users can now:
1. See exactly what materials each operation requires
2. Get visual feedback when materials don't match requirements  
3. Preview exact outputs before operating
4. Adjust operation parameters and see requirements update

## Test plan
- [x] TypeScript compilation passes
- [x] All existing tests pass
- [x] UI displays placeholders for workspace "dismantle pallet" operation
- [x] Parameterized operations work correctly (miter saw, table saw, planer)
- [x] Visual validation shows red borders for incompatible materials
- [x] Output preview updates based on actual inputs

🤖 Generated with [Claude Code](https://claude.ai/code)