### PR TITLE
Add progress button with integrated fill animation

### DIFF
--- a/src/components/ProgressButton.tsx
+++ b/src/components/ProgressButton.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+interface ProgressButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  progress?: number; // 0-1, defaults to 0
+  children: React.ReactNode;
+}
+
+export const ProgressButton: React.FC<ProgressButtonProps> = ({
+  progress = 0,
+  children,
+  className = "",
+  ...buttonProps
+}) => {
+  const progressPercent = Math.max(0, Math.min(1, progress)) * 100;
+
+  return (
+    <button
+      className={`button relative overflow-hidden ${className}`}
+      {...buttonProps}
+    >
+      {/* Fill background that grows from left to right */}
+      <div
+        className="absolute inset-0 bg-amber-600 transition-all duration-200 origin-left"
+        style={{ width: `${progressPercent}%` }}
+      />
+
+      {/* Button text with z-index to stay above fill */}
+      <span className="relative z-10 drop-shadow-[0_1px_2px_rgba(0,0,0,0.8)]">
+        {children}
+      </span>
+    </button>
+  );
+};

--- a/src/components/current-cell-info/MachinesSection.tsx
+++ b/src/components/current-cell-info/MachinesSection.tsx
@@ -24,6 +24,7 @@ import {
 } from "../../game/operation-helpers";
 import { groupBy } from "../../utils/arrayUtils";
 import { useApplyGameAction, useGameState } from "../useGameState";
+import { ProgressButton } from "../ProgressButton";
 import { MaterialIcon } from "./MaterialIcon";
 
 export const MachinesSection: React.FC = () => {
@@ -284,28 +285,15 @@ const MachineListItem: React.FC<{ machine: Machine }> = ({ machine }) => {
         </div>
       </div>
 
-      {isOperating ? (
-        <div className="space-y-1">
-          <div className="text-sm text-zinc-400">
-            Operating... ({machine.operationProgress.ticksRemaining} ticks
-            remaining)
-          </div>
-          <div className="w-full bg-zinc-700 rounded-full h-2">
-            <div
-              className="bg-amber-600 h-2 rounded-full transition-all duration-200"
-              style={{ width: `${progressPercent}%` }}
-            />
-          </div>
-        </div>
-      ) : (
-        <button
-          className="button"
-          disabled={!canOperate}
-          onClick={() => applyAction(operateMachineAction(machine))}
-        >
-          Operate
-        </button>
-      )}
+      <ProgressButton
+        progress={progressPercent / 100}
+        disabled={!canOperate}
+        onClick={() => applyAction(operateMachineAction(machine))}
+      >
+        {isOperating
+          ? `Operating... (${machine.operationProgress.ticksRemaining} ticks)`
+          : "Operate"}
+      </ProgressButton>
       {/* Take All button for outputs */}
       {machine.outputMaterials.length > 0 && (
         <button


### PR DESCRIPTION
## Summary
- Created reusable `ProgressButton` component with left-to-right fill animation
- Replaced separate progress bar on machine Operate button with integrated progress fill effect
- Progress now displays directly within the button itself for a more cohesive UI

## Implementation Details
- **ProgressButton component**: Accepts progress (0-1), maintains text readability using drop shadow
- **Styling**: Uses amber fill (`bg-amber-600`) matching existing theme, smooth 200ms transitions
- **Integration**: Updated MachinesSection to show "Operate" when idle, "Operating... (X ticks)" with progress fill when running

## Testing
- ✅ All E2E tests passing
- ✅ Text readable at all progress levels
- ✅ Consistent with Tailwind brown/lumberjack theme

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)