### PR TITLE
Add design doc for marketplace listings and job board

### DIFF
--- a/docs/marketplace-and-jobs.md
+++ b/docs/marketplace-and-jobs.md
@@ -1,0 +1,281 @@
+# Marketplace & Jobs — Selling System Redesign
+
+Design doc for replacing free selling (the sales table) with a marketplace
+listing system, and adding a second, generated tier of paid work ("jobs")
+alongside the authored commission sequence.
+
+**Status: design.** Nothing here is implemented yet.
+
+## Why
+
+Free selling today has no decisions in it: place any item on the sales table
+and it converts to money on the next tick. It's a faucet, not a system. This
+redesign replaces it with two interlocking systems that live in one new UI
+surface — the **Marketplace tab**, the in-fiction equivalent of opening your
+phone and browsing Craigslist / Facebook Marketplace / Etsy:
+
+- **Listings**: put an item up for sale at a price *you choose*, and get paid
+  only when a buyer bites. Sale chance is simulated from price, reputation,
+  and demand.
+- **Jobs**: generated one-off requests ("4 sanded oak boards, 3×4×1") you
+  accept and fulfill for guaranteed money. They give guidance and steady
+  income without advancing the story.
+
+After this change the game has three income tracks with distinct roles:
+
+| Track       | Pay vs. fair value | Guaranteed?         | Role                                        |
+| ----------- | ------------------ | ------------------- | ------------------------------------------- |
+| Commissions | ~3×                | Yes                 | Story progression, unlocks, boss paydays    |
+| Jobs        | ~1.5–2× (+ tip)    | Yes                 | Guided grind, guaranteed price              |
+| Listings    | You set the price  | No (probabilistic)  | Higher ceiling for skilled pricing/rep play |
+
+## What we're keeping
+
+- **The authored commission sequence** (`commissionSequence.ts`) is untouched:
+  linear, story-driven, each entry introduces one new element, big money and
+  reputation on completion. The word *commission* now refers exclusively to
+  this track; generated work is a *job*.
+- **`getSellValue()`** (`material-values.ts`) survives as the price anchor,
+  but its meaning changes: it is no longer "what you get," it is **fair
+  value** — what the market thinks an item is worth. All sale-chance math and
+  job payouts are expressed relative to it, so the existing species / surface
+  / finish tuning keeps paying off.
+- **Reputation** and its existing sink (lumber channel gating in
+  `lumberStock.ts`). This redesign adds new sources (job bonuses, sale
+  reviews) and a new sink (pricing power on listings).
+- **The tick simulation and the existing day concept** (600 ticks/day,
+  already shown on the Ticker's calendar page). Sale rolls happen per tick;
+  the job board refreshes daily. No richer calendar machinery until craft
+  markets need it (see Future work).
+- **Fulfillment from player inventory** via `materialMeetsInput`, exactly as
+  `completeCommissionAction` does today. Jobs deliver, and listings list,
+  what the player is carrying.
+- **Scavenging errands**, currently gated on the `freeSelling` flag — they
+  re-gate on the marketplace unlock (same unlock moment, see below).
+- **The injectable-RNG pattern** from `scavenge-actions.ts`
+  (`rng: () => number = Math.random` as a defaulted parameter) for all sale
+  rolls and job generation, so everything stays unit-testable.
+
+## What we're getting rid of
+
+- **The sales table** (`machines/salesTable.ts`), its sprite case in
+  `MachineSprite.tsx`, and the auto-sell pass at the bottom of
+  `tickAction.ts`. Instant "item → money next tick" selling is gone entirely.
+- **The `freeSelling` progression flag**, replaced by `marketplaceUnlocked`.
+  Same unlock trigger (completing the *Cut to Order* commission, per
+  `UNLOCK_CONDITIONS`), but it now reveals the Marketplace tab instead of
+  granting a machine.
+- **The sales-table grant** in `progression-actions.ts` (the machine no
+  longer exists to grant).
+- **The `StoreSellingSection` copy** pointing players at the sales table —
+  either removed or rewritten to point at the Marketplace tab.
+- **Save migration**: old saves may contain a placed or stored sales table
+  and a `freeSelling` flag. On load, drop the machine (returning any items on
+  it to the material dropoff position as piles) and map `freeSelling` →
+  `marketplaceUnlocked`.
+
+## The Marketplace tab
+
+A new top-level UI surface (a fourth `UiMode`, alongside normal / store /
+shopLayout), styled as the player's phone or laptop. It has two panes:
+
+1. **For Sale** — your active listings: item, asking price, how long it's
+   been up, and an interest indicator.
+2. **Job Board** — open offers, plus your currently accepted jobs and their
+   tip timers.
+
+Hidden entirely until `marketplaceUnlocked` (completing *Cut to Order*),
+preserving the current tutorial cadence: first commission unlocks the store,
+miter saw unlocks layout, second commission unlocks earning money freely.
+
+## Selling: listings
+
+### Flow
+
+1. Player carries an item (in `player.inventory`) and opens the Marketplace
+   tab.
+2. They pick the item, see its fair value hint, and choose an asking price.
+3. Listing the item removes it from inventory — it's boxed up awaiting
+   pickup and no longer exists in the shop world. (v1 keeps this abstract;
+   see Open questions.)
+4. Each tick, every listing rolls a chance to sell. On a sale: money +=
+   asking price, a small review-based reputation gain, and the existing
+   `"sale"` sound cue.
+5. Listings can be repriced or delisted at any time (delisting returns the
+   item to inventory).
+
+### Sale model
+
+Per listing, per tick:
+
+```
+P(sale) = BASE_RATE × priceFactor(r, reputation) × demandFactor(category)
+```
+
+- **`r = askingPrice / fairValue`** — the player's one big decision.
+- **`priceFactor`** is a logistic curve centered near `r = 1`: underpricing
+  sells fast, fair pricing sells reliably, overpricing stalls. **Reputation
+  shifts the curve's center right** — pricing power. A high-rep shop sells at
+  `r = 1.3` about as easily as a nobody sells at `r = 1.0`.
+- **`demandFactor`** is per-product-category **saturation**: each sale of a
+  category (cutting boards, shelves, …) dips that category's demand meter,
+  which recovers over a day or two. Selling ten identical cutting boards
+  floods your local market; rotating across your recipe book keeps every
+  meter high. This is the guard against find-best-item-and-spam.
+
+Tuning starting points (all subject to play): at `r = 1` with baseline
+reputation and full demand, an item should sell in roughly **half a day**
+(~300 ticks, so `BASE_RATE ≈ 1/300`). At `r = 0.7` it sells within an hour
+or two of game time; at `r = 1.5` with low rep, effectively never.
+
+### Reviews: the reputation trickle
+
+Every sale grants a small reputation gain scaled by value-for-money —
+roughly proportional to `fairValue / askingPrice`, capped, and never
+negative in v1. This creates the strategic arc: early game you underprice to
+build reputation; late game you spend that reputation as pricing power. The
+first non-commission reputation source in the game.
+
+### Anti-frustration guarantees
+
+- **Pity timer**: any listing priced at or below fair value (`r ≤ 1`) that
+  hasn't sold after **2 days** sells automatically at asking price. A fairly
+  priced item can be slow, but never stuck.
+- The interest indicator makes the model legible **at listing time**:
+  "priced to move" / "fair — should sell soon" / "ambitious — expect a
+  wait." The player is making an informed bet, not gambling blind.
+
+## Jobs
+
+### The board
+
+- The Job Board shows **3–5 open offers**. It refreshes on the day boundary:
+  stale offers rotate out (offers last ~3 days), new ones roll in.
+- Accepting moves an offer to your accepted list. **Concurrent-job limit:
+  starts at 1, grows to ~5** at reputation milestones (exact thresholds are
+  tuning; a skill-tree node granting +1 slot is a natural later addition).
+
+### Job anatomy
+
+A job reuses the commission data shape where possible:
+
+- `requiredMaterials`: `InputMaterialWithQuantity[]` — same matching logic
+  as commissions (`materialMeetsInput`, delivered from player inventory).
+- `basePay`: ~**1.5–2× the fair value** of the deliverables. Never decays.
+- `baseReputation`: a small fixed gain. Never decays.
+- **Tip**: a speed bonus starting at ~**+40% of basePay** and decaying
+  linearly to zero over ~**3 days from acceptance**, with a matching decaying
+  reputation bonus. Time pressure that never goes negative — a slow job is
+  merely less lucrative, not a failure.
+- **Cancelling** an accepted job is the only true penalty: a small
+  reputation loss. Letting an unaccepted offer expire costs nothing.
+
+### Generation
+
+Jobs are generated from the player's **capability envelope** — what they can
+actually build right now, derived from owned machines and mounted tools
+(`ownsMachine` etc.) plus `progression.commissionsCompleted` as a tech-tier
+marker. Rules:
+
+- Never generate a job the player cannot physically produce.
+- **Bias toward the newest capability**: just bought a planer? The board
+  fills with planing work. This is the "guidance" role — jobs teach the tool
+  you just acquired, emergently rather than through authored content.
+- **Always keep at least one zero-material-cost job on the board** — pallet
+  wood work, fulfillable from scavenged materials — so a broke player always
+  has a path back to solvency. (Together with the listing pity timer, this
+  is the income floor.)
+- Higher reputation skews generation toward bigger, better-paying requests.
+
+## Reputation economy after this change
+
+| Direction | Mechanism                                                      |
+| --------- | -------------------------------------------------------------- |
+| Earn      | Commissions (big chunks) — existing                            |
+| Earn      | Job base + speed bonuses (steady)                              |
+| Earn      | Sale reviews (trickle, boosted by underpricing)                |
+| Spend     | Lumber channel access — existing                               |
+| Spend     | Pricing power on listings (charge above fair value)            |
+| Spend     | More concurrent job slots; better job offers                   |
+| Lose      | Cancelling an accepted job (only loss in the system)           |
+
+## Data model & implementation sketch
+
+New persisted state (all in `GameState` / `saveLoad`):
+
+```ts
+interface MarketListing {
+  readonly id: string;
+  readonly material: MaterialInstance;
+  readonly askingPrice: number;
+  readonly listedAtTick: number;
+}
+
+interface JobOffer {
+  readonly id: string;
+  readonly name: string;          // flavor: who's asking, generated
+  readonly description: string;
+  readonly requiredMaterials: ReadonlyArray<InputMaterialWithQuantity>;
+  readonly basePay: number;
+  readonly baseReputation: number;
+  readonly postedAtTick: number;  // offers expire ~3 days after this
+}
+
+interface AcceptedJob extends JobOffer {
+  readonly acceptedAtTick: number; // tip decay runs from here
+}
+
+// GameState additions
+readonly listings: ReadonlyArray<MarketListing>;
+readonly jobBoard: ReadonlyArray<JobOffer>;
+readonly acceptedJobs: ReadonlyArray<AcceptedJob>;
+readonly categoryDemand: Readonly<Record<string, number>>; // 0–1 saturation meters
+```
+
+New actions (`src/game/game-actions/marketplace-actions.ts`):
+`listItemAction`, `delistItemAction`, `repriceListingAction`,
+`acceptJobAction`, `cancelJobAction`, `deliverJobAction`. Two new tick
+passes replace the sales-table pass in `tickAction`: sale rolls (+ pity
+timer + demand recovery) every tick, and a board refresh on day boundaries
+(`tick % 600 === 0`). All randomness through injected RNG.
+
+Suggested build order:
+
+1. **Listings core**: data model, list/delist/reprice, sale roll + pity
+   timer, Marketplace tab UI, sales-table removal + save migration.
+2. **Job board**: generation, offer lifecycle, accept/cancel/deliver, tip
+   decay, slot limits.
+3. **Depth layer**: category saturation meters, review-based reputation,
+   interest indicators, reputation-scaled generation.
+
+Phases 1–2 are each shippable; phase 3 items are individually optional and
+tunable.
+
+## Future work (explicitly out of scope)
+
+- **Craft markets**: calendar events announced in advance — build up
+  inventory, then sell a burst of stock in one day at a stall. This design
+  leaves room for them: the listing model doubles as booth inventory, the
+  day concept extends to a visible forward calendar, and demand meters give
+  markets a lever ("the fair ignores local saturation"). Requires a richer
+  calendar than v1 needs.
+- **Haggling**: buyers occasionally counter-offer below asking; accept or
+  hold out. A good skill unlock once the base loop is proven.
+- **Demand events**: "cutting boards are hot this week" rotating modifiers.
+- **Negative reviews** for overpriced sales, once the economy is stable
+  enough to afford a punishment lever.
+- **An online-store upgrade** (larger reach, higher base rate) as a
+  late-game purchase.
+
+## Open questions
+
+- Should listed items still occupy physical space somewhere (a staging
+  shelf) until sold? v1 says no — listing removes the item — but a "packed
+  boxes by the door" visual would be flavorful and could return as a soft
+  constraint later.
+- Exact reputation thresholds for job slots 2–5.
+- Should job flavor (client names, request text) be a generation table now,
+  or minimal placeholder text until the system proves out?
+- Does delivering a job happen entirely in the Marketplace tab (like
+  commissions in the store today), or should jobs eventually want a physical
+  handoff (customer pickup at the shop door)?

--- a/src/components/current-cell-info/FloorListSection.tsx
+++ b/src/components/current-cell-info/FloorListSection.tsx
@@ -51,7 +51,10 @@ const FloorListItem: React.FC<{ piles: MaterialPile[] }> = ({ piles }) => {
           ×{piles.length}
         </span>
       )}
