### PR TITLE
Implement time-based arrow key movement

### DIFF
--- a/src/components/Ticker.tsx
+++ b/src/components/Ticker.tsx
@@ -9,6 +9,32 @@ const NORMAL = 2;
 const FAST = 4;
 const FASTER = 20;
 
+const SpeedButton: React.FC<{
+  speed: number;
+  title: string;
+  children: ReactNode;
+  ticksPerSecond: number;
+  setTicksPerSecond: (speed: number) => void;
+}> = ({ speed, children, title, ticksPerSecond, setTicksPerSecond }) => {
+  return (
+    <button
+      className={classNames(
+        "align-middle font-sans p-1 tracking-[-0.2em] text-center text-sm grow",
+        "hover:bg-white/5",
+        ticksPerSecond === speed ? "bg-white/10" : "bg-transparent",
+      )}
+      onClick={(e) => {
+        setTicksPerSecond(speed);
+        e.currentTarget.blur();
+      }}
+      title={title}
+      tabIndex={-1}
+    >
+      {children}
+    </button>
+  );
+};
+
 export const Ticker: React.FC = () => {
   const gameState = useGameState();
   const applyAction = useApplyGameAction();
@@ -40,32 +66,17 @@ export const Ticker: React.FC = () => {
     }
   });
 
-  const SpeedButton: React.FC<{
-    speed: number;
-    title: string;
-    children: ReactNode;
-  }> = ({ speed, children, title }) => {
-    return (
-      <button
-        className={classNames(
-          "align-middle font-sans p-1 tracking-[-0.2em] text-center text-sm grow",
-          "hover:bg-white/5",
-          ticksPerSecond === speed ? "bg-white/10" : "bg-transparent",
-        )}
-        onClick={() => setTicksPerSecond(speed)}
-        title={title}
-      >
-        {children}
-      </button>
-    );
-  };
-
   return (
     <section>
       <TimeOfDay tick={gameState.tick} />
       <div className="rounded-b-md bg-zinc-700 overflow-hidden">
         <menu className="flex gap-0 justify-stretch">
-          <SpeedButton speed={PAUSED} title="Pause game">
+          <SpeedButton
+            speed={PAUSED}
+            title="Pause game"
+            ticksPerSecond={ticksPerSecond}
+            setTicksPerSecond={setTicksPerSecond}
+          >
             ⏸
           </SpeedButton>
           <button
@@ -73,18 +84,37 @@ export const Ticker: React.FC = () => {
               "align-middle font-sans p-1 tracking-[-0.2em] text-center text-sm grow",
               "hover:bg-white/5",
             )}
-            onClick={() => applyAction(tickAction)}
+            onClick={(e) => {
+              applyAction(tickAction);
+              e.currentTarget.blur();
+            }}
             title="Step forward one tick"
+            tabIndex={-1}
           >
             ❯
           </button>
-          <SpeedButton title="Play at normal speed" speed={NORMAL}>
+          <SpeedButton
+            title="Play at normal speed"
+            speed={NORMAL}
+            ticksPerSecond={ticksPerSecond}
+            setTicksPerSecond={setTicksPerSecond}
+          >
             ▶
           </SpeedButton>
-          <SpeedButton title="Play at fast speed" speed={FAST}>
+          <SpeedButton
+            title="Play at fast speed"
+            speed={FAST}
+            ticksPerSecond={ticksPerSecond}
+            setTicksPerSecond={setTicksPerSecond}
+          >
             ▶▶
           </SpeedButton>
-          <SpeedButton title="Play at faster speed" speed={FASTER}>
+          <SpeedButton
+            title="Play at faster speed"
+            speed={FASTER}
+            ticksPerSecond={ticksPerSecond}
+            setTicksPerSecond={setTicksPerSecond}
+          >
             ▶▶▶
           </SpeedButton>
         </menu>

--- a/src/components/shop-view/ShopKeyboardShortcuts.tsx
+++ b/src/components/shop-view/ShopKeyboardShortcuts.tsx
@@ -3,7 +3,6 @@ import { CellMap } from "../../game/CellMap";
 import { combineActions } from "../../game/game-actions/misc-actions";
 import {
   dropMaterialAction,
-  instaMovePlayerAction,
   moveMaterialsToMachineAction,
   operateMachineAction,
   pickUpMaterialAction,
@@ -11,7 +10,7 @@ import {
   takeInputsFromMachineAction,
   takeOutputsFromMachineAction,
 } from "../../game/game-actions/player-actions";
-import { clearWorkQueueAction } from "../../game/game-actions/work-item-actions";
+import { addWorkItemAction, clearWorkQueueAction } from "../../game/game-actions/work-item-actions";
 import { materialMeetsInput } from "../../game/material-helpers";
 import { mod } from "../../utils/mathUtils";
 import { useApplyGameAction, useGameState } from "../useGameState";
@@ -32,22 +31,22 @@ export const ShopKeyboardShortcuts: React.FC = () => {
       case "KeyD":
       case "ArrowRight":
         return applyAction(
-          combineActions(clearWorkQueueAction(), instaMovePlayerAction(0))
+          addWorkItemAction({ type: "move", direction: 0 })
         );
       case "KeyW":
       case "ArrowUp":
         return applyAction(
-          combineActions(clearWorkQueueAction(), instaMovePlayerAction(1))
+          addWorkItemAction({ type: "move", direction: 1 })
         );
       case "KeyA":
       case "ArrowLeft":
         return applyAction(
-          combineActions(clearWorkQueueAction(), instaMovePlayerAction(2))
+          addWorkItemAction({ type: "move", direction: 2 })
         );
       case "KeyS":
       case "ArrowDown":
         return applyAction(
-          combineActions(clearWorkQueueAction(), instaMovePlayerAction(3))
+          addWorkItemAction({ type: "move", direction: 3 })
         );
 
       // Pick Up


### PR DESCRIPTION
## Summary
- Implements time-based arrow key movement using the work queue system (fixes #8)
- Fixes speed control buttons that stopped working after React 19 upgrade
- Removes keyboard focus behavior from speed control buttons

## Changes

### Arrow Key Movement (Issue #8)
Changed arrow keys (WASD + arrows) to use the work queue system instead of instant movement. Players can now queue movements by pressing keys in succession, and movement happens over time (one cell per tick) just like click-based pathfinding.

**Files changed:**
- `src/components/shop-view/ShopKeyboardShortcuts.tsx`: Replace `instaMovePlayerAction` with `addWorkItemAction`, remove `clearWorkQueueAction` wrapper to allow queuing

### Speed Control Button Fix
Fixed speed control buttons that became non-functional after the React 19 upgrade. The root cause was defining the `SpeedButton` component inside the `Ticker` component, which creates a new component function on every render and breaks event handlers in React 19's stricter reconciliation.

**Files changed:**
- `src/components/Ticker.tsx`: 
  - Move `SpeedButton` outside `Ticker` component definition
  - Pass `ticksPerSecond` and `setTicksPerSecond` as props
  - Add `tabIndex={-1}` and `blur()` to prevent focus states

## Testing
- All existing tests pass
- Arrow key movement now queues like click-to-move
- Speed control buttons work correctly
- No keyboard focus remains after clicking buttons

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)