### PR TITLE
Implement recursive type for Tailwind SVG stops

### DIFF
--- a/src/utils/tailwind-svg-stops.ts
+++ b/src/utils/tailwind-svg-stops.ts
@@ -1,11 +1,7 @@
 import plugin from "tailwindcss/plugin";
 import { objectEntries } from "./arrayUtils";
 
-// TODO: Get recursive type working
-type Color =
-  | string
-  | Record<string, string | Record<string, string | Record<string, string>>>;
-
+type Color = string | { [key: string]: Color };
 export const tailwindSvgStopsPlugin = plugin(
   ({ matchUtilities, theme, e }) => {
     const stopValues: [string, string][] = [];


### PR DESCRIPTION
## Summary
- Replaced 3-level nested type definition with proper recursive type for color objects
- Removed TODO comment from `tailwind-svg-stops.ts`
- Enables handling of color themes at any nesting depth

## Changes
- Updated `Color` type from manual 3-level nesting to recursive definition: `type Color = string | { [key: string]: Color }`
- Removed arbitrary nesting depth limitation
- Fully backward compatible with existing code

## Testing
- TypeScript type checking passes
- Production build completes successfully
- No runtime changes (logic already handled arbitrary depth)

Fixes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)