### PR TITLE
Add 'Take All' button for machine outputs

### DIFF
--- a/src/components/current-cell-info/MachinesSection.tsx
+++ b/src/components/current-cell-info/MachinesSection.tsx
@@ -12,7 +12,10 @@ import {
   machineCanOperate,
   matchMaterialsToSlots,
 } from "../../game/machine-helpers";
-import { createMockMaterial, getMaterialName } from "../../game/material-helpers";
+import {
+  createMockMaterial,
+  getMaterialName,
+} from "../../game/material-helpers";
 import {
   executeOperation,
   generateOperationPreview,
@@ -158,9 +161,10 @@ const MachineListItem: React.FC<{ machine: Machine }> = ({ machine }) => {
               onChange={(event) => {
                 const newParams = {
                   ...machine.selectedParameters,
-                  [param.id]: typeof param.values[0] === "number"
-                    ? Number(event.target.value)
-                    : event.target.value,
+                  [param.id]:
+                    typeof param.values[0] === "number"
+                      ? Number(event.target.value)
+                      : event.target.value,
                 };
                 applyAction(
                   setMachineOperationAction(
@@ -280,20 +284,6 @@ const MachineListItem: React.FC<{ machine: Machine }> = ({ machine }) => {
         </div>
       </div>
 
-      {/* Take All button for outputs */}
-      {machine.outputMaterials.length > 0 && (
-        <button
-          className="button text-xs py-1"
-          onClick={() =>
-            applyAction(
-              takeOutputsFromMachineAction(machine.outputMaterials, machine)
-            )
-          }
-        >
-          Take All ({machine.outputMaterials.length})
-        </button>
-      )}
-
       {isOperating ? (
         <div className="space-y-1">
           <div className="text-sm text-zinc-400">
@@ -314,6 +304,19 @@ const MachineListItem: React.FC<{ machine: Machine }> = ({ machine }) => {
           onClick={() => applyAction(operateMachineAction(machine))}
         >
           Operate
+        </button>
+      )}
+      {/* Take All button for outputs */}
+      {machine.outputMaterials.length > 0 && (
+        <button
+          className="button text-xs py-1"
+          onClick={() =>
+            applyAction(
+              takeOutputsFromMachineAction(machine.outputMaterials, machine)
+            )
+          }
+        >
+          Take All ({machine.outputMaterials.length})
         </button>
       )}
     </section>

--- a/src/components/current-cell-info/MachinesSection.tsx
+++ b/src/components/current-cell-info/MachinesSection.tsx
@@ -1,10 +1,6 @@
 import React from "react";
 import { useCellMap } from "../../game/CellMap";
-import {
-  InputMaterialWithQuantity,
-  Machine,
-  ParameterValues,
-} from "../../game/Machine";
+import { Machine, ParameterValues } from "../../game/Machine";
 import { MaterialInstance } from "../../game/Materials";
 import {
   operateMachineAction,
@@ -12,12 +8,11 @@ import {
   takeInputsFromMachineAction,
   takeOutputsFromMachineAction,
 } from "../../game/game-actions/player-actions";
-import { machineCanOperate } from "../../game/machine-helpers";
 import {
-  createMockMaterial,
-  getMaterialName,
-  materialMeetsInput,
-} from "../../game/material-helpers";
+  machineCanOperate,
+  matchMaterialsToSlots,
+} from "../../game/machine-helpers";
+import { createMockMaterial, getMaterialName } from "../../game/material-helpers";
 import {
   executeOperation,
   generateOperationPreview,
@@ -27,65 +22,6 @@ import {
 import { groupBy } from "../../utils/arrayUtils";
 import { useApplyGameAction, useGameState } from "../useGameState";
 import { MaterialIcon } from "./MaterialIcon";
-
-// Helper to match actual materials to operation requirements
-function matchMaterialsToSlots(
-  actualMaterials: MaterialInstance[],
-  requirements: ReadonlyArray<InputMaterialWithQuantity>
-): Array<{
-  requirement: InputMaterialWithQuantity;
-  material: MaterialInstance;
-  isValid: boolean;
-  isPlaceholder: boolean;
-}> {
-  const slots = [];
-  const availableMaterials = [...actualMaterials];
-
-  for (const requirement of requirements) {
-    for (let i = 0; i < requirement.quantity; i++) {
-      // Find a matching material
-      const materialIndex = availableMaterials.findIndex((material) =>
-        materialMeetsInput(material, requirement)
-      );
-
-      if (materialIndex !== -1) {
-        // Found a matching material
-        const material = availableMaterials[materialIndex];
-        availableMaterials.splice(materialIndex, 1);
-        slots.push({
-          requirement,
-          material,
-          isValid: true,
-          isPlaceholder: false,
-        });
-      } else {
-        // No matching material found - try to find any material for this slot
-        const anyMaterialIndex = availableMaterials.findIndex(() => true);
-        if (anyMaterialIndex !== -1) {
-          // Found a material but it doesn't match requirements
-          const material = availableMaterials[anyMaterialIndex];
-          availableMaterials.splice(anyMaterialIndex, 1);
-          slots.push({
-            requirement,
-            material,
-            isValid: false,
-            isPlaceholder: false,
-          });
-        } else {
-          // No material at all - show mock material as placeholder
-          slots.push({
-            requirement,
-            material: createMockMaterial(requirement),
-            isValid: false,
-            isPlaceholder: true,
-          });
-        }
-      }
-    }
-  }
-
-  return slots;
-}
 
 export const MachinesSection: React.FC = () => {
   const gameState = useGameState();

--- a/src/components/current-cell-info/MachinesSection.tsx
+++ b/src/components/current-cell-info/MachinesSection.tsx
@@ -344,6 +344,20 @@ const MachineListItem: React.FC<{ machine: Machine }> = ({ machine }) => {
         </div>
       </div>
 
+      {/* Take All button for outputs */}
+      {machine.outputMaterials.length > 0 && (
+        <button
+          className="button text-xs py-1"
+          onClick={() =>
+            applyAction(
+              takeOutputsFromMachineAction(machine.outputMaterials, machine)
+            )
+          }
+        >
+          Take All ({machine.outputMaterials.length})
+        </button>
+      )}
+
       {isOperating ? (
         <div className="space-y-1">
           <div className="text-sm text-zinc-400">

--- a/src/game/machine-helpers.ts
+++ b/src/game/machine-helpers.ts
@@ -1,7 +1,71 @@
-import { Machine } from "./Machine";
+import { InputMaterialWithQuantity, Machine } from "./Machine";
 import { MaterialInstance } from "./Materials";
-import { materialMeetsInput } from "./material-helpers";
+import { createMockMaterial, materialMeetsInput } from "./material-helpers";
 import { getOperationInputMaterials } from "./operation-helpers";
+
+export interface MaterialSlot {
+  requirement: InputMaterialWithQuantity;
+  material: MaterialInstance;
+  isValid: boolean;
+  isPlaceholder: boolean;
+}
+
+/**
+ * Match actual materials to operation requirements, creating slots for each required material.
+ * Returns slots with materials, validation status, and placeholders for missing materials.
+ */
+export function matchMaterialsToSlots(
+  actualMaterials: MaterialInstance[],
+  requirements: ReadonlyArray<InputMaterialWithQuantity>,
+): MaterialSlot[] {
+  const slots: MaterialSlot[] = [];
+  const availableMaterials = [...actualMaterials];
+
+  for (const requirement of requirements) {
+    for (let i = 0; i < requirement.quantity; i++) {
+      // Find a matching material
+      const materialIndex = availableMaterials.findIndex((material) =>
+        materialMeetsInput(material, requirement),
+      );
+
+      if (materialIndex !== -1) {
+        // Found a matching material
+        const material = availableMaterials[materialIndex];
+        availableMaterials.splice(materialIndex, 1);
+        slots.push({
+          requirement,
+          material,
+          isValid: true,
+          isPlaceholder: false,
+        });
+      } else {
+        // No matching material found - try to find any material for this slot
+        const anyMaterialIndex = availableMaterials.findIndex(() => true);
+        if (anyMaterialIndex !== -1) {
+          // Found a material but it doesn't match requirements
+          const material = availableMaterials[anyMaterialIndex];
+          availableMaterials.splice(anyMaterialIndex, 1);
+          slots.push({
+            requirement,
+            material,
+            isValid: false,
+            isPlaceholder: false,
+          });
+        } else {
+          // No material at all - show mock material as placeholder
+          slots.push({
+            requirement,
+            material: createMockMaterial(requirement),
+            isValid: false,
+            isPlaceholder: true,
+          });
+        }
+      }
+    }
+  }
+
+  return slots;
+}
 
 export function machineCanOperate(machine: Machine): boolean {
   const inventory = [...machine.inputMaterials];


### PR DESCRIPTION
## Summary
- Add a convenient "Take All" button to collect all output materials from a machine at once
- Button appears below the input/output display when outputs are available
- Shows the total count of items to be collected

## Changes
- Modified `MachinesSection.tsx` to add the "Take All" button component
- Button uses existing `takeOutputsFromMachineAction` with all outputs
- Only visible when `machine.outputMaterials.length > 0`
- Styled consistently with existing UI (brown theme, compact design)

## Testing
- All automated E2E tests pass
- Button functionality tested with manual verification

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)