### PR TITLE
Add garbage can for disposing of unwanted materials

### DIFF
--- a/src/components/machine-sprites/GarbageCanSprite.tsx
+++ b/src/components/machine-sprites/GarbageCanSprite.tsx
@@ -1,0 +1,60 @@
+import { Graphics } from "pixi.js";
+import React, { useCallback } from "react";
+import { Machine } from "../../game/Machine";
+import { MaterialSprite } from "../material-sprites/MaterialSprite";
+import { PIXELS_PER_CELL } from "../shop-view/shop-scale";
+
+export const GarbageCanSprite: React.FC<Machine> = (machine) => {
+  const { inputMaterials, processingMaterials, outputMaterials } = machine;
+
+  return (
+    <pixiContainer>
+      <pixiGraphics
+        draw={useCallback((g: Graphics) => {
+          g.clear();
+          const size = PIXELS_PER_CELL * 0.6;
+          const halfSize = size / 2;
+
+          // Draw garbage can body (trapezoid shape)
+          g.moveTo(-halfSize * 0.8, -halfSize);
+          g.lineTo(halfSize * 0.8, -halfSize);
+          g.lineTo(halfSize, halfSize);
+          g.lineTo(-halfSize, halfSize);
+          g.lineTo(-halfSize * 0.8, -halfSize);
+          g.fill({ color: 0x4a5568 }); // Gray color
+
+          // Draw lid
+          g.rect(-halfSize * 0.9, -halfSize * 1.1, size * 0.9, size * 0.15);
+          g.fill({ color: 0x2d3748 }); // Darker gray
+
+          // Draw handle on lid
+          g.circle(0, -halfSize * 1.1, size * 0.08);
+          g.fill({ color: 0x1a202c }); // Very dark gray
+        }, [])}
+      />
+      {inputMaterials.map((material, index) => (
+        <pixiContainer
+          y={-PIXELS_PER_CELL * 0.3}
+          angle={index * 10}
+          key={`in-${index}`}
+        >
+          <MaterialSprite material={material} key={index} alpha={0.7} />
+        </pixiContainer>
+      ))}
+      {processingMaterials.map((material, index) => (
+        <pixiContainer
+          y={PIXELS_PER_CELL * 0.1}
+          angle={index * 10}
+          key={`proc-${index}`}
+        >
+          <MaterialSprite
+            material={material}
+            key={index}
+            alpha={0.3}
+            tint={0xff6666}
+          />
+        </pixiContainer>
+      ))}
+    </pixiContainer>
+  );
+};

--- a/src/components/shop-view/MachineSprite.tsx
+++ b/src/components/shop-view/MachineSprite.tsx
@@ -3,6 +3,7 @@ import React, { useCallback } from "react";
 import { MACHINE_TYPES, Machine } from "../../game/Machine";
 import { colors } from "../../utils/colors";
 import { useTexture } from "../../utils/useTexture";
+import { GarbageCanSprite } from "../machine-sprites/GarbageCanSprite";
 import { JobsiteTableSawSprite } from "../machine-sprites/JobsiteTableSawSprite";
 import { LunchboxPlanerSprite } from "../machine-sprites/LunchboxPlanerSprite";
 import { MiterSawSprite } from "../machine-sprites/MiterSawSprite";
