### PR TITLE
Add start menu with Continue / New Game flow

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -1,16 +1,33 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
+import { GameState } from "../game/GameState";
+import { saveGame } from "../game/saveLoad";
 import { DebugView } from "./DebugView";
 import { FixtureLoader } from "./FixtureLoader";
 import { HomePage } from "./HomePage";
 import { LayoutPage } from "./LayoutPage";
+import { StartMenu } from "./StartMenu";
 import { StorePage } from "./store-page/StorePage";
 import { UiModeProvider, useUiMode } from "./UiMode";
 import { ActionKeyContextProvider } from "./consumerCountContext";
 import { GameStateProvider, useGameState } from "./useGameState";
 
 export const Main: React.FC = () => {
+  const [activeGame, setActiveGame] = useState<GameState | null>(null);
+
+  if (!activeGame) {
+    return <StartMenu onStart={setActiveGame} />;
+  }
+
+  const handleQuitToMenu = (finalState: GameState) => {
+    saveGame(finalState);
+    setActiveGame(null);
+  };
+
   return (
-    <GameStateProvider>
+    <GameStateProvider
+      initialState={activeGame}
+      onQuitToMenu={handleQuitToMenu}
+    >
       <UiModeProvider>
         <ActionKeyContextProvider>
           <ScreenSwitcher />

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,19 +1,12 @@
 import React from "react";
 import { useUiMode } from "./UiMode";
-import {
-  useGameState,
-  useSaveGame,
-  useLoadGame,
-  useNewGame,
-} from "./useGameState";
+import { useGameState, useQuitToMenu } from "./useGameState";
 
 export const NavBar: React.FC = () => {
   const { mode, setMode } = useUiMode();
   const gameState = useGameState();
   const { storeUnlocked, shopLayoutUnlocked } = gameState.progression;
-  const saveGame = useSaveGame();
-  const loadGame = useLoadGame();
-  const newGame = useNewGame();
+  const quitToMenu = useQuitToMenu();
 
   return (
     <nav className="flex gap-2 p-2 rounded bg-white/10 w-fit">
@@ -40,23 +33,12 @@ export const NavBar: React.FC = () => {
         </button>
       )}
       <div className="border-l border-white/20 mx-2" />
-      <button className="button-ghost" onClick={saveGame}>
-        Save
-      </button>
-      <button className="button-ghost" onClick={loadGame}>
-        Load
-      </button>
       <button
         className="button-ghost"
-        onClick={() => {
-          if (
-            confirm("Start a new game? This will delete your current save.")
-          ) {
-            newGame();
-          }
-        }}
+        onClick={quitToMenu}
+        title="Save and return to main menu"
       >
-        New Game
+        Save & Quit
       </button>
     </nav>
   );

--- a/src/components/StartMenu.tsx
+++ b/src/components/StartMenu.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from "react";
+import { GameState } from "../game/GameState";
+import { initialGameState } from "../game/initialGameState";
+import { deleteSave, hasSavedGame, loadGame } from "../game/saveLoad";
+
+interface StartMenuProps {
+  onStart: (state: GameState) => void;
+}
+
+export const StartMenu: React.FC<StartMenuProps> = ({ onStart }) => {
+  const [hasSave, setHasSave] = useState(() => hasSavedGame());
+
+  const handleContinue = () => {
+    const saved = loadGame();
+    if (saved) {
+      onStart(saved);
+    } else {
+      setHasSave(false);
+    }
+  };
+
+  const handleNewGame = () => {
+    if (hasSave) {
+      const ok = confirm(
+        "Start a new game? This will delete your current save.",
+      );
+      if (!ok) return;
+      deleteSave();
+    }
+    onStart(initialGameState);
+  };
+
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center px-6 py-12 select-none">
+      <div className="w-full max-w-md flex flex-col items-center gap-8">
+        <h1 className="font-lumberjack text-5xl text-center text-amber-100 tracking-wide">
+          Woodworking Tycoon
+        </h1>
+
+        <div className="w-full flex flex-col gap-3">
+          {hasSave && (
+            <button
+              className="button text-xl py-3"
+              onClick={handleContinue}
+              autoFocus
+            >
+              Continue
+            </button>
+          )}
+          <button
+            className={
+              hasSave ? "button-ghost text-xl py-3" : "button text-xl py-3"
+            }
+            onClick={handleNewGame}
+            autoFocus={!hasSave}
+          >
+            New Game
+          </button>
+        </div>
+      </div>
+    </main>
+  );
+};

--- a/src/components/layout-page/LayoutEditorCanvas.tsx
+++ b/src/components/layout-page/LayoutEditorCanvas.tsx
@@ -12,9 +12,8 @@ import {
   gameStateContext,
   useApplyGameAction,
   useGameState,
-  useLoadGame,
   useMachines,
-  useNewGame,
+  useQuitToMenu,
   useSaveGame,
 } from "../useGameState";
 import { MachineGhostPreview } from "./MachineGhostPreview";
@@ -53,8 +52,7 @@ export const LayoutEditorCanvas: React.FC<LayoutEditorCanvasProps> = ({
   const machines = useMachines();
   const updateGameState = useApplyGameAction();
   const saveGame = useSaveGame();
-  const loadGame = useLoadGame();
-  const newGame = useNewGame();
+  const quitToMenu = useQuitToMenu();
   const floorTexture = useTexture("/images/concrete-floor-2-big.png");
 
   const materialPileGroups = cellMap
@@ -77,8 +75,7 @@ export const LayoutEditorCanvas: React.FC<LayoutEditorCanvasProps> = ({
           gameState,
           updateGameState,
           saveGame,
-          loadGame,
-          newGame,
+          quitToMenu,
         }}
       >
         <pixiContainer sortableChildren={true}>

--- a/src/components/shop-view/ShopView.tsx
+++ b/src/components/shop-view/ShopView.tsx
@@ -7,9 +7,8 @@ import {
   useApplyGameAction,
   useGameState,
   useMachines,
+  useQuitToMenu,
   useSaveGame,
-  useLoadGame,
-  useNewGame,
 } from "../useGameState";
 import { FloorTileSprite } from "./FloorTileSprite";
 import { MachineSprite } from "./MachineSprite";
@@ -24,8 +23,7 @@ export const ShopView: React.FC = () => {
   const machines = useMachines();
   const updateGameState = useApplyGameAction();
   const saveGame = useSaveGame();
-  const loadGame = useLoadGame();
-  const newGame = useNewGame();
+  const quitToMenu = useQuitToMenu();
   const cellMap = useCellMap();
   const floorTexture = useTexture("/images/concrete-floor-2-big.png");
 
@@ -46,7 +44,7 @@ export const ShopView: React.FC = () => {
         backgroundAlpha={0}
         antialias={true}
       >
-        <gameStateContext.Provider value={{ gameState, updateGameState, saveGame, loadGame, newGame }}>
+        <gameStateContext.Provider value={{ gameState, updateGameState, saveGame, quitToMenu }}>
           <pixiTilingSprite
             eventMode="static"
             texture={floorTexture}

--- a/src/components/useGameState.tsx
+++ b/src/components/useGameState.tsx
@@ -7,8 +7,7 @@ import React, {
 } from "react";
 import { GameState } from "../game/GameState";
 import { UpdateFunction } from "../utils/typeUtils";
-import { initialGameState } from "../game/initialGameState";
-import { loadGame, saveGame, deleteSave } from "../game/saveLoad";
+import { saveGame } from "../game/saveLoad";
 import { getMachines, Machine } from "../game/Machine";
 
 export const gameStateContext = createContext<
@@ -16,34 +15,24 @@ export const gameStateContext = createContext<
       gameState: GameState;
       updateGameState: UpdateFunction<GameState>;
       saveGame: () => void;
-      loadGame: () => void;
-      newGame: () => void;
+      quitToMenu: () => void;
     }
   | undefined
 >(undefined);
 
-export const GameStateProvider: React.FC<{ children?: ReactNode }> = ({
-  children,
-}) => {
-  const [gameState, setGameState] = useState<GameState>(() => {
-    const savedGame = loadGame();
-    return savedGame || initialGameState;
-  });
+export const GameStateProvider: React.FC<{
+  initialState: GameState;
+  onQuitToMenu: (finalState: GameState) => void;
+  children?: ReactNode;
+}> = ({ initialState, onQuitToMenu, children }) => {
+  const [gameState, setGameState] = useState<GameState>(initialState);
 
   const handleSaveGame = () => {
     saveGame(gameState);
   };
 
-  const handleLoadGame = () => {
-    const savedGame = loadGame();
-    if (savedGame) {
-      setGameState(savedGame);
-    }
-  };
-
-  const handleNewGame = () => {
-    deleteSave();
-    setGameState(initialGameState);
+  const handleQuitToMenu = () => {
+    onQuitToMenu(gameState);
   };
 
   // Expose game state functions to window for testing and debugging
@@ -68,8 +57,7 @@ export const GameStateProvider: React.FC<{ children?: ReactNode }> = ({
         gameState,
         updateGameState: setGameState,
         saveGame: handleSaveGame,
-        loadGame: handleLoadGame,
-        newGame: handleNewGame,
+        quitToMenu: handleQuitToMenu,
       }}
     >
       {children}
@@ -114,18 +102,10 @@ export function useSaveGame() {
   return value.saveGame;
 }
 
-export function useLoadGame() {
+export function useQuitToMenu() {
   const value = useContext(gameStateContext);
   if (value === undefined) {
-    throw new Error("useLoadGame must be used within a GameStateProvider");
+    throw new Error("useQuitToMenu must be used within a GameStateProvider");
   }
-  return value.loadGame;
-}
-
-export function useNewGame() {
-  const value = useContext(gameStateContext);
-  if (value === undefined) {
-    throw new Error("useNewGame must be used within a GameStateProvider");
-  }
-  return value.newGame;
+  return value.quitToMenu;
 }

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -11,10 +11,16 @@ test.describe('Woodworking Tycoon Basic Functionality', () => {
       }
     });
 
-    await test.step('navigate to app and wait for main content', async () => {
+    await test.step('navigate to app and wait for start menu', async () => {
       await page.goto('/');
       await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('main');
+    });
+
+    await test.step('start menu shows and we can start a new game', async () => {
+      await expect(page.getByRole('heading', { name: 'Woodworking Tycoon' })).toBeVisible();
+      await page.getByRole('button', { name: 'New Game' }).click();
+      await page.waitForFunction(() => (window as any).__GET_GAME_STATE__);
     });
 
     await test.step('page loads under 30 seconds', async () => {

--- a/tests/layout-editor.spec.ts
+++ b/tests/layout-editor.spec.ts
@@ -5,6 +5,9 @@ test.describe("Layout Editor", () => {
     // Navigate to the game
     await page.goto("http://localhost:3002");
 
+    // Click through start menu into a new game
+    await page.getByRole("button", { name: "New Game" }).click();
+
     // Wait for game to load
     await page.waitForFunction(() => (window as any).__UPDATE_GAME_STATE__);
     await page.waitForTimeout(500); // Give PIXI time to initialize


### PR DESCRIPTION
## Summary
- App now boots to a StartMenu rather than auto-loading the most recent save. Continue (shown only when a save exists) and New Game are now explicit choices, so the clock doesn't start ticking the moment the page opens.
- `GameStateProvider` simplified — it takes an `initialState` and an `onQuitToMenu` callback. Save load + new-game lifecycle moved up to `Main`.
- NavBar no longer has Save / Load / New Game. It has a single **Save & Quit** button that saves and returns to the start menu (where the player can pick Continue / New Game again).

## Test plan
- [x] `npm run tsc` clean
- [x] `npm run test:unit` (6/6 pass)
- [x] `npm run test:e2e` (2/2 pass — basic.spec and layout-editor.spec both updated to click through the new menu)
- [ ] Manual: open app → see start menu, no clock ticking. Click New Game → game starts. Save & Quit → returns to menu, Continue button now visible.
- [ ] Manual: New Game with existing save → confirm dialog appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)