-      <Tooltip content={<ShiftHint verb="Pick up" plural={piles.length > 1} />} shortcut="pick-up">
+      <Tooltip
+        content={<ShiftHint verb="Pick up" plural={piles.length > 1} />}
+        shortcut="pick-up"
+      >
         <button
           className="button-paper text-xs"
           onClick={(event) => {

--- a/src/components/current-cell-info/MachinesSection.tsx
+++ b/src/components/current-cell-info/MachinesSection.tsx
@@ -234,7 +234,9 @@ const MachineSpecSheet: React.FC<{ machine: Machine }> = ({ machine }) => {
               </span>
               <select
                 className="bg-paper-ivory text-ink-black border border-ink-black/30 px-2 py-0.5 rounded font-condensed grow"
-                value={machine.selectedParameters?.[param.id] || param.values[0]}
+                value={
+                  machine.selectedParameters?.[param.id] || param.values[0]
+                }
                 onChange={(event) => {
                   const newParams = {
                     ...machine.selectedParameters,
@@ -476,22 +478,24 @@ const ToolRack: React.FC<{ machine: Machine }> = ({ machine }) => {
           gameState.storage.tools
             .filter((toolId) => {
               const compatible = TOOL_TYPES[toolId].compatibleMachines;
-              return !compatible || compatible.includes(machine.state.machineTypeId);
+              return (
+                !compatible || compatible.includes(machine.state.machineTypeId)
+              );
             })
             .map((toolId, index) => (
-            <li
-              key={`stored-${toolId}-${index}`}
-              className="flex items-center gap-2 py-1 text-ink-fade"
-            >
-              <span className="grow">{TOOL_TYPES[toolId].name} (stored)</span>
-              <button
-                className="button-paper text-xs"
-                onClick={() => applyAction(mountToolAction(machine, toolId))}
+              <li
+                key={`stored-${toolId}-${index}`}
+                className="flex items-center gap-2 py-1 text-ink-fade"
               >
-                Attach
-              </button>
-            </li>
-          ))}
+                <span className="grow">{TOOL_TYPES[toolId].name} (stored)</span>
+                <button
+                  className="button-paper text-xs"
+                  onClick={() => applyAction(mountToolAction(machine, toolId))}
+                >
+                  Attach
+                </button>
+              </li>
+            ))}
         {machine.state.tools.length === 0 &&
           gameState.storage.tools.length === 0 && (
             <li className="py-1 italic text-ink-fade text-xs">
@@ -543,7 +547,9 @@ const OperationlessMachineCard: React.FC<{ machine: Machine }> = ({
                 className="button-paper text-xs"
                 onClick={(event) => {
                   if (event.shiftKey) {
-                    applyAction(takeInputsFromMachineAction(materials, machine));
+                    applyAction(
+                      takeInputsFromMachineAction(materials, machine),
+                    );
                   } else {
                     applyAction(
                       takeInputsFromMachineAction([materials[0]], machine),

--- a/src/components/current-cell-info/MaterialIcon.tsx
+++ b/src/components/current-cell-info/MaterialIcon.tsx
@@ -49,7 +49,14 @@ export const MaterialIcon: React.FC<{
   placeholder?: boolean;
   isValid?: boolean;
   tooltip?: ReactNode;
-}> = ({ material, size = "medium", quantity, placeholder = false, isValid = true, tooltip }) => {
+}> = ({
+  material,
+  size = "medium",
+  quantity,
+  placeholder = false,
+  isValid = true,
+  tooltip,
+}) => {
   switch (material.type) {
     // Make the board with SVG so we don't have to use Pixi to render it
     case "board": {
@@ -59,7 +66,13 @@ export const MaterialIcon: React.FC<{
       const depth = (board.thickness * PIXELS_PER_INCH) / 4;
 
       return (
-        <Wrapper size={size} quantity={quantity} isValid={isValid} tooltip={tooltip} placeholder={placeholder}>
+        <Wrapper
+          size={size}
+          quantity={quantity}
+          isValid={isValid}
+          tooltip={tooltip}
+          placeholder={placeholder}
+        >
           <svg
             viewBox={`0 0 ${PIXELS_PER_CELL} ${PIXELS_PER_CELL}`}
             className="w-full"
@@ -90,7 +103,12 @@ export const MaterialIcon: React.FC<{
       const depth = (board.thickness * PIXELS_PER_INCH) / 4;
 
       return (
-        <Wrapper size={size} isValid={isValid} tooltip={tooltip} placeholder={placeholder}>
+        <Wrapper
+          size={size}
+          isValid={isValid}
+          tooltip={tooltip}
+          placeholder={placeholder}
+        >
           <svg
             viewBox={`0 0 ${PIXELS_PER_CELL} ${PIXELS_PER_CELL}`}
             className="w-full"
@@ -116,14 +134,24 @@ export const MaterialIcon: React.FC<{
 
     case "pallet":
       return (
-        <Wrapper size={size} isValid={isValid} tooltip={tooltip} placeholder={placeholder}>
+        <Wrapper
+          size={size}
+          isValid={isValid}
+          tooltip={tooltip}
+          placeholder={placeholder}
+        >
           <img src="/images/pallet.png" />
         </Wrapper>
       );
 
     default:
       return (
-        <Wrapper size={size} isValid={isValid} tooltip={tooltip} placeholder={placeholder}>
+        <Wrapper
+          size={size}
+          isValid={isValid}
+          tooltip={tooltip}
+          placeholder={placeholder}
+        >
           <SimpleSpriteStage scale={sizeToScale[size]}>
             <MaterialSprite material={material} />
           </SimpleSpriteStage>
@@ -146,7 +174,14 @@ const Wrapper: React.FC<{
   isValid?: boolean;
   tooltip?: ReactNode;
   placeholder?: boolean;
-}> = ({ children, size, quantity, isValid = true, tooltip, placeholder = false }) => {
+}> = ({
+  children,
+  size,
+  quantity,
+  isValid = true,
+  tooltip,
+  placeholder = false,
+}) => {
   // Determine border style based on state
   const borderStyle = placeholder
     ? "border-2 border-dashed border-zinc-600"
@@ -168,7 +203,7 @@ const Wrapper: React.FC<{
           sizeToClassname[size],
           borderStyle,
           bgStyle,
-          placeholder ? "opacity-50" : ""
+          placeholder ? "opacity-50" : "",
         )}
       >
         {children}

--- a/src/components/layout-page/LayoutEditorCanvas.tsx
+++ b/src/components/layout-page/LayoutEditorCanvas.tsx
@@ -111,7 +111,9 @@ export const LayoutEditorCanvas: React.FC<LayoutEditorCanvasProps> = ({
               <MachineSprite
                 machine={machinePlacement}
                 isSelected={selectedMachineIndex === index}
-                onClick={editMode === "none" ? () => onMachineClick(index) : undefined}
+                onClick={
+                  editMode === "none" ? () => onMachineClick(index) : undefined
+                }
               />
             </pixiContainer>
           ))}

--- a/src/components/layout-page/StorageSection.tsx
+++ b/src/components/layout-page/StorageSection.tsx
@@ -53,9 +53,7 @@ export const StorageSection: React.FC<StorageSectionProps> = ({
           Storage
         </h3>
         {groupedMachines.length === 0 ? (
-          <p className="italic text-ink-fade text-sm">
-            No machines in storage
-          </p>
+          <p className="italic text-ink-fade text-sm">No machines in storage</p>
         ) : (
           <ul className="divide-y divide-ink-black/15">
             {groupedMachines.map((machineIds) => {

--- a/src/components/machine-sprites/GarbageCanSprite.tsx
+++ b/src/components/machine-sprites/GarbageCanSprite.tsx
@@ -4,7 +4,9 @@ import { Machine } from "../../game/Machine";
 import { MaterialSprite } from "../material-sprites/MaterialSprite";
 import { PIXELS_PER_CELL } from "../shop-view/shop-scale";
 
-export const GarbageCanSprite: React.FC<{ machine: Machine }> = ({ machine }) => {
+export const GarbageCanSprite: React.FC<{ machine: Machine }> = ({
+  machine,
+}) => {
   const { inputMaterials, processingMaterials, outputMaterials } = machine;
 
   return (

--- a/src/components/machine-sprites/JobsiteTableSawSprite.tsx
+++ b/src/components/machine-sprites/JobsiteTableSawSprite.tsx
@@ -15,10 +15,16 @@ import { extractFirstNumber } from "./extractFirstNumber";
 
 const AnimatedPixiContainer = animated("pixiContainer");
 
-export const JobsiteTableSawSprite: React.FC<{ machine: Machine }> = ({ machine }) => {
+export const JobsiteTableSawSprite: React.FC<{ machine: Machine }> = ({
+  machine,
+}) => {
   const { inputMaterials, outputMaterials } = machine;
-  const tableSawTableTexture = useTexture("/images/jobsite-table-saw-table.png");
-  const tableSawFenceTexture = useTexture("/images/jobsite-table-saw-fence.png");
+  const tableSawTableTexture = useTexture(
+    "/images/jobsite-table-saw-table.png",
+  );
+  const tableSawFenceTexture = useTexture(
+    "/images/jobsite-table-saw-fence.png",
+  );
 
   const ripWidth =
     extractFirstNumber(machine.selectedOperation.id) ||
@@ -26,7 +32,7 @@ export const JobsiteTableSawSprite: React.FC<{ machine: Machine }> = ({ machine 
   const fencePosition = ripWidth * PIXELS_PER_INCH;
 
   const springProps = useSpring({
-    x: fencePosition
+    x: fencePosition,
   });
 
   return (

--- a/src/components/machine-sprites/LunchboxPlanerSprite.tsx
+++ b/src/components/machine-sprites/LunchboxPlanerSprite.tsx
@@ -12,7 +12,9 @@ import { extractFirstNumber } from "./extractFirstNumber";
 
 const AnimatedPixiSprite = animated("pixiSprite");
 
-export const LunchboxPlanerSprite: React.FC<{ machine: Machine }> = ({ machine }) => {
+export const LunchboxPlanerSprite: React.FC<{ machine: Machine }> = ({
+  machine,
+}) => {
   const { inputMaterials, outputMaterials } = machine;
   const planerBottomTexture = useTexture("/images/lunchbox-planer-bottom.png");
   const planerTopTexture = useTexture("/images/lunchbox-planer-top.png");
@@ -23,7 +25,7 @@ export const LunchboxPlanerSprite: React.FC<{ machine: Machine }> = ({ machine }
     Math.max(...BOARD_DIMENSIONS);
 
   const springProps = useSpring({
-    scale: IMAGE_SCALE + cutThickness * 0.005
+    scale: IMAGE_SCALE + cutThickness * 0.005,
   });
 
   return (
@@ -40,7 +42,7 @@ export const LunchboxPlanerSprite: React.FC<{ machine: Machine }> = ({ machine }
           x={lerp(
             -inputMaterials.length * PIXELS_PER_INCH,
             inputMaterials.length * PIXELS_PER_INCH,
-            index / inputMaterials.length
+            index / inputMaterials.length,
           )}
           y={feetToPixels(board.length / 2)}
         >
@@ -54,7 +56,7 @@ export const LunchboxPlanerSprite: React.FC<{ machine: Machine }> = ({ machine }
           x={lerp(
             -outputMaterials.length * PIXELS_PER_INCH,
             outputMaterials.length * PIXELS_PER_INCH,
-            index / outputMaterials.length
+            index / outputMaterials.length,
           )}
           y={-feetToPixels(board.length / 2)}
         >

--- a/src/components/machine-sprites/SalesTableSprite.tsx
+++ b/src/components/machine-sprites/SalesTableSprite.tsx
@@ -25,7 +25,13 @@ export const SalesTableSprite: React.FC<{ machine: Machine }> = ({
 
           // Cash box in the corner
           const boxSize = size * 0.28;
-          g.roundRect(half - boxSize - 3, -half + 3, boxSize, boxSize * 0.75, 2);
+          g.roundRect(
+            half - boxSize - 3,
+            -half + 3,
+            boxSize,
+            boxSize * 0.75,
+            2,
+          );
           g.fill({ color: 0x4a5d23 }); // money-green box
           g.circle(half - boxSize / 2 - 3, -half + 3 + boxSize * 0.375, 1.5);
           g.fill({ color: 0xc9b783 }); // latch

--- a/src/components/material-sprites/BoardSprite.tsx
+++ b/src/components/material-sprites/BoardSprite.tsx
@@ -25,7 +25,7 @@ export const BoardSprite: React.FC<
           -width / 2 - shadowWidth,
           -height / 2 - shadowWidth,
           width + depth + shadowWidth * 2,
-          height + shadowWidth * 2
+          height + shadowWidth * 2,
         );
         g.fill({ color: 0x000000, alpha: 0.1 });
       }
@@ -38,7 +38,7 @@ export const BoardSprite: React.FC<
       g.rect(width / 2, -height / 2, depth, height);
       g.fill(colorBySpecies[species].secondary);
     },
-    [boardWidth, boardLength, thickness, species]
+    [boardWidth, boardLength, thickness, species],
   );
 
   return <pixiGraphics {...omitUndefined(rest)} draw={draw} />;

--- a/src/components/material-sprites/CuttingBoardSprite.tsx
+++ b/src/components/material-sprites/CuttingBoardSprite.tsx
@@ -69,11 +69,7 @@ export const CuttingBoardSprite: React.FC<
         for (let row = 0; -height / 2 + row * block < height / 2; row++) {
           const y = -height / 2 + row * block;
           const offset = row % 2 === 0 ? 0 : block / 2;
-          for (
-            let x = -width / 2 - block + offset;
-            x < width / 2;
-            x += block
-          ) {
+          for (let x = -width / 2 - block + offset; x < width / 2; x += block) {
             g.rect(
               Math.max(x + inset, -width / 2 + inset),
               y + inset,

--- a/src/components/material-sprites/FinishedBoxSprite.tsx
+++ b/src/components/material-sprites/FinishedBoxSprite.tsx
@@ -15,7 +15,10 @@ export const FinishedBoxSprite: React.FC<{
       draw={useCallback((g: Graphics) => {
         g.clear();
         g.rect(-10, -10, 20, 20);
-        g.stroke({ width: 1, color: colorBySpecies[material.species].secondary });
+        g.stroke({
+          width: 1,
+          color: colorBySpecies[material.species].secondary,
+        });
         g.fill(colorBySpecies[material.species].primary);
       }, [])}
     />

--- a/src/components/material-sprites/MaterialSprite.tsx
+++ b/src/components/material-sprites/MaterialSprite.tsx
@@ -22,15 +22,19 @@ export const MaterialSprite: React.FC<{
       return <PalletSprite pallet={material} alpha={alpha} tint={tint} />;
 
     case "jewelryBox":
-      return <FinishedBoxSprite material={material as FinishedProduct} alpha={alpha} tint={tint} />;
+      return (
+        <FinishedBoxSprite
+          material={material as FinishedProduct}
+          alpha={alpha}
+          tint={tint}
+        />
+      );
 
     case "panel":
       return <PanelSprite panel={material} alpha={alpha} tint={tint} />;
 
     case "endGrainSlice":
-      return (
-        <EndGrainSliceSprite slice={material} alpha={alpha} tint={tint} />
-      );
+      return <EndGrainSliceSprite slice={material} alpha={alpha} tint={tint} />;
 
     case "simpleCuttingBoard":
     case "stripedCuttingBoard":

--- a/src/components/material-sprites/PalletSprite.tsx
+++ b/src/components/material-sprites/PalletSprite.tsx
@@ -19,7 +19,7 @@ export const PalletSprite: React.FC<{
   const bottom = pallet.deckBoards.slice(0, MAX_BOTTOM_DECK);
   const top = pallet.deckBoards.slice(
     MAX_BOTTOM_DECK,
-    MAX_BOTTOM_DECK + MAX_TOP_DECK
+    MAX_BOTTOM_DECK + MAX_TOP_DECK,
   );
 
   const deckBoard = useMemo(() => board("pallet", 3, 4, 2), []);
@@ -42,12 +42,9 @@ export const PalletSprite: React.FC<{
               x={lerp(0, totalWidth, i / (MAX_BOTTOM_DECK - 1))}
               y={totalHeight / 2}
             >
-              <BoardSprite
-                board={deckBoard}
-                tint={tint}
-              />
+              <BoardSprite board={deckBoard} tint={tint} />
             </pixiContainer>
-          )
+          ),
       )}
 
       {array(pallet.stringerBoardsLeft).map((_, i) => (
@@ -57,10 +54,7 @@ export const PalletSprite: React.FC<{
           y={lerp(0, totalHeight, i / (MAX_STRINGERS - 1))}
           angle={90}
         >
-          <BoardSprite
-            board={stringerBoard}
-            tint={tint}
-          />
+          <BoardSprite board={stringerBoard} tint={tint} />
         </pixiContainer>
       ))}
 
@@ -72,12 +66,9 @@ export const PalletSprite: React.FC<{
               x={lerp(0, totalWidth, i / (MAX_TOP_DECK - 1))}
               y={totalHeight / 2}
             >
-              <BoardSprite
-                board={deckBoard}
-                tint={tint}
-              />
+              <BoardSprite board={deckBoard} tint={tint} />
             </pixiContainer>
-          )
+          ),
       )}
     </pixiContainer>
   );

--- a/src/components/shop-view/MachineSprite.tsx
+++ b/src/components/shop-view/MachineSprite.tsx
@@ -46,7 +46,12 @@ const MachineSelectionHighlight: React.FC<{
       const offsetY = ((minY + maxY) / 2) * cellSize;
 
       // Yellow selection outline
-      g.rect(offsetX - width / 2 - 4, offsetY - height / 2 - 4, width + 8, height + 8);
+      g.rect(
+        offsetX - width / 2 - 4,
+        offsetY - height / 2 - 4,
+        width + 8,
+        height + 8,
+      );
       g.stroke({ width: 3, color: 0xfcd34d });
     },
     [machine.type.cellsOccupied],
@@ -125,7 +130,8 @@ const OperationStatusBadge: React.FC<{ machine: Machine }> = ({ machine }) => {
       ? phases[progress.phaseIndex + 1]
       : phases[Math.min(progress.phaseIndex, phases.length - 1)]
     : undefined;
-  const needsYou = relevantPhase !== undefined && relevantPhase.attended && !attending;
+  const needsYou =
+    relevantPhase !== undefined && relevantPhase.attended && !attending;
 
   const total = phases.reduce((sum, phase) => sum + phase.duration, 0);
   const remaining = isOperating

--- a/src/components/shop-view/PersonSprite.tsx
+++ b/src/components/shop-view/PersonSprite.tsx
@@ -20,7 +20,7 @@ export const PersonSprite: React.FC<{ person: Person }> = ({ person }) => {
     to: {
       x: position[0],
       y: position[1],
-      angle
+      angle,
     },
     config: {
       mass: 0.1,
@@ -31,7 +31,11 @@ export const PersonSprite: React.FC<{ person: Person }> = ({ person }) => {
   });
 
   return (
-    <AnimatedPixiContainer x={springProps.x} y={springProps.y} angle={springProps.angle}>
+    <AnimatedPixiContainer
+      x={springProps.x}
+      y={springProps.y}
+      angle={springProps.angle}
+    >
       {person.inventory.map((material, index) => (
         <pixiContainer angle={index * 1} x={inchesToPixels(6)} key={index}>
           <MaterialSprite material={material} key={index} />

--- a/src/components/shop-view/ShopKeyboardShortcuts.tsx
+++ b/src/components/shop-view/ShopKeyboardShortcuts.tsx
@@ -63,7 +63,9 @@ export const ShopKeyboardShortcuts: React.FC = () => {
   // Emptying the queue stays available while away — it only affects what
   // happens once the player is back.
   useShortcut("clear-work-queue", () => applyAction(clearWorkQueueAction()));
-  useShortcut("cancel-last-move", () => applyAction(cancelLastWorkItemAction()));
+  useShortcut("cancel-last-move", () =>
+    applyAction(cancelLastWorkItemAction()),
+  );
 
   useShortcut("cycle-machine", cycleTarget, present);
 
@@ -191,7 +193,9 @@ export const ShopKeyboardShortcuts: React.FC = () => {
         }
       }
 
-      applyAction(setMachineOperationAction(machine, nextOperation, parameters));
+      applyAction(
+        setMachineOperationAction(machine, nextOperation, parameters),
+      );
     },
     present,
   );

--- a/src/components/shop-view/ShopView.tsx
+++ b/src/components/shop-view/ShopView.tsx
@@ -44,7 +44,9 @@ export const ShopView: React.FC = () => {
         backgroundAlpha={0}
         antialias={true}
       >
-        <gameStateContext.Provider value={{ gameState, updateGameState, saveGame, quitToMenu }}>
+        <gameStateContext.Provider
+          value={{ gameState, updateGameState, saveGame, quitToMenu }}
+        >
           <pixiTilingSprite
             eventMode="static"
             texture={floorTexture}
@@ -80,9 +82,7 @@ export const ShopView: React.FC = () => {
             />
           ))}
           <WorkQueueSprite />
-          {!gameState.player.away && (
-            <PersonSprite person={gameState.player} />
-          )}
+          {!gameState.player.away && <PersonSprite person={gameState.player} />}
         </gameStateContext.Provider>
       </Application>
     </>

--- a/src/components/shop-view/WorkQueueSprite.tsx
+++ b/src/components/shop-view/WorkQueueSprite.tsx
@@ -33,7 +33,7 @@ export const WorkQueueSprite: React.FC = () => {
       }
       g.stroke({ width: 8, color: 0x87ceeb, alpha: 0.5 });
     },
-    [positions]
+    [positions],
   );
 
   if (positions.length === 1) {

--- a/src/components/shortcuts/ShortcutHelpOverlay.tsx
+++ b/src/components/shortcuts/ShortcutHelpOverlay.tsx
@@ -102,7 +102,9 @@ export const ShortcutHelpProvider: React.FC<{
 export function useHelpOverlay(): { open: () => void } {
   const value = useContext(helpContext);
   if (!value) {
-    throw new Error("useHelpOverlay must be used within a ShortcutHelpProvider");
+    throw new Error(
+      "useHelpOverlay must be used within a ShortcutHelpProvider",
+    );
   }
   return value;
 }

--- a/src/components/shortcuts/ShortcutProvider.tsx
+++ b/src/components/shortcuts/ShortcutProvider.tsx
@@ -140,10 +140,7 @@ export const ShortcutProvider: React.FC<{ children: React.ReactNode }> = ({
     return () => document.removeEventListener("keydown", onKeyDown);
   }, []);
 
-  const value = useMemo(
-    () => ({ register, pushModal }),
-    [register, pushModal],
-  );
+  const value = useMemo(() => ({ register, pushModal }), [register, pushModal]);
 
   return (
     <shortcutContext.Provider value={value}>

--- a/src/components/skills-page/SkillsPage.tsx
+++ b/src/components/skills-page/SkillsPage.tsx
@@ -30,7 +30,10 @@ function recipesForSkill(skillId: SkillId): ReadonlyArray<string> {
   }
   for (const toolType of Object.values(TOOL_TYPES)) {
     for (const operation of toolType.operations) {
-      if (operation.requiredSkill === skillId && !names.includes(operation.name)) {
+      if (
+        operation.requiredSkill === skillId &&
+        !names.includes(operation.name)
+      ) {
         names.push(operation.name);
       }
     }
@@ -83,8 +86,8 @@ export const SkillsPage: React.FC = () => {
             ))}
           </div>
           <p className="text-xs text-ink-fade font-typewriter mt-4">
-            Finish products and commissions to earn craft XP. Each level
-            grants a skill point.
+            Finish products and commissions to earn craft XP. Each level grants
+            a skill point.
           </p>
         </div>
       </div>

--- a/src/components/store-page/StoreMachinesSection.tsx
+++ b/src/components/store-page/StoreMachinesSection.tsx
@@ -74,9 +74,7 @@ const MachineProductCard: React.FC<MachineSaleInfo> = ({ machine, price }) => {
 
 const PriceTag: React.FC<{ price: number }> = ({ price }) => {
   if (price === 0) {
-    return (
-      <span className="price-tag text-store-orange-dark">FREE</span>
-    );
+    return <span className="price-tag text-store-orange-dark">FREE</span>;
   }
   const dollars = Math.floor(price);
   const cents = Math.round((price - dollars) * 100)

--- a/src/components/store-page/StoreSuppliesSection.tsx
+++ b/src/components/store-page/StoreSuppliesSection.tsx
@@ -1,8 +1,5 @@
 import React from "react";
-import {
-  CONSUMABLE_TYPES,
-  ConsumableId,
-} from "../../game/Consumable";
+import { CONSUMABLE_TYPES, ConsumableId } from "../../game/Consumable";
 import {
   buyConsumablePackAction,
   buyMaterialAction,

--- a/src/game/Machine.ts
+++ b/src/game/Machine.ts
@@ -216,7 +216,9 @@ export class Machine {
    * station whose recipes are all still locked, or "none").
    */
   get selectedOperationOrNull():
-    MachineOperation | ParameterizedOperation | null {
+    | MachineOperation
+    | ParameterizedOperation
+    | null {
     return (
       this.operations.find((op) => op.id === this.state.selectedOperationId) ??
       null

--- a/src/game/game-actions/consumables.test.ts
+++ b/src/game/game-actions/consumables.test.ts
@@ -62,9 +62,7 @@ function rawMapleBoard(): FinishedProduct {
 
 describe("consumable stock helpers", () => {
   it("checks, adds, and subtracts amounts", () => {
-    const stock = addConsumables(NO_CONSUMABLES, [
-      { id: "nails", amount: 10 },
-    ]);
+    const stock = addConsumables(NO_CONSUMABLES, [{ id: "nails", amount: 10 }]);
     assert.strictEqual(stock.nails, 10);
     assert.ok(hasConsumables(stock, [{ id: "nails", amount: 10 }]));
     assert.ok(!hasConsumables(stock, [{ id: "nails", amount: 11 }]));

--- a/src/game/game-actions/machine-actions.ts
+++ b/src/game/game-actions/machine-actions.ts
@@ -12,13 +12,13 @@ export function canPlaceMachine(
   machineType: MachineType,
   position: Vector,
   rotation: Direction,
-  excludeMachineIndex?: number
+  excludeMachineIndex?: number,
 ): boolean {
   // Check all cells the machine occupies
   for (const relativeCell of machineType.cellsOccupied) {
     const absolutePosition = translateVec(
       rotateVec(relativeCell, rotation),
-      position
+      position,
     );
 
     // Check if cell exists in the map
@@ -31,8 +31,9 @@ export function canPlaceMachine(
     if (cell?.machine !== undefined) {
       // If we're excluding a specific machine (during move), check if this is it
       if (excludeMachineIndex !== undefined) {
-        const machines = cellMap.getCells()
-          .flatMap(c => c.machine ? [c.machine] : []);
+        const machines = cellMap
+          .getCells()
+          .flatMap((c) => (c.machine ? [c.machine] : []));
         const machineAtCell = cell.machine;
         const machineIndex = machines.indexOf(machineAtCell);
 
@@ -49,7 +50,7 @@ export function canPlaceMachine(
   for (const relativeCell of machineType.freeCellsNeeded) {
     const absolutePosition = translateVec(
       rotateVec(relativeCell, rotation),
-      position
+      position,
     );
 
     // Check if cell exists in the map
@@ -62,8 +63,9 @@ export function canPlaceMachine(
     if (cell?.machine !== undefined) {
       // If we're excluding a specific machine (during move), check if this is it
       if (excludeMachineIndex !== undefined) {
-        const machines = cellMap.getCells()
-          .flatMap(c => c.machine ? [c.machine] : []);
+        const machines = cellMap
+          .getCells()
+          .flatMap((c) => (c.machine ? [c.machine] : []));
         const machineAtCell = cell.machine;
         const machineIndex = machines.indexOf(machineAtCell);
 
@@ -86,10 +88,10 @@ export function canPlaceMachine(
 export function getMachineOccupiedCells(
   machineType: MachineType,
   position: Vector,
-  rotation: Direction
+  rotation: Direction,
 ): Vector[] {
   return machineType.cellsOccupied.map((relativeCell) =>
-    translateVec(rotateVec(relativeCell, rotation), position)
+    translateVec(rotateVec(relativeCell, rotation), position),
   );
 }
 
@@ -100,10 +102,10 @@ export function getMachineOccupiedCells(
 export function getMachineFreeCells(
   machineType: MachineType,
   position: Vector,
-  rotation: Direction
+  rotation: Direction,
 ): Vector[] {
   return machineType.freeCellsNeeded.map((relativeCell) =>
-    translateVec(rotateVec(relativeCell, rotation), position)
+    translateVec(rotateVec(relativeCell, rotation), position),
   );
 }
 
@@ -113,7 +115,7 @@ export function getMachineFreeCells(
 function dropMachineMaterials(
   gameState: GameAction extends (state: infer S) => any ? S : never,
   position: Vector,
-  materials: ReadonlyArray<any>
+  materials: ReadonlyArray<any>,
 ): any {
   if (materials.length === 0) {
     return gameState;
@@ -137,13 +139,13 @@ function dropMachineMaterials(
 export function placeMachineAction(
   machineTypeId: MachineId,
   position: Vector,
-  rotation: Direction = 0
+  rotation: Direction = 0,
 ): GameAction {
   return (gameState) => {
     // Verify machine is in storage
     if (!gameState.storage.machines.includes(machineTypeId)) {
       console.warn(
-        `Tried to place machine ${machineTypeId} but it's not in storage`
+        `Tried to place machine ${machineTypeId} but it's not in storage`,
       );
       return gameState;
     }
@@ -166,9 +168,9 @@ export function placeMachineAction(
     const unlockedOps = machineType.operations.filter(
       (op: { requiredSkill?: string }) =>
         !op.requiredSkill ||
-        (gameState.progression.unlockedSkills as ReadonlyArray<string>).includes(
-          op.requiredSkill,
-        ),
+        (
+          gameState.progression.unlockedSkills as ReadonlyArray<string>
+        ).includes(op.requiredSkill),
     );
     const newMachine = {
       machineTypeId,
@@ -205,7 +207,7 @@ export function placeMachineAction(
 export function moveMachineAction(
   machineIndex: number,
   newPosition: Vector,
-  newRotation: Direction
+  newRotation: Direction,
 ): GameAction {
   return (gameState) => {
     if (machineIndex < 0 || machineIndex >= gameState.machines.length) {
@@ -224,7 +226,11 @@ export function moveMachineAction(
     ];
 
     // Drop materials at old position
-    let updatedState = dropMachineMaterials(gameState, oldPosition, allMaterials);
+    let updatedState = dropMachineMaterials(
+      gameState,
+      oldPosition,
+      allMaterials,
+    );
 
     // Update machine with new position/rotation and clear materials
     const updatedMachines = [...updatedState.machines];
@@ -265,7 +271,11 @@ export function removeMachineToStorageAction(machineIndex: number): GameAction {
     ];
 
     // Drop materials at machine position
-    let updatedState = dropMachineMaterials(gameState, machine.position, allMaterials);
+    let updatedState = dropMachineMaterials(
+      gameState,
+      machine.position,
+      allMaterials,
+    );
 
     // Remove machine from placed machines
     const updatedMachines = [

--- a/src/game/game-actions/player-actions.ts
+++ b/src/game/game-actions/player-actions.ts
@@ -2,7 +2,13 @@ import { materialMeetsInput } from "../material-helpers";
 import { hasConsumables, subtractConsumables } from "../Consumable";
 import { CellMap } from "../CellMap";
 import { GameAction, MaterialPile } from "../GameState";
-import { Machine, MachineOperation, ParameterizedOperation, ParameterValues, MACHINE_TYPES } from "../Machine";
+import {
+  Machine,
+  MachineOperation,
+  ParameterizedOperation,
+  ParameterValues,
+  MACHINE_TYPES,
+} from "../Machine";
 import { MaterialInstance } from "../Materials";
 import { Direction, rotateVec, translateVec, vectorEquals } from "../Vectors";
 import { getOperationInputMaterials } from "../operation-helpers";
@@ -14,7 +20,7 @@ export function instaMovePlayerAction(direction: Direction): GameAction {
     const cellMap = CellMap.fromGameState(gameState);
     const destinationPosition = translateVec(
       gameState.player.position,
-      rotateVec([1, 0], direction)
+      rotateVec([1, 0], direction),
     );
     const destinationCell = cellMap.at(destinationPosition);
     if (destinationCell === undefined || destinationCell.machine) {
@@ -33,7 +39,7 @@ export function instaMovePlayerAction(direction: Direction): GameAction {
 }
 
 export function pickUpMaterialAction(
-  materialPiles: ReadonlyArray<MaterialPile>
+  materialPiles: ReadonlyArray<MaterialPile>,
 ): GameAction {
   return (gameState) => {
     for (const materialPile of materialPiles) {
@@ -53,7 +59,7 @@ export function pickUpMaterialAction(
           ],
         },
         materialPiles: gameState.materialPiles.filter(
-          (pile) => !materialPiles.includes(pile)
+          (pile) => !materialPiles.includes(pile),
         ),
       },
       { kind: "material-pickup" },
@@ -62,7 +68,7 @@ export function pickUpMaterialAction(
 }
 
 export function dropMaterialAction(
-  materials: ReadonlyArray<MaterialInstance>
+  materials: ReadonlyArray<MaterialInstance>,
 ): GameAction {
   return (gameState) => {
     for (const material of materials) {
@@ -77,7 +83,7 @@ export function dropMaterialAction(
         player: {
           ...gameState.player,
           inventory: gameState.player.inventory.filter(
-            (item) => !materials.includes(item)
+            (item) => !materials.includes(item),
           ),
         },
         materialPiles: [
@@ -95,7 +101,7 @@ export function dropMaterialAction(
 
 export function moveMaterialsToMachineAction(
   materials: ReadonlyArray<MaterialInstance>,
-  machine: Machine
+  machine: Machine,
 ): GameAction {
   return (gameState) => {
     const machineState = machine.state;
@@ -119,13 +125,13 @@ export function moveMaterialsToMachineAction(
         player: {
           ...gameState.player,
           inventory: gameState.player.inventory.filter(
-            (item) => !materials.includes(item)
+            (item) => !materials.includes(item),
           ),
         },
         machines: gameState.machines.map((m) =>
           vectorEquals(m.position, machineState.position)
             ? { ...m, inputMaterials: [...m.inputMaterials, ...materials] }
-            : m
+            : m,
         ),
       },
       { kind: "material-drop" },
@@ -135,7 +141,7 @@ export function moveMaterialsToMachineAction(
 
 export function takeInputsFromMachineAction(
   materials: ReadonlyArray<MaterialInstance>,
-  machine: Machine
+  machine: Machine,
 ): GameAction {
   return (gameState) => {
     const machineState = machine.state;
@@ -157,10 +163,10 @@ export function takeInputsFromMachineAction(
             ? {
                 ...m,
                 inputMaterials: m.inputMaterials.filter(
-                  (item: MaterialInstance) => !materials.includes(item)
+                  (item: MaterialInstance) => !materials.includes(item),
                 ),
               }
-            : m
+            : m,
         ),
       },
       { kind: "material-pickup" },
@@ -170,7 +176,7 @@ export function takeInputsFromMachineAction(
 
 export function takeOutputsFromMachineAction(
   materials: ReadonlyArray<MaterialInstance>,
-  machine: Machine
+  machine: Machine,
 ): GameAction {
   return (gameState) => {
     const machineState = machine.state;
@@ -192,10 +198,10 @@ export function takeOutputsFromMachineAction(
             ? {
                 ...m,
                 outputMaterials: m.outputMaterials.filter(
-                  (item: MaterialInstance) => !materials.includes(item)
+                  (item: MaterialInstance) => !materials.includes(item),
                 ),
               }
-            : m
+            : m,
         ),
       },
       { kind: "material-pickup" },
@@ -206,11 +212,13 @@ export function takeOutputsFromMachineAction(
 export function setMachineOperationAction(
   machine: Machine,
   operation: MachineOperation | ParameterizedOperation,
-  parameters?: ParameterValues
+  parameters?: ParameterValues,
 ): GameAction {
   return (gameState) => {
     const machineState = machine.state;
-    if (!availableOperations(machine, gameState.progression).includes(operation)) {
+    if (
+      !availableOperations(machine, gameState.progression).includes(operation)
+    ) {
       throw new Error("Tried to set machine operation to invalid operation");
     }
 
@@ -218,8 +226,12 @@ export function setMachineOperationAction(
       ...gameState,
       machines: gameState.machines.map((m) =>
         vectorEquals(m.position, machineState.position)
-          ? { ...m, selectedOperationId: operation.id, selectedParameters: parameters }
-          : m
+          ? {
+              ...m,
+              selectedOperationId: operation.id,
+              selectedParameters: parameters,
+            }
+          : m,
       ),
     };
   };
@@ -240,13 +252,13 @@ export function operateMachineAction(machine: Machine): GameAction {
     // Validate that we have all required materials
     const inputMaterials = getOperationInputMaterials(
       machine.selectedOperation,
-      machineState.selectedParameters
+      machineState.selectedParameters,
     );
 
     for (const inputMaterial of inputMaterials) {
       for (let i = 0; i < inputMaterial.quantity; i++) {
         const index = inventory.findIndex((m) =>
-          materialMeetsInput(m, inputMaterial)
+          materialMeetsInput(m, inputMaterial),
         );
         if (index === -1) {
           console.warn("Tried to perform operation without required materials");
@@ -285,7 +297,7 @@ export function operateMachineAction(machine: Machine): GameAction {
                 ticksRemaining: firstPhase.duration,
               },
             }
-          : m
+          : m,
       ),
     };
   };

--- a/src/game/game-actions/progression-actions.ts
+++ b/src/game/game-actions/progression-actions.ts
@@ -30,7 +30,10 @@ export function checkProgressionMilestonesAction(): GameAction {
         // The sales table can't be bought — it's granted once, here, so the
         // player can never be priced out of their only way to earn money.
         if (key === "freeSelling") {
-          storage = { ...storage, machines: [...storage.machines, "salesTable"] };
+          storage = {
+            ...storage,
+            machines: [...storage.machines, "salesTable"],
+          };
         }
       }
     }
@@ -41,8 +44,10 @@ export function checkProgressionMilestonesAction(): GameAction {
       tutorialStageFor(updatedState),
     );
 
-    if (progression === gameState.progression &&
-        tutorialStage === progression.tutorialStage) {
+    if (
+      progression === gameState.progression &&
+      tutorialStage === progression.tutorialStage
+    ) {
       return gameState;
     }
     return {

--- a/src/game/game-actions/skill-actions.test.ts
+++ b/src/game/game-actions/skill-actions.test.ts
@@ -66,9 +66,6 @@ describe("spendSkillPointAction", () => {
 
   it("refuses to buy an already-owned starter skill", () => {
     const state = stateWithPoints(1);
-    assert.strictEqual(
-      spendSkillPointAction(STARTER_SKILLS[0])(state),
-      state,
-    );
+    assert.strictEqual(spendSkillPointAction(STARTER_SKILLS[0])(state), state);
   });
 });

--- a/src/game/game-actions/sound-actions.test.ts
+++ b/src/game/game-actions/sound-actions.test.ts
@@ -43,11 +43,17 @@ describe("sound-actions", () => {
 
 describe("material movement sound cues", () => {
   it("pickUpMaterialAction emits a pickup cue", () => {
-    const pile = { material: makePallet(), position: [0, 0] as [number, number] };
+    const pile = {
+      material: makePallet(),
+      position: [0, 0] as [number, number],
+    };
     const state = {
       ...initialGameState,
       materialPiles: [pile],
-      player: { ...initialGameState.player, position: [0, 0] as [number, number] },
+      player: {
+        ...initialGameState.player,
+        position: [0, 0] as [number, number],
+      },
     };
     const result = pickUpMaterialAction([pile])(state);
     assert.deepStrictEqual(result.pendingSounds, [{ kind: "material-pickup" }]);
@@ -64,11 +70,17 @@ describe("material movement sound cues", () => {
   });
 
   it("emits no cue when a pickup is rejected", () => {
-    const pile = { material: makePallet(), position: [3, 3] as [number, number] };
+    const pile = {
+      material: makePallet(),
+      position: [3, 3] as [number, number],
+    };
     const state = {
       ...initialGameState,
       materialPiles: [pile],
-      player: { ...initialGameState.player, position: [0, 0] as [number, number] },
+      player: {
+        ...initialGameState.player,
+        position: [0, 0] as [number, number],
+      },
     };
     const result = pickUpMaterialAction([pile])(state);
     assert.strictEqual(result.pendingSounds?.length, 0);

--- a/src/game/game-actions/store-actions.test.ts
+++ b/src/game/game-actions/store-actions.test.ts
@@ -82,9 +82,10 @@ describe("sellMaterialAction", () => {
 
 describe("buyMachineAction", () => {
   it("deducts the price and adds the machine to storage", () => {
-    const result = buyMachineAction("jobsiteTableSaw", 150)(
-      stateWith({ money: 200 }),
-    );
+    const result = buyMachineAction(
+      "jobsiteTableSaw",
+      150,
+    )(stateWith({ money: 200 }));
     assert.strictEqual(result.money, 50);
     assert.deepStrictEqual(result.storage.machines, ["jobsiteTableSaw"]);
   });
@@ -96,17 +97,16 @@ describe("buyMachineAction", () => {
   });
 
   it("unlocks shop layout and advances the tutorial when buying a miter saw", () => {
-    const result = buyMachineAction("miterSaw", 150)(
-      stateWith({ money: 200 }),
-    );
+    const result = buyMachineAction("miterSaw", 150)(stateWith({ money: 200 }));
     assert.strictEqual(result.progression.shopLayoutUnlocked, true);
     assert.strictEqual(result.progression.tutorialStage, 2);
   });
 
   it("does not unlock shop layout for other machines", () => {
-    const result = buyMachineAction("jobsiteTableSaw", 150)(
-      stateWith({ money: 200 }),
-    );
+    const result = buyMachineAction(
+      "jobsiteTableSaw",
+      150,
+    )(stateWith({ money: 200 }));
     assert.strictEqual(result.progression.shopLayoutUnlocked, false);
   });
 });

--- a/src/game/game-actions/store-actions.ts
+++ b/src/game/game-actions/store-actions.ts
@@ -4,14 +4,17 @@ import { getActiveCommission } from "../commissionSequence";
 import { MachineId } from "../Machine";
 import { MaterialInstance } from "../Materials";
 import { materialMeetsInput } from "../material-helpers";
-import { incrementCommissionsCompletedAction, checkProgressionMilestonesAction } from "./progression-actions";
+import {
+  incrementCommissionsCompletedAction,
+  checkProgressionMilestonesAction,
+} from "./progression-actions";
 import { combineActions } from "./misc-actions";
 import { withXp } from "./skill-actions";
 import { emitSound } from "./sound-actions";
 
 export function buyMaterialAction(
   material: MaterialInstance,
-  price: number
+  price: number,
 ): GameAction {
   return (gameState) => {
     if (gameState.money < price) {
@@ -30,7 +33,9 @@ export function buyMaterialAction(
 }
 
 /** Buys one pack of a consumable — supplies go straight to the shop stock. */
-export function buyConsumablePackAction(consumableId: ConsumableId): GameAction {
+export function buyConsumablePackAction(
+  consumableId: ConsumableId,
+): GameAction {
   return (gameState) => {
     const { packSize, packPrice } = CONSUMABLE_TYPES[consumableId];
     if (gameState.money < packPrice) {
@@ -49,7 +54,7 @@ export function buyConsumablePackAction(consumableId: ConsumableId): GameAction 
 
 export function sellMaterialAction(
   material: MaterialInstance,
-  price: number
+  price: number,
 ): GameAction {
   return (gameState) => {
     if (!gameState.player.inventory.some((item) => item === material)) {
@@ -62,7 +67,7 @@ export function sellMaterialAction(
       player: {
         ...gameState.player,
         inventory: gameState.player.inventory.filter(
-          (item) => item !== material
+          (item) => item !== material,
         ),
       },
     };
@@ -71,7 +76,7 @@ export function sellMaterialAction(
 
 export function buyMachineAction(
   machineTypeId: MachineId,
-  price: number
+  price: number,
 ): GameAction {
   return (gameState) => {
     if (gameState.money < price) {
@@ -105,7 +110,7 @@ export function completeCommissionAction(): GameAction {
     // Check if player has all required materials
     for (const requiredMaterial of commission.requiredMaterials) {
       const matchingMaterials = gameState.player.inventory.filter((material) =>
-        materialMeetsInput(material, requiredMaterial)
+        materialMeetsInput(material, requiredMaterial),
       );
       if (matchingMaterials.length < requiredMaterial.quantity) {
         console.warn("Player doesn't have required materials for commission");
@@ -118,7 +123,10 @@ export function completeCommissionAction(): GameAction {
     for (const requiredMaterial of commission.requiredMaterials) {
       let remainingQuantity = requiredMaterial.quantity;
       updatedInventory = updatedInventory.filter((material) => {
-        if (remainingQuantity > 0 && materialMeetsInput(material, requiredMaterial)) {
+        if (
+          remainingQuantity > 0 &&
+          materialMeetsInput(material, requiredMaterial)
+        ) {
           remainingQuantity--;
           return false; // Remove this material
         }
@@ -146,7 +154,7 @@ export function completeCommissionAction(): GameAction {
     // Progression must only advance when the commission actually completes
     return combineActions(
       incrementCommissionsCompletedAction(),
-      checkProgressionMilestonesAction()
+      checkProgressionMilestonesAction(),
     )(completedState);
   };
 }

--- a/src/game/game-actions/tickAction.test.ts
+++ b/src/game/game-actions/tickAction.test.ts
@@ -23,7 +23,11 @@ function workspaceMachine(overrides: Partial<MachineState>): MachineState {
     outputMaterials: [],
     selectedOperationId: "dismantlePallet",
     selectedParameters: undefined,
-    operationProgress: { status: "notStarted", phaseIndex: 0, ticksRemaining: 0 },
+    operationProgress: {
+      status: "notStarted",
+      phaseIndex: 0,
+      ticksRemaining: 0,
+    },
     tools: [],
     ...overrides,
   };
@@ -89,7 +93,11 @@ describe("tickAction", () => {
   it("counts down an attended operation while the player is at the machine", () => {
     const machine = workspaceMachine({
       processingMaterials: [nearlyDismantledPallet()],
-      operationProgress: { status: "inProgress", phaseIndex: 0, ticksRemaining: 3 },
+      operationProgress: {
+        status: "inProgress",
+        phaseIndex: 0,
+        ticksRemaining: 3,
+      },
     });
     const result = tickAction(attendingStateWith({ machines: [machine] }));
     assert.deepStrictEqual(result.machines[0].operationProgress, {
@@ -102,7 +110,11 @@ describe("tickAction", () => {
   it("pauses an attended operation while the player is elsewhere", () => {
     const machine = workspaceMachine({
       processingMaterials: [nearlyDismantledPallet()],
-      operationProgress: { status: "inProgress", phaseIndex: 0, ticksRemaining: 3 },
+      operationProgress: {
+        status: "inProgress",
+        phaseIndex: 0,
+        ticksRemaining: 3,
+      },
     });
     // Player at [0,0], not the operation cell — no progress, no cancel
     const result = tickAction(stateWith({ machines: [machine] }));
@@ -112,7 +124,11 @@ describe("tickAction", () => {
   it("emits an operation-complete sound cue when an operation finishes", () => {
     const machine = workspaceMachine({
       processingMaterials: [nearlyDismantledPallet()],
-      operationProgress: { status: "inProgress", phaseIndex: 0, ticksRemaining: 1 },
+      operationProgress: {
+        status: "inProgress",
+        phaseIndex: 0,
+        ticksRemaining: 1,
+      },
     });
     const result = tickAction(attendingStateWith({ machines: [machine] }));
     assert.deepStrictEqual(result.pendingSounds, [
@@ -174,7 +190,11 @@ describe("tickAction", () => {
   it("pauses attended work during away trips — you're not there to do it", () => {
     const machine = workspaceMachine({
       processingMaterials: [nearlyDismantledPallet()],
-      operationProgress: { status: "inProgress", phaseIndex: 0, ticksRemaining: 5 },
+      operationProgress: {
+        status: "inProgress",
+        phaseIndex: 0,
+        ticksRemaining: 5,
+      },
     });
     const state = stateWith({
       tick: 10,
@@ -189,10 +209,7 @@ describe("tickAction", () => {
     });
     const result = tickAction(state);
     assert.strictEqual(result.player.workQueue.length, 1);
-    assert.strictEqual(
-      result.machines[0].operationProgress.ticksRemaining,
-      5,
-    );
+    assert.strictEqual(result.machines[0].operationProgress.ticksRemaining, 5);
   });
 
   it("delivers scavenged loot to the dropoff spot on return", () => {
@@ -218,7 +235,11 @@ describe("tickAction", () => {
   it("applies the operation output when the countdown finishes", () => {
     const machine = workspaceMachine({
       processingMaterials: [nearlyDismantledPallet()],
-      operationProgress: { status: "inProgress", phaseIndex: 0, ticksRemaining: 1 },
+      operationProgress: {
+        status: "inProgress",
+        phaseIndex: 0,
+        ticksRemaining: 1,
+      },
     });
     const result = tickAction(attendingStateWith({ machines: [machine] }));
     const finished = result.machines[0];
@@ -248,7 +269,11 @@ describe("tickAction", () => {
       tools: ["hammer"],
       selectedOperationId: "buildRusticPalletShelf",
       processingMaterials: shelfBoards,
-      operationProgress: { status: "inProgress", phaseIndex: 0, ticksRemaining: 1 },
+      operationProgress: {
+        status: "inProgress",
+        phaseIndex: 0,
+        ticksRemaining: 1,
+      },
     });
     const result = tickAction(attendingStateWith({ machines: [machine] }));
     // Rustic shelf sells for $60 -> 60 XP
@@ -261,7 +286,11 @@ describe("tickAction operation phases", () => {
     const machine = workspaceMachine({
       selectedOperationId: "glueUpPanel",
       processingMaterials: glueStrips(),
-      operationProgress: { status: "inProgress", phaseIndex: 0, ticksRemaining: 1 },
+      operationProgress: {
+        status: "inProgress",
+        phaseIndex: 0,
+        ticksRemaining: 1,
+      },
     });
     const result = tickAction(attendingStateWith({ machines: [machine] }));
     assert.deepStrictEqual(result.machines[0].operationProgress, {
@@ -275,7 +304,11 @@ describe("tickAction operation phases", () => {
     const machine = workspaceMachine({
       selectedOperationId: "glueUpPanel",
       processingMaterials: glueStrips(),
-      operationProgress: { status: "inProgress", phaseIndex: 0, ticksRemaining: 4 },
+      operationProgress: {
+        status: "inProgress",
+        phaseIndex: 0,
+        ticksRemaining: 4,
+      },
     });
     const result = tickAction(stateWith({ machines: [machine] }));
     assert.strictEqual(result.machines[0], machine);
@@ -285,7 +318,11 @@ describe("tickAction operation phases", () => {
     const machine = workspaceMachine({
       selectedOperationId: "glueUpPanel",
       processingMaterials: glueStrips(),
-      operationProgress: { status: "inProgress", phaseIndex: 1, ticksRemaining: 10 },
+      operationProgress: {
+        status: "inProgress",
+        phaseIndex: 1,
+        ticksRemaining: 10,
+      },
     });
     const state = stateWith({
       tick: 10,
@@ -303,7 +340,11 @@ describe("tickAction operation phases", () => {
     const machine = workspaceMachine({
       selectedOperationId: "glueUpPanel",
       processingMaterials: glueStrips(),
-      operationProgress: { status: "inProgress", phaseIndex: 1, ticksRemaining: 1 },
+      operationProgress: {
+        status: "inProgress",
+        phaseIndex: 1,
+        ticksRemaining: 1,
+      },
     });
     // Player at [0,0], nowhere near the bench
     const result = tickAction(stateWith({ machines: [machine] }));
@@ -319,7 +360,11 @@ describe("tickAction operation phases", () => {
     const machine = workspaceMachine({
       selectedOperationId: "glueUpPanel",
       processingMaterials: glueStrips(),
-      operationProgress: { status: "inProgress", phaseIndex: 0, ticksRemaining: 0 },
+      operationProgress: {
+        status: "inProgress",
+        phaseIndex: 0,
+        ticksRemaining: 0,
+      },
     });
     const result = tickAction(stateWith({ machines: [machine] }));
     assert.deepStrictEqual(result.machines[0].operationProgress, {

--- a/src/game/game-actions/tickAction.ts
+++ b/src/game/game-actions/tickAction.ts
@@ -81,7 +81,7 @@ export const tickAction: GameAction = (gameState) => {
     );
     if (!selectedOperation) {
       throw new Error(
-        `Unknown operation: ${machineState.selectedOperationId} for machine ${machineState.machineTypeId}`
+        `Unknown operation: ${machineState.selectedOperationId} for machine ${machineState.machineTypeId}`,
       );
     }
 
@@ -155,7 +155,7 @@ export const tickAction: GameAction = (gameState) => {
       executeOperation(
         selectedOperation,
         machineState.processingMaterials,
-        machineState.selectedParameters
+        machineState.selectedParameters,
       );
 
     for (const output of outputs) {
@@ -207,7 +207,10 @@ export const tickAction: GameAction = (gameState) => {
     const [sold, ...remaining] = machineState.inputMaterials;
     // Round to cents so repeated sales don't accumulate float error
     money = Math.round((money + getSellValue(sold)) * 100) / 100;
-    soundEvents.push({ kind: "sale", machineTypeId: machineState.machineTypeId });
+    soundEvents.push({
+      kind: "sale",
+      machineTypeId: machineState.machineTypeId,
+    });
     return { ...machineState, inputMaterials: remaining };
   });
 

--- a/src/game/game-actions/tool-actions.test.ts
+++ b/src/game/game-actions/tool-actions.test.ts
@@ -103,7 +103,10 @@ describe("unmountToolAction", () => {
       ),
     };
     const result = unmountToolAction(workspaceOf(state), "sandingBlock")(state);
-    assert.strictEqual(result.machines[0].selectedOperationId, "dismantlePallet");
+    assert.strictEqual(
+      result.machines[0].selectedOperationId,
+      "dismantlePallet",
+    );
   });
 
   it("refuses while the station is mid-operation", () => {

--- a/src/game/game-actions/tool-actions.ts
+++ b/src/game/game-actions/tool-actions.ts
@@ -115,6 +115,10 @@ function withValidSelectedOperation(machineState: MachineState): MachineState {
     ...machineState,
     selectedOperationId: operations[0]?.id ?? "none",
     selectedParameters: undefined,
-    operationProgress: { status: "notStarted", phaseIndex: 0, ticksRemaining: 0 },
+    operationProgress: {
+      status: "notStarted",
+      phaseIndex: 0,
+      ticksRemaining: 0,
+    },
   };
 }

--- a/src/game/machines/cutting-board-chain.test.ts
+++ b/src/game/machines/cutting-board-chain.test.ts
@@ -80,22 +80,34 @@ describe("finishCuttingBoard", () => {
 
   it("accepts full-thickness sanded panels — the planer is optional", () => {
     assert.ok(
-      materialMeetsInput(uniformPanel("maple", 5, 2, 2, 4, "sanded"), requirement),
+      materialMeetsInput(
+        uniformPanel("maple", 5, 2, 2, 4, "sanded"),
+        requirement,
+      ),
     );
   });
 
   it("rejects panels that aren't sanded", () => {
     assert.ok(
-      !materialMeetsInput(uniformPanel("maple", 5, 2, 2, 3, "rough"), requirement),
+      !materialMeetsInput(
+        uniformPanel("maple", 5, 2, 2, 3, "rough"),
+        requirement,
+      ),
     );
     assert.ok(
-      !materialMeetsInput(uniformPanel("maple", 5, 2, 2, 3, "smooth"), requirement),
+      !materialMeetsInput(
+        uniformPanel("maple", 5, 2, 2, 3, "smooth"),
+        requirement,
+      ),
     );
   });
 
   it("rejects a panel that is too narrow", () => {
     assert.ok(
-      !materialMeetsInput(uniformPanel("maple", 4, 2, 2, 3, "sanded"), requirement),
+      !materialMeetsInput(
+        uniformPanel("maple", 4, 2, 2, 3, "sanded"),
+        requirement,
+      ),
     );
   });
 
@@ -159,9 +171,13 @@ describe("planePanel", () => {
 
   it("accepts panels at or above the target thickness, never below", () => {
     const requirement = planePanel.getInputMaterials({ targetThickness: 3 })[0];
-    assert.ok(materialMeetsInput(uniformPanel("maple", 5, 2, 2, 4), requirement));
+    assert.ok(
+      materialMeetsInput(uniformPanel("maple", 5, 2, 2, 4), requirement),
+    );
     // Equal thickness is a skim pass — squeeze-out is sacrificial material
-    assert.ok(materialMeetsInput(uniformPanel("maple", 5, 2, 2, 3), requirement));
+    assert.ok(
+      materialMeetsInput(uniformPanel("maple", 5, 2, 2, 3), requirement),
+    );
     assert.ok(
       !materialMeetsInput(uniformPanel("maple", 5, 2, 2, 2), requirement),
     );

--- a/src/game/machines/end-grain.test.ts
+++ b/src/game/machines/end-grain.test.ts
@@ -6,7 +6,11 @@ import { getMachines, MachineOperation, MachineState } from "../Machine";
 import { initialGameState } from "../initialGameState";
 import { mountToolAction } from "../game-actions/tool-actions";
 import { tickAction } from "../game-actions/tickAction";
-import { isFinishedProduct, makeMaterial, materialMeetsInput } from "../material-helpers";
+import {
+  isFinishedProduct,
+  makeMaterial,
+  materialMeetsInput,
+} from "../material-helpers";
 import { getSellValue } from "../material-values";
 import { EndGrainSlice, SheetGood } from "../Materials";
 import { panel, uniformPanel } from "../panel-helpers";
@@ -67,10 +71,16 @@ describe("crosscutPanel", () => {
 
   it("takes a clean long-grain panel, never an end-grain one", () => {
     assert.ok(
-      materialMeetsInput(uniformPanel("maple", 5, 2, 2, 4, "sanded"), requirement),
+      materialMeetsInput(
+        uniformPanel("maple", 5, 2, 2, 4, "sanded"),
+        requirement,
+      ),
     );
     assert.ok(
-      !materialMeetsInput(uniformPanel("maple", 5, 2, 2, 4, "rough"), requirement),
+      !materialMeetsInput(
+        uniformPanel("maple", 5, 2, 2, 4, "rough"),
+        requirement,
+      ),
     );
     const endGrain = {
       ...uniformPanel("maple", 5, 2, 2, 4, "sanded"),
@@ -142,7 +152,10 @@ describe("finishEndGrainBoard", () => {
 
   it("rejects long-grain panels of the same shape", () => {
     assert.ok(
-      !materialMeetsInput(uniformPanel("maple", 5, 2, 1, 8, "sanded"), requirement),
+      !materialMeetsInput(
+        uniformPanel("maple", 5, 2, 1, 8, "sanded"),
+        requirement,
+      ),
     );
   });
 
@@ -196,11 +209,17 @@ describe("planer vs end grain", () => {
     }
     const requirement = planePanel.getInputMaterials({ targetThickness: 4 })[0];
     assert.ok(
-      materialMeetsInput(uniformPanel("maple", 5, 2, 1, 8, "rough"), requirement),
+      materialMeetsInput(
+        uniformPanel("maple", 5, 2, 1, 8, "rough"),
+        requirement,
+      ),
     );
     assert.ok(
       !materialMeetsInput(
-        { ...uniformPanel("maple", 5, 2, 1, 8, "rough"), grain: "end" as const },
+        {
+          ...uniformPanel("maple", 5, 2, 1, 8, "rough"),
+          grain: "end" as const,
+        },
         requirement,
       ),
     );

--- a/src/game/machines/garbageCan.ts
+++ b/src/game/machines/garbageCan.ts
@@ -4,7 +4,8 @@ import { MaterialInstance } from "../Materials";
 export const garbageCan: MachineType = {
   id: "garbageCan",
   name: "Garbage Can",
-  description: "Dispose of unwanted materials and scraps. Materials are permanently removed.",
+  description:
+    "Dispose of unwanted materials and scraps. Materials are permanently removed.",
   cellsOccupied: [[0, 0]],
   freeCellsNeeded: [],
   cost: 0, // Free - basic quality of life feature

--- a/src/game/machines/jobsiteTableSaw.ts
+++ b/src/game/machines/jobsiteTableSaw.ts
@@ -33,7 +33,9 @@ export const jobsiteTableSaw: MachineType = {
       getInputMaterials: (params) => [
         {
           type: ["board"],
-          width: BOARD_DIMENSIONS.filter((d) => d > (params.targetWidth as BoardDimension)),
+          width: BOARD_DIMENSIONS.filter(
+            (d) => d > (params.targetWidth as BoardDimension),
+          ),
           // Never rip a rough edge against the fence — kickback city.
           // Straight-line it first (jointer, sled, or hand plane).
           jointedEdges: [1, 2],
@@ -45,7 +47,11 @@ export const jobsiteTableSaw: MachineType = {
         if (!isBoard(inputBoard)) {
           throw new Error("Input material is not a board");
         }
-        const result = cutBoard(inputBoard, params.targetWidth as BoardDimension, "width");
+        const result = cutBoard(
+          inputBoard,
+          params.targetWidth as BoardDimension,
+          "width",
+        );
         // The fence-side piece gains a saw-straight second edge; the offcut
         // keeps whatever the input had (its far edge is unchanged).
         const [kept, ...offcuts] = result.outputs;

--- a/src/game/machines/jointer.ts
+++ b/src/game/machines/jointer.ts
@@ -32,9 +32,7 @@ export const jointer: MachineType = {
       requiredSkill: "basicMilling",
       name: "Joint Face",
       duration: 10,
-      inputMaterials: [
-        { type: ["board"], jointedFaces: [0], quantity: 1 },
-      ],
+      inputMaterials: [{ type: ["board"], jointedFaces: [0], quantity: 1 }],
       output: (materials: ReadonlyArray<MaterialInstance>) => {
         const inputBoard = materials[0];
         if (!isBoard(inputBoard)) {
@@ -43,9 +41,7 @@ export const jointer: MachineType = {
         // One flat face; the rest of the board is as rough as it came
         return {
           inputs: [],
-          outputs: [
-            makeMaterial<Board>({ ...inputBoard, jointedFaces: 1 }),
-          ],
+          outputs: [makeMaterial<Board>({ ...inputBoard, jointedFaces: 1 })],
         };
       },
     },
@@ -70,9 +66,7 @@ export const jointer: MachineType = {
         }
         return {
           inputs: [],
-          outputs: [
-            makeMaterial<Board>({ ...inputBoard, jointedEdges: 1 }),
-          ],
+          outputs: [makeMaterial<Board>({ ...inputBoard, jointedEdges: 1 })],
         };
       },
     },

--- a/src/game/machines/lunchboxPlaner.ts
+++ b/src/game/machines/lunchboxPlaner.ts
@@ -33,7 +33,9 @@ export const lunchboxPlaner: MachineType = {
         // Equal thickness is a skim pass: rough stock carries sacrificial
         // material beyond its nominal size, so milling never shrinks the
         // listed dimensions.
-        const validThicknesses = BOARD_DIMENSIONS.filter(d => d >= targetThickness);
+        const validThicknesses = BOARD_DIMENSIONS.filter(
+          (d) => d >= targetThickness,
+        );
         return [
           {
             type: ["board"],
@@ -82,7 +84,9 @@ export const lunchboxPlaner: MachineType = {
         const targetThickness = params.targetThickness as BoardDimension;
         // Equal thickness is a skim pass — glue squeeze-out and alignment
         // ridges are sacrificial, same as rough stock's extra material.
-        const validThicknesses = BOARD_DIMENSIONS.filter(d => d >= targetThickness);
+        const validThicknesses = BOARD_DIMENSIONS.filter(
+          (d) => d >= targetThickness,
+        );
         return [
           {
             type: ["panel"],

--- a/src/game/machines/milling.test.ts
+++ b/src/game/machines/milling.test.ts
@@ -98,8 +98,12 @@ describe("straight-line sled", () => {
 
 describe("hand plane", () => {
   it("flattens a face and straightens an edge, slowly", () => {
-    const faceOp = handPlane.operations.find((op) => op.id === "handPlaneFace")!;
-    const edgeOp = handPlane.operations.find((op) => op.id === "handPlaneEdge")!;
+    const faceOp = handPlane.operations.find(
+      (op) => op.id === "handPlaneFace",
+    )!;
+    const edgeOp = handPlane.operations.find(
+      (op) => op.id === "handPlaneEdge",
+    )!;
     const flattened = faceOp.output([roughBoard()]).outputs[0];
     assert.ok(isBoard(flattened));
     assert.strictEqual(flattened.jointedFaces, 1);

--- a/src/game/machines/miterSaw.ts
+++ b/src/game/machines/miterSaw.ts
@@ -29,7 +29,9 @@ export const miterSaw: MachineType = {
       getInputMaterials: (params) => [
         {
           type: ["board"],
-          length: BOARD_DIMENSIONS.filter((d) => d > (params.targetLength as BoardDimension)),
+          length: BOARD_DIMENSIONS.filter(
+            (d) => d > (params.targetLength as BoardDimension),
+          ),
           quantity: 1,
         },
       ],
@@ -38,7 +40,11 @@ export const miterSaw: MachineType = {
         if (!isBoard(inputBoard)) {
           throw new Error("Input material is not a board");
         }
-        return cutBoard(inputBoard, params.targetLength as BoardDimension, "length");
+        return cutBoard(
+          inputBoard,
+          params.targetLength as BoardDimension,
+          "length",
+        );
       },
     } as ParameterizedOperation,
   ],

--- a/src/game/machines/pattern-boards.test.ts
+++ b/src/game/machines/pattern-boards.test.ts
@@ -39,14 +39,10 @@ function strips(...pairs: [Species, PanelStrip["width"]][]): PanelStrip[] {
 describe("stripsAlternate", () => {
   it("accepts strict alternation and rejects repeats", () => {
     assert.ok(
-      stripsAlternate(
-        strips(["walnut", 2], ["maple", 2], ["walnut", 2]),
-      ),
+      stripsAlternate(strips(["walnut", 2], ["maple", 2], ["walnut", 2])),
     );
     assert.ok(
-      !stripsAlternate(
-        strips(["walnut", 2], ["walnut", 2], ["maple", 2]),
-      ),
+      !stripsAlternate(strips(["walnut", 2], ["walnut", 2], ["maple", 2])),
     );
   });
 });
@@ -173,12 +169,8 @@ describe("extendPanel", () => {
     assert.ok(
       materialMeetsInput(panel(strips(["walnut", 3]), 2, 4, "rough"), panelReq),
     );
-    assert.ok(
-      !materialMeetsInput(board("maple", 2, 2, 4, "rough"), stripReq),
-    );
-    assert.ok(
-      materialMeetsInput(board("maple", 2, 2, 4, "smooth"), stripReq),
-    );
+    assert.ok(!materialMeetsInput(board("maple", 2, 2, 4, "rough"), stripReq));
+    assert.ok(materialMeetsInput(board("maple", 2, 2, 4, "smooth"), stripReq));
   });
 });
 
@@ -220,7 +212,10 @@ describe("glue-up phases", () => {
     ];
     for (const op of allOperations) {
       if (op.phases) {
-        const sum = op.phases.reduce((total, phase) => total + phase.duration, 0);
+        const sum = op.phases.reduce(
+          (total, phase) => total + phase.duration,
+          0,
+        );
         assert.strictEqual(sum, op.duration, `${op.id} phases sum`);
       }
     }
@@ -264,7 +259,13 @@ describe("finishStripedBoard", () => {
 
   it("rejects single-species and pallet-tainted panels", () => {
     const uniform = panel(
-      strips(["maple", 2], ["maple", 2], ["maple", 2], ["maple", 2], ["maple", 2]),
+      strips(
+        ["maple", 2],
+        ["maple", 2],
+        ["maple", 2],
+        ["maple", 2],
+        ["maple", 2],
+      ),
       2,
       3,
       "sanded",

--- a/src/game/machines/workspace.ts
+++ b/src/game/machines/workspace.ts
@@ -71,14 +71,14 @@ export const workspace: MachineType = {
         }
 
         const deckBoardsCount = inputPallet.deckBoards.filter(
-          (board: boolean) => board
+          (board: boolean) => board,
         ).length;
         // Every board pried loose gives its nails back — one per board.
         // A whole pallet worth of prying keeps the rustic shelf free.
         if (deckBoardsCount <= 1) {
           const stringers = array(3).map(() => board("pallet", 4, 6, 3));
           const deckBoards = array(deckBoardsCount).map(() =>
-            board("pallet", 3, 4, 1)
+            board("pallet", 3, 4, 1),
           );
           return {
             inputs: [],
@@ -91,7 +91,9 @@ export const workspace: MachineType = {
           const deckBoardsLeft = [
             ...inputPallet.deckBoards,
           ] as typeof inputPallet.deckBoards;
-          const index = deckBoardsLeft.findLastIndex((board: boolean) => board === true);
+          const index = deckBoardsLeft.findLastIndex(
+            (board: boolean) => board === true,
+          );
           deckBoardsLeft[index] = false;
           return {
             inputs: [
@@ -260,7 +262,13 @@ export const workspace: MachineType = {
       inputMaterials: [
         // A plywood base plus scrap runners and a fence
         { type: ["plywood"], length: [4], width: [4], quantity: 1 },
-        { type: ["board"], width: [4], length: [3], thickness: [1], quantity: 2 },
+        {
+          type: ["board"],
+          width: [4],
+          length: [3],
+          thickness: [1],
+          quantity: 2,
+        },
       ],
       output: () => {
         // The output is tooling, not product: the sled lands in tool
@@ -281,7 +289,13 @@ export const workspace: MachineType = {
         // A long plywood base with toggle clamps to carry wavy-edged stock;
         // same pallet-scrap ingredients as the crosscut sled
         { type: ["plywood"], length: [4], width: [4], quantity: 1 },
-        { type: ["board"], width: [4], length: [3], thickness: [1], quantity: 2 },
+        {
+          type: ["board"],
+          width: [4],
+          length: [3],
+          thickness: [1],
+          quantity: 2,
+        },
       ],
       output: () => {
         return {

--- a/src/game/tools/handPlane.ts
+++ b/src/game/tools/handPlane.ts
@@ -21,9 +21,7 @@ export const handPlane: ToolType = {
       name: "Flatten Face by Hand",
       requiredSkill: "basicMilling",
       duration: 35,
-      inputMaterials: [
-        { type: ["board"], jointedFaces: [0], quantity: 1 },
-      ],
+      inputMaterials: [{ type: ["board"], jointedFaces: [0], quantity: 1 }],
       output: (materials: ReadonlyArray<MaterialInstance>) => {
         const inputBoard = materials[0];
         if (!isBoard(inputBoard)) {
@@ -31,9 +29,7 @@ export const handPlane: ToolType = {
         }
         return {
           inputs: [],
-          outputs: [
-            makeMaterial<Board>({ ...inputBoard, jointedFaces: 1 }),
-          ],
+          outputs: [makeMaterial<Board>({ ...inputBoard, jointedFaces: 1 })],
         };
       },
     },
@@ -42,9 +38,7 @@ export const handPlane: ToolType = {
       name: "Straighten Edge by Hand",
       requiredSkill: "basicMilling",
       duration: 30,
-      inputMaterials: [
-        { type: ["board"], jointedEdges: [0], quantity: 1 },
-      ],
+      inputMaterials: [{ type: ["board"], jointedEdges: [0], quantity: 1 }],
       output: (materials: ReadonlyArray<MaterialInstance>) => {
         const inputBoard = materials[0];
         if (!isBoard(inputBoard)) {
@@ -52,9 +46,7 @@ export const handPlane: ToolType = {
         }
         return {
           inputs: [],
-          outputs: [
-            makeMaterial<Board>({ ...inputBoard, jointedEdges: 1 }),
-          ],
+          outputs: [makeMaterial<Board>({ ...inputBoard, jointedEdges: 1 })],
         };
       },
     },

--- a/src/game/tools/sanding-operations.test.ts
+++ b/src/game/tools/sanding-operations.test.ts
@@ -39,8 +39,12 @@ describe("sanding operations", () => {
 
   it("won't accept an already-sanded material", () => {
     const requirement = blockSandBoard.inputMaterials[0];
-    assert.ok(!materialMeetsInput(board("pallet", 3, 4, 1, "sanded"), requirement));
-    assert.ok(materialMeetsInput(board("pallet", 3, 4, 1, "rough"), requirement));
+    assert.ok(
+      !materialMeetsInput(board("pallet", 3, 4, 1, "sanded"), requirement),
+    );
+    assert.ok(
+      materialMeetsInput(board("pallet", 3, 4, 1, "rough"), requirement),
+    );
   });
 
   it("sands panels and preserves their strips", () => {

--- a/src/game/tools/sanding-operations.ts
+++ b/src/game/tools/sanding-operations.ts
@@ -1,10 +1,5 @@
 import { MachineOperation } from "../Machine";
-import {
-  Board,
-  improvedSurface,
-  MaterialInstance,
-  Panel,
-} from "../Materials";
+import { Board, improvedSurface, MaterialInstance, Panel } from "../Materials";
 import { isBoard } from "../board-helpers";
 import { isPanel } from "../panel-helpers";
 import { makeMaterial } from "../material-helpers";

--- a/src/game/tools/straightLineSled.ts
+++ b/src/game/tools/straightLineSled.ts
@@ -24,9 +24,7 @@ export const straightLineSled: ToolType = {
       name: "Straight-Line Rip",
       requiredSkill: "jigsAndFixtures",
       duration: 18,
-      inputMaterials: [
-        { type: ["board"], jointedEdges: [0], quantity: 1 },
-      ],
+      inputMaterials: [{ type: ["board"], jointedEdges: [0], quantity: 1 }],
       output: (materials: ReadonlyArray<MaterialInstance>) => {
         const inputBoard = materials[0];
         if (!isBoard(inputBoard)) {
@@ -34,9 +32,7 @@ export const straightLineSled: ToolType = {
         }
         return {
           inputs: [],
-          outputs: [
-            makeMaterial<Board>({ ...inputBoard, jointedEdges: 1 }),
-          ],
+          outputs: [makeMaterial<Board>({ ...inputBoard, jointedEdges: 1 })],
         };
       },
     },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,6 +21,6 @@ loadAssets().then(() => {
 // Live reload
 addEventListener("load", () => {
   new EventSource("/esbuild").addEventListener("change", () =>
-    location.reload()
+    location.reload(),
   );
 });

--- a/src/pixi-react.d.ts
+++ b/src/pixi-react.d.ts
@@ -1,5 +1,11 @@
 // Type declarations for @pixi/react v8 components
-import type { Container, Graphics, Sprite, TilingSprite, Texture } from "pixi.js";
+import type {
+  Container,
+  Graphics,
+  Sprite,
+  TilingSprite,
+  Texture,
+} from "pixi.js";
 
 type PixiProps<T> = Partial<T> & {
   x?: number;

--- a/src/utils/sfx.ts
+++ b/src/utils/sfx.ts
@@ -15,7 +15,11 @@ import { getAudioContext } from "./getAudioContext";
  */
 
 export type UiSoundName =
-  "ui-click" | "ui-hover" | "ui-tab" | "ui-purchase" | "ui-back";
+  | "ui-click"
+  | "ui-hover"
+  | "ui-tab"
+  | "ui-purchase"
+  | "ui-back";
 
 // Per-sound gain. Hover is deliberately subtle so it doesn't fatigue.
 const SOUND_GAIN: Record<UiSoundName, number> = {


### PR DESCRIPTION
Replaces the free-selling sales table with a priced-listing marketplace
and adds a generated job board alongside the authored commission
sequence. Covers what stays, what goes, the sale-probability model,
job generation and tip decay, reputation economy, data model, and
build order.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015t4kMy8EpdgvW7LR4DDz1G