@@ -73,7 +74,12 @@ const LocalMachineSprite: React.FC<Machine> = (machine) => {
           ))}
           {processingMaterials.map((material, index) => (
             <pixiContainer angle={index * 10 + 2.5} key={`proc-${index}`}>
-              <MaterialSprite material={material} key={index} alpha={0.6} tint={0xFFB366} />
+              <MaterialSprite
+                material={material}
+                key={index}
+                alpha={0.6}
+                tint={0xffb366}
+              />
             </pixiContainer>
           ))}
           {outputMaterials.map((material, index) => (
@@ -99,7 +105,12 @@ const LocalMachineSprite: React.FC<Machine> = (machine) => {
           ))}
           {processingMaterials.map((material, index) => (
             <pixiContainer angle={index * 10 + 2.5} key={`proc-${index}`}>
-              <MaterialSprite material={material} key={index} alpha={0.6} tint={0xFFB366} />
+              <MaterialSprite
+                material={material}
+                key={index}
+                alpha={0.6}
+                tint={0xffb366}
+              />
             </pixiContainer>
           ))}
           {outputMaterials.map((material, index) => (
@@ -121,7 +132,12 @@ const LocalMachineSprite: React.FC<Machine> = (machine) => {
           ))}
           {processingMaterials.map((material, index) => (
             <pixiContainer angle={index * 10 + 2.5} key={`proc-${index}`}>
-              <MaterialSprite material={material} key={index} alpha={0.6} tint={0xFFB366} />
+              <MaterialSprite
+                material={material}
+                key={index}
+                alpha={0.6}
+                tint={0xffb366}
+              />
             </pixiContainer>
           ))}
           {outputMaterials.map((material, index) => (
@@ -133,48 +149,6 @@ const LocalMachineSprite: React.FC<Machine> = (machine) => {
       );
     }
   }
-};
-
-const GarbageCanSprite: React.FC<Machine> = (machine) => {
-  const { inputMaterials, processingMaterials, outputMaterials } = machine;
-
-  return (
-    <pixiContainer>
-      <pixiGraphics
-        draw={useCallback((g: Graphics) => {
-          g.clear();
-          const size = PIXELS_PER_CELL * 0.6;
-          const halfSize = size / 2;
-
-          // Draw garbage can body (trapezoid shape)
-          g.moveTo(-halfSize * 0.8, -halfSize);
-          g.lineTo(halfSize * 0.8, -halfSize);
-          g.lineTo(halfSize, halfSize);
-          g.lineTo(-halfSize, halfSize);
-          g.lineTo(-halfSize * 0.8, -halfSize);
-          g.fill({ color: 0x4a5568 }); // Gray color
-
-          // Draw lid
-          g.rect(-halfSize * 0.9, -halfSize * 1.1, size * 0.9, size * 0.15);
-          g.fill({ color: 0x2d3748 }); // Darker gray
-
-          // Draw handle on lid
-          g.circle(0, -halfSize * 1.1, size * 0.08);
-          g.fill({ color: 0x1a202c }); // Very dark gray
-        }, [])}
-      />
-      {inputMaterials.map((material, index) => (
-        <pixiContainer y={-PIXELS_PER_CELL * 0.3} angle={index * 10} key={`in-${index}`}>
-          <MaterialSprite material={material} key={index} alpha={0.7} />
-        </pixiContainer>
-      ))}
-      {processingMaterials.map((material, index) => (
-        <pixiContainer y={PIXELS_PER_CELL * 0.1} angle={index * 10} key={`proc-${index}`}>
-          <MaterialSprite material={material} key={index} alpha={0.3} tint={0xFF6666} />
-        </pixiContainer>
-      ))}
-    </pixiContainer>
-  );
 };
 
 const DefaultMachineSprite: React.FC = () => {

--- a/src/components/shop-view/MachineSprite.tsx
+++ b/src/components/shop-view/MachineSprite.tsx
@@ -54,6 +54,9 @@ const LocalMachineSprite: React.FC<Machine> = (machine) => {
     case MACHINE_TYPES.lunchboxPlaner.id:
       return <LunchboxPlanerSprite {...machine} />;
 
+    case MACHINE_TYPES.garbageCan.id:
+      return <GarbageCanSprite {...machine} />;
+
     case MACHINE_TYPES.workspace.id:
       return (
         <pixiContainer>
@@ -130,6 +133,48 @@ const LocalMachineSprite: React.FC<Machine> = (machine) => {
       );
     }
   }
+};
+
+const GarbageCanSprite: React.FC<Machine> = (machine) => {
+  const { inputMaterials, processingMaterials, outputMaterials } = machine;
+
+  return (
+    <pixiContainer>
+      <pixiGraphics
+        draw={useCallback((g: Graphics) => {
+          g.clear();
+          const size = PIXELS_PER_CELL * 0.6;
+          const halfSize = size / 2;
+
+          // Draw garbage can body (trapezoid shape)
+          g.moveTo(-halfSize * 0.8, -halfSize);
+          g.lineTo(halfSize * 0.8, -halfSize);
+          g.lineTo(halfSize, halfSize);
+          g.lineTo(-halfSize, halfSize);
+          g.lineTo(-halfSize * 0.8, -halfSize);
+          g.fill({ color: 0x4a5568 }); // Gray color
+
+          // Draw lid
+          g.rect(-halfSize * 0.9, -halfSize * 1.1, size * 0.9, size * 0.15);
+          g.fill({ color: 0x2d3748 }); // Darker gray
+
+          // Draw handle on lid
+          g.circle(0, -halfSize * 1.1, size * 0.08);
+          g.fill({ color: 0x1a202c }); // Very dark gray
+        }, [])}
+      />
+      {inputMaterials.map((material, index) => (
+        <pixiContainer y={-PIXELS_PER_CELL * 0.3} angle={index * 10} key={`in-${index}`}>
+          <MaterialSprite material={material} key={index} alpha={0.7} />
+        </pixiContainer>
+      ))}
+      {processingMaterials.map((material, index) => (
+        <pixiContainer y={PIXELS_PER_CELL * 0.1} angle={index * 10} key={`proc-${index}`}>
+          <MaterialSprite material={material} key={index} alpha={0.3} tint={0xFF6666} />
+        </pixiContainer>
+      ))}
+    </pixiContainer>
+  );
 };
 
 const DefaultMachineSprite: React.FC = () => {

--- a/src/components/store-page/StoreMachinesSection.tsx
+++ b/src/components/store-page/StoreMachinesSection.tsx
@@ -10,6 +10,7 @@ interface MachineSaleInfo {
 
 export const StoreMachinesSection: React.FC = () => {
   const machinesToSell: MachineSaleInfo[] = [
+    { machine: MACHINE_TYPES.garbageCan, price: 0 },
     { machine: MACHINE_TYPES.jobsiteTableSaw, price: 200 },
     { machine: MACHINE_TYPES.miterSaw, price: 200 },
     { machine: MACHINE_TYPES.makeshiftBench, price: 100 },

--- a/src/game/Machine.ts
+++ b/src/game/Machine.ts
@@ -1,5 +1,6 @@
 import { MaterialInstance } from "./Materials";
 import { Direction, Vector } from "./Vectors";
+import { garbageCan } from "./machines/garbageCan";
 import { jobsiteTableSaw } from "./machines/jobsiteTableSaw";
 import { lunchboxPlaner } from "./machines/lunchboxPlaner";
 import { makeshiftBench } from "./machines/makeshiftBench";
@@ -27,6 +28,7 @@ export const MACHINE_TYPES = {
   jobsiteTableSaw,
   miterSaw,
   lunchboxPlaner,
+  garbageCan,
 } satisfies { [id: string]: MachineType };
 export type MachineId = keyof typeof MACHINE_TYPES;
 

--- a/src/game/initialGameState.tsx
+++ b/src/game/initialGameState.tsx
@@ -31,6 +31,8 @@ export const initialGameState: GameState = {
   machines: [
     // Single workspace for tutorial
     machine(MACHINE_TYPES.workspace, [1, 2], 0),
+    // Garbage can for disposing unwanted materials
+    machine(MACHINE_TYPES.garbageCan, [0, 5], 0),
   ],
   storage: {
     machines: [], // Empty - no machines available initially

--- a/src/game/machines/garbageCan.ts
+++ b/src/game/machines/garbageCan.ts
@@ -1,0 +1,29 @@
+import { MachineType } from "../Machine";
+import { MaterialInstance } from "../Materials";
+
+export const garbageCan: MachineType = {
+  id: "garbageCan",
+  name: "Garbage Can",
+  description: "Dispose of unwanted materials and scraps. Materials are permanently removed.",
+  cellsOccupied: [[0, 0]],
+  freeCellsNeeded: [],
+  cost: 0, // Free - basic quality of life feature
+  materialStorage: 0,
+  toolStorage: 0,
+  inputSpaces: 5, // Can accept multiple materials at once
+  operations: [
+    {
+      name: "Dispose",
+      id: "dispose",
+      duration: 1, // Very quick operation
+      inputMaterials: [{ quantity: 1 }], // Accept any single material
+      output: (materials: ReadonlyArray<MaterialInstance>) => {
+        // Material is destroyed - no outputs, no inputs returned
+        return {
+          inputs: [],
+          outputs: [],
+        };
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
Implements #18 - Adds a garbage can/disposal system for getting rid of unwanted material scraps and offcuts.

## Changes
- **New Machine Type**: `garbageCan` with disposal operation that permanently removes materials
- **Visual Representation**: Gray trash can sprite rendered with PIXI Graphics (placeholder until #36)
- **Store Integration**: Available for free in the store
- **Initial Setup**: Included in starting workshop at position [0,5]

## Features
- Free to obtain (cost: $0)
- Quick disposal (1 tick operation)
- Accepts up to 5 materials at once
- No outputs - materials are permanently removed from game
- Simple quality of life improvement for inventory management

## Test Plan
- [x] TypeScript compilation passes
- [x] All E2E tests pass
- [ ] Manual testing: Verify garbage can appears in initial workshop
- [ ] Manual testing: Drag materials to garbage can and confirm they disappear
- [ ] Manual testing: Purchase additional garbage cans from store

Closes #18 

🤖 Generated with [Claude Code](https://claude.com/claude-code)