### PR TITLE
Convert the shop grid to 1-ft cells with box-based collision

### DIFF
--- a/docs/carrying-machines.md
+++ b/docs/carrying-machines.md
@@ -45,7 +45,7 @@ machine riding over the player's shoulders.
 ## Weight
 
 `carryMoveBusyTicks`: benchtop machines carry at full walking speed;
-floor machines and worktables weigh `1 + cellsOccupied.length`
+floor machines and worktables weigh `1 + round(footprint sq ft / 4)`
 tick-equivalents, which divide walking speed in `playerWalkSpeed` (same
 penalty pool as deep sawdust and the vac drag — see
 docs/continuous-movement.md), so rearranging heavy benches costs real
@@ -53,8 +53,10 @@ shop time.
 
 ## Crates
 
-Machines enter the world as `GameState.machineCrates` — 1×1, walkable,
-drawn as stenciled boxes (`MachineCrateSprite`):
+Machines enter the world as `GameState.machineCrates` — anchored to one
+cell (drawn bigger than the 1-ft tile, and grabbable from any
+neighboring cell), walkable, drawn as stenciled boxes
+(`MachineCrateSprite`):
 
 - **Store purchases** (`buyMachineAction`) land on the open floor nearest
   the shop entrance (`ShopInfo.entrancePosition`, marked by the

--- a/docs/continuous-movement.md
+++ b/docs/continuous-movement.md
@@ -39,27 +39,33 @@ snaps to that cell's center. This is what keeps the Playwright specs'
 
 ## Collision
 
-Axis-separated circle-vs-box (`stepPlayerMotion`): each axis integrates
-independently and clamps the body's leading edge against blocked cells
-(machine footprints and anything off the floor — crates and piles don't
+Axis-separated body-vs-box (`stepPlayerMotion`): each axis integrates
+independently and clamps the body's leading edge against the shop walls
+and a flat list of world-space solid boxes (crates and piles don't
 block, same as before). Diagonal input into a machine slides along its
-face. Each axis sweeps every cell boundary it crosses, so a dropped frame
-can't tunnel through a machine. All pure and unit-tested
-(`player-motion.test.ts`).
+face. The clamp compares the start and end of the whole step, so a
+dropped frame can't tunnel through a machine, and a box the body already
+overlaps (a fixture teleport, a machine set down over the body's margin)
+never clamps — the body can always walk out, just never press deeper in.
+All pure and unit-tested (`player-motion.test.ts`).
 
-Machines that don't visually fill their tile don't block their whole tile
-either: `MachineType.collisionBox` is an AABB in the machine's local frame
-(rotated with the placement), and `machine-collision.ts` clips it to each
-occupied cell as per-edge insets the sweep collides against. Boxes for
-image-based machines are measured from their sprite art by
-`npm run generate:collision-boxes` (committed as
+The solids come from `machine-collision.ts` (`shopSolids`): each machine
+contributes its `MachineType.collisionBox` — an AABB in the machine's
+local frame, rotated with the placement — or, when it has none, one full
+box per occupied tile. Boxes for image-based machines are measured from
+their sprite art by `npm run generate:collision-boxes` (committed as
 `machine-collision-boxes.generated.ts`; re-run after art changes);
-procedurally drawn machines set theirs by hand. Insets are capped at
-`MAX_COLLISION_INSET` (0.25), strictly below the 0.3 body radius, so the
-player's *center* can never enter an occupied cell — the cell-underfoot
-bookkeeping below never sees the player standing "in" a machine. Load the
-game with `?collision` in the URL to see the solid areas painted over the
-shop.
+procedurally drawn machines set theirs by hand.
+
+Cells are one square foot and the body radius is 0.8 cells (~10"), so
+the body spans several cells: a 2-cell gap is a walkable aisle, a 1-cell
+gap is not, and "standing at" a machine is a small zone of cells around
+its operation position (`Machine.operationZone`) rather than one exact
+cell. Machine collision boxes must reach within the body radius of their
+footprint's edges (enforced in `machine-collision.test.ts`) so the
+cell-underfoot bookkeeping below never sees the player standing "in" a
+machine. Load the game with `?collision` in the URL to see the solid
+boxes painted over the shop.
 
 ## Speed, not busy-ticks
 

--- a/scripts/generate-collision-boxes.ts
+++ b/scripts/generate-collision-boxes.ts
@@ -11,8 +11,8 @@ import { PNG } from "pngjs";
  *
  * The geometry mirrors how MachineSprite renders: every layer is anchored
  * at 0.5 on the origin cell's center, drawn at 8 image pixels per inch
- * (times an optional per-layer scale), and a cell is 32 inches — so one
- * cell is 256 image pixels and the mapping from opaque-pixel bounds to
+ * (times an optional per-layer scale), and a cell is 12 inches — so one
+ * cell is 96 image pixels and the mapping from opaque-pixel bounds to
  * cell units is pure arithmetic. Machines drawn procedurally (garbage can,
  * worktables) have nothing to measure; their boxes are hand-set in their
  * defs, which always win over this file.
@@ -27,8 +27,8 @@ const OUT_FILE = path.join(
   "machine-collision-boxes.generated.ts",
 );
 
-/** 8 image pixels per inch × 32 inches per cell. */
-const IMAGE_PIXELS_PER_CELL = 256;
+/** 8 image pixels per inch × 12 inches per cell. */
+const IMAGE_PIXELS_PER_CELL = 96;
 
 /** A pixel this opaque counts as solid — fringes and soft shadows don't. */
 const ALPHA_THRESHOLD = 128;

--- a/src/components/machine-sprites/GarbageCanSprite.tsx
+++ b/src/components/machine-sprites/GarbageCanSprite.tsx
@@ -9,12 +9,14 @@ export const GarbageCanSprite: React.FC<{ machine: Machine }> = ({
 }) => {
   const { inputMaterials, processingMaterials, outputMaterials } = machine;
 
+  // The can is centered on its 2×2-ft footprint, whose center sits half a
+  // cell past the origin cell's center.
   return (
-    <pixiContainer>
+    <pixiContainer x={PIXELS_PER_CELL * 0.5} y={PIXELS_PER_CELL * 0.5}>
       <pixiGraphics
         draw={useCallback((g: Graphics) => {
           g.clear();
-          const radius = (PIXELS_PER_CELL * 0.7) / 2;
+          const radius = PIXELS_PER_CELL * 0.93;
 
           // Drop shadow offset toward the lower right
           g.circle(radius * 0.08, radius * 0.1, radius);

--- a/src/components/machine-sprites/StorageRackSprite.tsx
+++ b/src/components/machine-sprites/StorageRackSprite.tsx
@@ -35,7 +35,7 @@ export const StorageRackSprite: React.FC<{ machine: Machine }> = ({
   const draw = useCallback(
     (g: Graphics) => {
       g.clear();
-      const half = PIXELS_PER_CELL * 0.42;
+      const half = PIXELS_PER_CELL * 0.94;
       const size = half * 2;
       const rng = seededRandom("storage-rack");
 
@@ -44,7 +44,7 @@ export const StorageRackSprite: React.FC<{ machine: Machine }> = ({
       g.fill({ color: 0x000000, alpha: 0.18 });
 
       // Corner posts peeking out from under the deck
-      const post = PIXELS_PER_CELL * 0.14;
+      const post = PIXELS_PER_CELL * 0.31;
       for (const [px, py] of [
         [-half + 1, -half + 1],
         [half - post - 1, -half + 1],
@@ -94,5 +94,10 @@ export const StorageRackSprite: React.FC<{ machine: Machine }> = ({
     [stored],
   );
 
-  return <pixiGraphics draw={draw} />;
+  // Centered on the 2×2-ft footprint, half a cell past the origin center.
+  return (
+    <pixiContainer x={PIXELS_PER_CELL * 0.5} y={PIXELS_PER_CELL * 0.5}>
+      <pixiGraphics draw={draw} />
+    </pixiContainer>
+  );
 };

--- a/src/components/manual/articles/MarketplaceArticle.tsx
+++ b/src/components/manual/articles/MarketplaceArticle.tsx
@@ -43,11 +43,11 @@ export const MarketplaceArticle: React.FC = () => (
 
     <H>Scavenging</H>
     <P>
-      Walk to the garage door and it lists places to go, each with a number
-      key — including a scavenging run: leave the shop and come back with free
+      Walk to the garage door and it lists places to go, each with a number key
+      — including a scavenging run: leave the shop and come back with free
       pallets. The shop keeps running while you're out — glue keeps curing and
-      machines finish their passes — but you can't do anything else until
-      you're back.
+      machines finish their passes — but you can't do anything else until you're
+      back.
     </P>
 
     <Note>

--- a/src/components/shop-overlay/DoorPrompt.tsx
+++ b/src/components/shop-overlay/DoorPrompt.tsx
@@ -36,8 +36,11 @@ export const DoorPrompt: React.FC<{
 }> = ({ canvasWidth, canvasHeight }) => {
   const gameState = useGameState();
   const applyAction = useApplyGameAction();
-  const { machine: targetedMachine, doorOpen, closeDoor } =
-    useTargetedMachine();
+  const {
+    machine: targetedMachine,
+    doorOpen,
+    closeDoor,
+  } = useTargetedMachine();
   const scale = useContext(OverlayScaleContext);
 
   const { storeUnlocked, lumberyardUnlocked, marketplaceUnlocked } =

--- a/src/components/shop-overlay/PlayerPrompt.tsx
+++ b/src/components/shop-overlay/PlayerPrompt.tsx
@@ -6,7 +6,7 @@ import { canVacuumAt } from "../../game/game-actions/shop-vac-actions";
 import { MACHINE_TYPES } from "../../game/Machine";
 import { canisterFillFraction, carryingShopVac } from "../../game/ShopVac";
 import { resolveInteract } from "../../game/interact";
-import { vectorEquals } from "../../game/Vectors";
+import { chebyshevDistance } from "../../game/Vectors";
 import { HintSurfaceContext, ShortcutKeys } from "../shortcuts/Kbd";
 import { useTargetedMachine } from "../TargetedMachineContext";
 import { useGameState } from "../useGameState";
@@ -31,11 +31,13 @@ export const PlayerPrompt: React.FC = () => {
   const draggingVac = carryingShopVac(gameState);
   const standingOnVac =
     gameState.shopVac?.position != null &&
-    vectorEquals(gameState.shopVac.position, gameState.player.position);
+    chebyshevDistance(gameState.shopVac.position, gameState.player.position) <=
+      1;
   const crateUnderfoot =
     gameState.progression.shopLayoutUnlocked && !carried
-      ? gameState.machineCrates.find((crate) =>
-          vectorEquals(crate.position, gameState.player.position),
+      ? gameState.machineCrates.find(
+          (crate) =>
+            chebyshevDistance(crate.position, gameState.player.position) <= 1,
         )
       : undefined;
 

--- a/src/components/shop-view/CollisionDebugLayer.tsx
+++ b/src/components/shop-view/CollisionDebugLayer.tsx
@@ -1,36 +1,33 @@
 import { Graphics } from "pixi.js";
 import React, { useCallback } from "react";
-import { useCellMap } from "../../game/CellMap";
-import { cellObstruction } from "../../game/machine-collision";
+import { getMachines } from "../../game/Machine";
+import { shopSolids } from "../../game/machine-collision";
+import { useGameState } from "../useGameState";
 import { PIXELS_PER_CELL } from "./shop-scale";
 
 /**
  * Dev overlay (load the game with `?collision`): paints the exact solid
- * area the movement sweep collides against in each blocked cell, so
- * generated and hand-set collision boxes can be checked by eye instead of
- * by walking into them.
+ * boxes the movement sweep collides against, so generated and hand-set
+ * collision boxes can be checked by eye instead of by walking into them.
  */
 export const CollisionDebugLayer: React.FC = () => {
-  const cellMap = useCellMap();
+  const gameState = useGameState();
 
   const draw = useCallback(
     (g: Graphics) => {
       g.clear();
-      for (const cell of cellMap.getCells()) {
-        const insets = cellObstruction(cell, cell.position);
-        if (insets === undefined) continue;
-        const [cx, cy] = cell.position;
-        const x = (cx + insets.left) * PIXELS_PER_CELL;
-        const y = (cy + insets.top) * PIXELS_PER_CELL;
-        const width = (1 - insets.left - insets.right) * PIXELS_PER_CELL;
-        const height = (1 - insets.top - insets.bottom) * PIXELS_PER_CELL;
+      for (const solid of shopSolids(getMachines(gameState.machines))) {
+        const x = solid.min[0] * PIXELS_PER_CELL;
+        const y = solid.min[1] * PIXELS_PER_CELL;
+        const width = (solid.max[0] - solid.min[0]) * PIXELS_PER_CELL;
+        const height = (solid.max[1] - solid.min[1]) * PIXELS_PER_CELL;
         g.rect(x, y, width, height);
         g.fill({ color: 0xef4444, alpha: 0.25 });
         g.rect(x, y, width, height);
         g.stroke({ width: 1.5, color: 0xef4444, alpha: 0.9 });
       }
     },
-    [cellMap],
+    [gameState.machines],
   );
 
   return <pixiGraphics draw={draw} />;

--- a/src/components/shop-view/EntranceSprite.tsx
+++ b/src/components/shop-view/EntranceSprite.tsx
@@ -1,12 +1,14 @@
 import { Graphics } from "pixi.js";
 import React, { useCallback } from "react";
+import { DOOR_HALF_WIDTH } from "../../game/ShopInfo";
 import { useGameState } from "../useGameState";
 import { PIXELS_PER_CELL, cellToPixelVec } from "./shop-scale";
 
 /**
- * The garage-door threshold along the entrance cell's outer edge — a faint
+ * The garage-door threshold along the entrance's outer edge — a faint
  * hazard-striped strip marking where deliveries land, so crates showing up
- * there read as "came in through the door".
+ * there read as "came in through the door". The strip spans the full door
+ * width (see DOOR_HALF_WIDTH), centered on the entrance cell.
  */
 export const EntranceSprite: React.FC = () => {
   const gameState = useGameState();
@@ -15,10 +17,12 @@ export const EntranceSprite: React.FC = () => {
   const draw = useCallback((g: Graphics) => {
     g.clear();
     const stripHeight = 10;
+    const left = -DOOR_HALF_WIDTH * PIXELS_PER_CELL;
+    const width = (DOOR_HALF_WIDTH * 2 + 1) * PIXELS_PER_CELL;
     const top = PIXELS_PER_CELL - stripHeight;
-    g.rect(0, top, PIXELS_PER_CELL, stripHeight);
+    g.rect(left, top, width, stripHeight);
     g.fill({ color: 0x2b2b2b, alpha: 0.5 });
-    for (let sx = -stripHeight; sx < PIXELS_PER_CELL; sx += 16) {
+    for (let sx = left - stripHeight; sx < left + width; sx += 16) {
       g.moveTo(sx, PIXELS_PER_CELL);
       g.lineTo(sx + stripHeight, top);
       g.stroke({ width: 5, color: 0xd9a441, alpha: 0.5 });

--- a/src/components/shop-view/MachineCrateSprite.tsx
+++ b/src/components/shop-view/MachineCrateSprite.tsx
@@ -15,7 +15,9 @@ export const MachineCrateSprite: React.FC<{ crate: MachineCrate }> = ({
 
   const draw = useCallback((g: Graphics) => {
     g.clear();
-    const half = PIXELS_PER_CELL * 0.34;
+    // A real crate is bigger than the 1-ft cell it anchors to — it
+    // overhangs its cell visually but never blocks walking.
+    const half = PIXELS_PER_CELL * 0.9;
 
     // The lid
     g.rect(-half, -half, half * 2, half * 2);

--- a/src/components/shop-view/MachineSprite.tsx
+++ b/src/components/shop-view/MachineSprite.tsx
@@ -135,7 +135,7 @@ const OperationStatusBadge: React.FC<{ machine: Machine }> = ({ machine }) => {
       if (!isOperating || relevantPhase === undefined) {
         return;
       }
-      const y = -PIXELS_PER_CELL * 0.68;
+      const y = -PIXELS_PER_CELL * 1.8;
       if (needsYou) {
         // Amber pause marker: this machine is waiting for the player
         g.circle(0, y, 7);
@@ -149,7 +149,7 @@ const OperationStatusBadge: React.FC<{ machine: Machine }> = ({ machine }) => {
         return;
       }
       // Progress bar: amber while attended handwork, green while hands-free
-      const barWidth = PIXELS_PER_CELL * 0.7;
+      const barWidth = PIXELS_PER_CELL * 1.87;
       g.rect(-barWidth / 2 - 1, y - 3, barWidth + 2, 6);
       g.fill({ color: 0x1c1917, alpha: 0.75 });
       g.rect(-barWidth / 2, y - 2, barWidth * fraction, 4);
@@ -280,8 +280,8 @@ const LocalMachineSprite: React.FC<{ machine: Machine }> = ({ machine }) => {
 const DustBagSprite: React.FC = () => {
   const draw = useCallback((g: Graphics) => {
     g.clear();
-    const x = PIXELS_PER_CELL * 0.32;
-    const y = PIXELS_PER_CELL * 0.3;
+    const x = PIXELS_PER_CELL * 0.85;
+    const y = PIXELS_PER_CELL * 0.8;
     // The bag: a soft sack, slightly slumped
     g.ellipse(x, y, 12, 14);
     g.fill(0xcbb489);

--- a/src/components/shop-view/PlayerMotionLayer.tsx
+++ b/src/components/shop-view/PlayerMotionLayer.tsx
@@ -1,8 +1,8 @@
 import { useTick } from "@pixi/react";
 import { Ticker } from "pixi.js";
 import React, { useEffect, useRef } from "react";
-import { CellMap } from "../../game/CellMap";
-import { cellObstruction } from "../../game/machine-collision";
+import { getMachines } from "../../game/Machine";
+import { shopSolids } from "../../game/machine-collision";
 import { setPlayerPositionAction } from "../../game/game-actions/player-actions";
 import {
   directionFromInput,
@@ -82,16 +82,12 @@ export const PlayerMotionLayer: React.FC<{ paused: boolean }> = ({
 
     // Clamp dt so a hitch (tab switch, GC pause) can't fling the body.
     const dt = Math.min(ticker.deltaMS / 1000, 0.1);
-    const cellMap = CellMap.fromGameState(gs);
-    const obstructionAt = (cell: Vector) =>
-      cellObstruction(cellMap.at(cell), cell);
-
     const next = stepPlayerMotion(
       playerMotion.pos,
       input,
       playerWalkSpeed(gs),
       dt,
-      obstructionAt,
+      { size: gs.shopInfo.size, solids: shopSolids(getMachines(gs.machines)) },
     );
     playerMotion.moving =
       next[0] !== playerMotion.pos[0] || next[1] !== playerMotion.pos[1];

--- a/src/components/shop-view/ShopKeyboardShortcuts.tsx
+++ b/src/components/shop-view/ShopKeyboardShortcuts.tsx
@@ -23,7 +23,7 @@ import {
   addWorkItemAction,
   clearWorkQueueAction,
 } from "../../game/game-actions/work-item-actions";
-import { vectorEquals } from "../../game/Vectors";
+import { chebyshevDistance } from "../../game/Vectors";
 import { resolveInteract } from "../../game/interact";
 import {
   machineCanOperate,
@@ -99,8 +99,8 @@ export const ShopKeyboardShortcuts: React.FC = () => {
       if (gs.player.carriedMachine) {
         return applyAction(putDownCarriedMachineAction());
       }
-      const crateUnderfoot = gs.machineCrates.some((crate) =>
-        vectorEquals(crate.position, gs.player.position),
+      const crateUnderfoot = gs.machineCrates.some(
+        (crate) => chebyshevDistance(crate.position, gs.player.position) <= 1,
       );
       if (crateUnderfoot) {
         return applyAction(pickUpCrateAction());

--- a/src/components/shop-view/ShopVacSprite.tsx
+++ b/src/components/shop-view/ShopVacSprite.tsx
@@ -44,10 +44,10 @@ export const ShopVacSprite: React.FC = () => {
     if (carried) {
       const targetX =
         playerCenter[0] -
-        Math.cos(playerMotion.heading) * PIXELS_PER_CELL * 0.55;
+        Math.cos(playerMotion.heading) * PIXELS_PER_CELL * 1.47;
       const targetY =
         playerCenter[1] -
-        Math.sin(playerMotion.heading) * PIXELS_PER_CELL * 0.55;
+        Math.sin(playerMotion.heading) * PIXELS_PER_CELL * 1.47;
       const dt = ticker.deltaMS / 1000;
       const ease = Math.min(1, dt * FOLLOW_RATE);
       const previous = dragPos.current ?? [targetX, targetY];
@@ -59,7 +59,7 @@ export const ShopVacSprite: React.FC = () => {
       [x, y] = cellToPixelCenter(vac.position!);
     }
 
-    const radius = PIXELS_PER_CELL * 0.21;
+    const radius = PIXELS_PER_CELL * 0.56;
     // Shadow, casters
     g.ellipse(x, y + radius * 0.45, radius * 1.15, radius * 0.55);
     g.fill({ color: 0x000000, alpha: 0.22 });

--- a/src/components/shop-view/ShopView.tsx
+++ b/src/components/shop-view/ShopView.tsx
@@ -44,7 +44,10 @@ const RendererSize: React.FC<{ width: number; height: number }> = ({
 }) => {
   const { app } = useApplication();
   useEffect(() => {
-    if (app?.renderer && (app.renderer.width !== width || app.renderer.height !== height)) {
+    if (
+      app?.renderer &&
+      (app.renderer.width !== width || app.renderer.height !== height)
+    ) {
       app.renderer.resize(width, height);
     }
   }, [app, width, height]);
@@ -141,72 +144,75 @@ export const ShopView: React.FC = () => {
           >
             <RendererSize width={scaledWidth} height={scaledHeight} />
             <pixiContainer scale={scale}>
-          <pixiTilingSprite
-            eventMode="static"
-            texture={floorTexture}
-            tilePosition={{ x: 0, y: 0 }}
-            tileScale={{ x: 0.25, y: 0.25 }}
-            width={width}
-            height={height}
-          />
-          {cellMap.getCells().map((cell) => (
-            <FloorTileSprite
-              cell={cell}
-              key={`cell-${cell.position.join(",")}`}
-            />
-          ))}
-          <EntranceSprite />
-          {/* Settled sawdust sits on the floor, under everything that moves */}
-          <DustLayer width={width} height={height} />
-          {gameState.progression.sweepingUnlocked && <BroomSprite />}
-
-          {gameState.machineCrates.map((crate, index) => (
-            <MachineCrateSprite
-              crate={crate}
-              key={`crate-${index}-${crate.position.join(",")}`}
-            />
-          ))}
-
-          {materialPileGroups.map((materialPiles, i) => {
-            const [x, y] = cellToPixelVec(materialPiles[0].position);
-            return (
-              <pixiContainer
-                key={`pile${materialPiles[0].position.join(",")}`}
-                x={x}
-                y={y}
-              >
-                <MaterialPilesSprite materialPiles={materialPiles} />
-              </pixiContainer>
-            );
-          })}
-          {[...machines]
-            // Worktables draw first so mounted benchtop machines sit on top
-            .sort(
-              (a, b) =>
-                Number(b.type.worktable ?? false) -
-                Number(a.type.worktable ?? false),
-            )
-            .map((machinePlacement) => (
-              <MachineSprite
-                key={
-                  machinePlacement.type.id + machinePlacement.position.join(",")
-                }
-                machine={machinePlacement}
-                isSelected={
-                  !gameState.player.away &&
-                  gameState.player.carriedMachine == null &&
-                  isTargeted(machinePlacement)
-                }
-                onClick={machineClickHandler(machinePlacement)}
+              <pixiTilingSprite
+                eventMode="static"
+                texture={floorTexture}
+                tilePosition={{ x: 0, y: 0 }}
+                tileScale={{ x: 0.25, y: 0.25 }}
+                width={width}
+                height={height}
               />
-            ))}
-          {collisionDebugRequested() && <CollisionDebugLayer />}
-            <PlayerMotionLayer paused={ticksPerSecond === TICK_SPEED_PAUSED} />
-            <ShopVacSprite />
-            {!gameState.player.away && (
-              <PersonSprite person={gameState.player} />
-            )}
-            <CarriedMachineLayer />
+              {cellMap.getCells().map((cell) => (
+                <FloorTileSprite
+                  cell={cell}
+                  key={`cell-${cell.position.join(",")}`}
+                />
+              ))}
+              <EntranceSprite />
+              {/* Settled sawdust sits on the floor, under everything that moves */}
+              <DustLayer width={width} height={height} />
+              {gameState.progression.sweepingUnlocked && <BroomSprite />}
+
+              {gameState.machineCrates.map((crate, index) => (
+                <MachineCrateSprite
+                  crate={crate}
+                  key={`crate-${index}-${crate.position.join(",")}`}
+                />
+              ))}
+
+              {materialPileGroups.map((materialPiles, i) => {
+                const [x, y] = cellToPixelVec(materialPiles[0].position);
+                return (
+                  <pixiContainer
+                    key={`pile${materialPiles[0].position.join(",")}`}
+                    x={x}
+                    y={y}
+                  >
+                    <MaterialPilesSprite materialPiles={materialPiles} />
+                  </pixiContainer>
+                );
+              })}
+              {[...machines]
+                // Worktables draw first so mounted benchtop machines sit on top
+                .sort(
+                  (a, b) =>
+                    Number(b.type.worktable ?? false) -
+                    Number(a.type.worktable ?? false),
+                )
+                .map((machinePlacement) => (
+                  <MachineSprite
+                    key={
+                      machinePlacement.type.id +
+                      machinePlacement.position.join(",")
+                    }
+                    machine={machinePlacement}
+                    isSelected={
+                      !gameState.player.away &&
+                      gameState.player.carriedMachine == null &&
+                      isTargeted(machinePlacement)
+                    }
+                    onClick={machineClickHandler(machinePlacement)}
+                  />
+                ))}
+              {collisionDebugRequested() && <CollisionDebugLayer />}
+              <PlayerMotionLayer
+                paused={ticksPerSecond === TICK_SPEED_PAUSED}
+              />
+              <ShopVacSprite />
+              {!gameState.player.away && (
+                <PersonSprite person={gameState.player} />
+              )}
+              <CarriedMachineLayer />
             </pixiContainer>
           </gameStateContext.Provider>
         </Application>

--- a/src/components/shop-view/shop-scale.tsx
+++ b/src/components/shop-view/shop-scale.tsx
@@ -1,8 +1,8 @@
+import { INCHES_PER_CELL, INCHES_PER_FOOT } from "../../game/shop-scale";
 import { Vector } from "../../game/Vectors";
 
 export const PIXELS_PER_INCH = 4; // the main defining scale
-export const INCHES_PER_FOOT = 12;
-export const INCHES_PER_CELL = 32;
+export { INCHES_PER_CELL, INCHES_PER_FOOT };
 export const PIXELS_PER_CELL = INCHES_PER_CELL * PIXELS_PER_INCH;
 export const SPACING = 0;
 

--- a/src/components/store-page/BoardSelector.tsx
+++ b/src/components/store-page/BoardSelector.tsx
@@ -105,7 +105,11 @@ const LumberChannelSection: React.FC<{ channel: LumberChannel }> = ({
 
 /** A wooden upright between bays, running down past the rail to the floor. */
 const RackPost: React.FC = () => (
-  <li aria-hidden className="w-1.5 shrink-0 self-stretch" style={{ background: POST_BG }} />
+  <li
+    aria-hidden
+    className="w-1.5 shrink-0 self-stretch"
+    style={{ background: POST_BG }}
+  />
 );
 
 /**
@@ -204,7 +208,11 @@ const BoardForSale: React.FC<{
           )
         }
       >
-        <BoardFaceSvg vertical board={material} className="block h-full w-auto" />
+        <BoardFaceSvg
+          vertical
+          board={material}
+          className="block h-full w-auto"
+        />
         {/* The paper tag stapled near the board's foot */}
         <span className="absolute left-1/2 bottom-2 z-20 -translate-x-1/2 flex flex-col items-center rounded-[1px] border border-paper-manila-edge bg-paper-ivory px-0.5 py-px font-condensed leading-tight text-ink-black shadow-sm">
           <span className="text-[10px] uppercase whitespace-nowrap">

--- a/src/game/CellMap.ts
+++ b/src/game/CellMap.ts
@@ -142,20 +142,18 @@ export class CellMap {
       }
     }
 
-    if (machine.type.operationPosition !== undefined) {
-      const operationPosition = translateVec(
-        rotateVec(machine.type.operationPosition, machine.rotation),
-        machine.position,
-      );
-
-      if (this.has(operationPosition)) {
-        this._at(operationPosition)!.operableMachines.push(machine);
+    // A body is bigger than a 1-ft cell, so machines are operable from a
+    // small apron of cells around the operation position, not one exact
+    // cell — and outputs are collected from an apron around the outfeed.
+    for (const cell of machine.operationZone) {
+      if (this.has(cell)) {
+        this._at(cell)!.operableMachines.push(machine);
       }
     }
-
-    const outputPosition = machine.absoluteOutputPosition;
-    if (outputPosition !== null && this.has(outputPosition)) {
-      this._at(outputPosition)!.outputMachines.push(machine);
+    for (const cell of machine.outputZone) {
+      if (this.has(cell)) {
+        this._at(cell)!.outputMachines.push(machine);
+      }
     }
   }
 

--- a/src/game/Dust.test.ts
+++ b/src/game/Dust.test.ts
@@ -12,28 +12,28 @@ import {
   machineDustCells,
   machineDustMultiplier,
 } from "./Dust";
-import { Machine, MachineState } from "./Machine";
-import { Vector } from "./Vectors";
+import { Machine } from "./Machine";
+import { rotateVec, translateVec, Vector } from "./Vectors";
 
 const SHOP: Vector = [4, 6];
 
+/**
+ * A synthetic single-cell machine with its operator cell in front — the
+ * dust helpers only read the footprint, rotation, and operation position,
+ * so a fake keeps these tests independent of any real machine's footprint.
+ */
 function planerAt(position: Vector, rotation: 0 | 1 | 2 | 3 = 0): Machine {
-  const state: MachineState = {
-    machineTypeId: "lunchboxPlaner",
+  const operationPosition: Vector = [0, 1];
+  return {
+    type: { cellsOccupied: [[0, 0]], operationPosition },
     position,
     rotation,
-    selectedOperationId: "plane",
-    operationProgress: {
-      status: "notStarted",
-      phaseIndex: 0,
-      ticksRemaining: 0,
+    localToShop: (local: Vector) =>
+      translateVec(rotateVec(local, rotation), position),
+    get absoluteOperationPosition(): Vector {
+      return translateVec(rotateVec(operationPosition, rotation), position);
     },
-    inputMaterials: [],
-    processingMaterials: [],
-    outputMaterials: [],
-    tools: [],
-  };
-  return new Machine(state);
+  } as unknown as Machine;
 }
 
 describe("dust keys", () => {
@@ -199,7 +199,10 @@ describe("machineDustMultiplier", () => {
         [1, 3],
         [2, 1],
         [2, 2],
-      ].map((cell) => [dustKey(cell as [number, number]), { pine: 100 }]),
+      ].map((cell) => [
+        dustKey(cell as [number, number]),
+        { pine: DUST_MAX_PER_CELL },
+      ]),
     );
     assert.strictEqual(
       machineDustMultiplier(buried, planerAt([1, 1]), SHOP),
@@ -207,7 +210,11 @@ describe("machineDustMultiplier", () => {
     );
     // One buried cell out of eight averages inside the dead zone
     assert.strictEqual(
-      machineDustMultiplier({ "1,1": { pine: 100 } }, planerAt([1, 1]), SHOP),
+      machineDustMultiplier(
+        { "1,1": { pine: DUST_MAX_PER_CELL } },
+        planerAt([1, 1]),
+        SHOP,
+      ),
       1,
     );
   });

--- a/src/game/Dust.ts
+++ b/src/game/Dust.ts
@@ -12,8 +12,14 @@ export type SpeciesAmounts = Readonly<Partial<Record<Species, number>>>;
 /** Per-cell sawdust, keyed "x,y". Sparse: a missing key is a clean cell. */
 export type DustMap = Readonly<Record<string, SpeciesAmounts>>;
 
-/** A cell holds this much dust, total across species, before it spills. */
-export const DUST_MAX_PER_CELL = 100;
+/** A cell holds this much dust, total across species, before it spills.
+ * Cells are one square foot, so this is about a seventh of what the old
+ * 32-inch tiles held — same depth of sawdust, less floor per cell. */
+export const DUST_MAX_PER_CELL = 15;
+
+/** How much sawdust one swept-up floor pile holds — several cells' worth,
+ * a real knee-high pile rather than one square foot's dusting. */
+export const SAWDUST_PILE_CAPACITY = 100;
 
 /**
  * Share of an emission that lands on the machine's own cells (and its

--- a/src/game/Machine.ts
+++ b/src/game/Machine.ts
@@ -4,7 +4,13 @@ import { MaterialInstance } from "./Materials";
 import { SkillId } from "./Skill";
 import { TOOL_TYPES, ToolId } from "./Tool";
 import { UPGRADE_TYPES, UpgradeId } from "./Upgrade";
-import { Direction, rotateVec, translateVec, Vector } from "./Vectors";
+import {
+  Direction,
+  rotateVec,
+  translateVec,
+  Vector,
+  vectorEquals,
+} from "./Vectors";
 import { garbageCan } from "./machines/garbageCan";
 import { jobsiteTableSaw } from "./machines/jobsiteTableSaw";
 import { jointer } from "./machines/jointer";
@@ -330,6 +336,26 @@ export interface MachineState {
 }
 
 /**
+ * A cell plus its eight neighbors, minus the given footprint cells.
+ * Empty when the anchor is null (machines with no operation position).
+ */
+function zoneAround(anchor: Vector | null, excluded: Vector[]): Vector[] {
+  if (anchor === null) {
+    return [];
+  }
+  const zone: Vector[] = [];
+  for (let dy = -1; dy <= 1; dy++) {
+    for (let dx = -1; dx <= 1; dx++) {
+      const cell: Vector = [anchor[0] + dx, anchor[1] + dy];
+      if (!excluded.some((occupied) => vectorEquals(occupied, cell))) {
+        zone.push(cell);
+      }
+    }
+  }
+  return zone;
+}
+
+/**
  * Whether two machine states refer to the same placed machine. Position
  * alone isn't enough: a benchtop machine mounted on a worktable shares the
  * table's anchor cell, so identity is position plus type. (Two machines of
@@ -389,7 +415,9 @@ export class Machine {
    * station whose recipes are all still locked, or "none").
    */
   get selectedOperationOrNull():
-    MachineOperation | ParameterizedOperation | null {
+    | MachineOperation
+    | ParameterizedOperation
+    | null {
     return (
       this.operations.find((op) => op.id === this.state.selectedOperationId) ??
       null
@@ -407,6 +435,26 @@ export class Machine {
   /** Convert a machine-local cell offset into a shop cell. */
   localToShop(local: Vector): Vector {
     return translateVec(rotateVec(local, this.rotation), this.position);
+  }
+
+  /** The shop cells this machine's footprint occupies. */
+  get occupiedCells(): Vector[] {
+    return this.type.cellsOccupied.map((cell) => this.localToShop(cell));
+  }
+
+  /**
+   * The cells that count as standing at this machine to work it. A body
+   * is wider than one 1-ft cell, so the operator "cell" is really the
+   * canonical operation position plus its eight neighbors (minus the
+   * machine's own footprint) — a small apron in front of the machine.
+   */
+  get operationZone(): Vector[] {
+    return zoneAround(this.absoluteOperationPosition, this.occupiedCells);
+  }
+
+  /** Same apron, around the outfeed cell — where outputs are collected. */
+  get outputZone(): Vector[] {
+    return zoneAround(this.absoluteOutputPosition, this.occupiedCells);
   }
 
   /** The shop cell the player stands in to work this machine, or null. */

--- a/src/game/ShopInfo.ts
+++ b/src/game/ShopInfo.ts
@@ -5,9 +5,14 @@ export interface ShopInfo {
   electricity: 120 | 240;
   size: Vector;
   materialDropoffPosition: Vector;
-  /** Where deliveries land: machine crates spawn on the nearest open floor. */
+  /** Center cell of the garage door: where deliveries land (machine
+   * crates spawn on the nearest open floor) and the middle of the door
+   * strip along the bottom wall. */
   entrancePosition: Vector;
 }
+
+/** Half-width of the garage door strip, in cells — a 7-ft door. */
+export const DOOR_HALF_WIDTH = 3;
 
 /** The garage door sits at the bottom edge, middle of the wall. */
 export function defaultEntrancePosition(size: Vector): Vector {
@@ -15,11 +20,15 @@ export function defaultEntrancePosition(size: Vector): Vector {
 }
 
 /**
- * Whether a cell counts as "at the garage door" — the entrance cell or any
- * cell touching it. Standing here surfaces the places you can walk out to
- * (the door panel, and the door verbs on the action bar).
+ * Whether a cell counts as "at the garage door" — anywhere along the
+ * door strip, up to a cell in from the wall. Standing here surfaces the
+ * places you can walk out to (the door panel, and the door verbs on the
+ * action bar).
  */
 export function isAtShopDoor(shopInfo: ShopInfo, position: Vector): boolean {
   const [ex, ey] = shopInfo.entrancePosition;
-  return Math.abs(position[0] - ex) <= 1 && Math.abs(position[1] - ey) <= 1;
+  return (
+    Math.abs(position[0] - ex) <= DOOR_HALF_WIDTH &&
+    Math.abs(position[1] - ey) <= 1
+  );
 }

--- a/src/game/Vectors.ts
+++ b/src/game/Vectors.ts
@@ -44,6 +44,11 @@ export function vectorEquals(a: Vector, b: Vector): boolean {
   return a[0] === b[0] && a[1] === b[1];
 }
 
+/** Chessboard distance in cells — 0 is the same cell, 1 is any neighbor. */
+export function chebyshevDistance(a: Vector, b: Vector): number {
+  return Math.max(Math.abs(a[0] - b[0]), Math.abs(a[1] - b[1]));
+}
+
 export function localToGlobal(
   origin: Vector,
   local: Vector,

--- a/src/game/game-actions/dust-actions.test.ts
+++ b/src/game/game-actions/dust-actions.test.ts
@@ -8,15 +8,15 @@ import { makeMaterial } from "../material-helpers";
 import { sweepAction } from "./dust-actions";
 
 /**
- * Player mid-shop at [1,1] facing +x (direction 0), sweeping unlocked.
- * The default shop's machines sit at [1,2] (workspace) and [0,5]
- * (garbage), so [1,1] has the workspace as an orthogonal neighbor.
+ * Player mid-shop on open floor at [6,8] facing +x (direction 0), with
+ * sweeping unlocked. The default shop's workspace occupies [1..3, 1..2]
+ * and the garbage can [0..1, 13..14], both well outside the swept 3×3.
  */
 function sweepingState(overrides: Partial<GameState> = {}): GameState {
   return {
     ...initialGameState,
     progression: { ...initialGameState.progression, sweepingUnlocked: true },
-    player: { ...initialGameState.player, position: [1, 1], direction: 0 },
+    player: { ...initialGameState.player, position: [6, 8], direction: 0 },
     ...overrides,
   };
 }
@@ -24,23 +24,23 @@ function sweepingState(overrides: Partial<GameState> = {}): GameState {
 describe("sweepAction", () => {
   it("does nothing before sweeping is unlocked", () => {
     const state = {
-      ...sweepingState({ dust: { "1,1": { walnut: 50 } } }),
+      ...sweepingState({ dust: { "6,8": { walnut: 50 } } }),
       progression: initialGameState.progression,
     };
     assert.strictEqual(sweepAction()(state), state);
   });
 
-  it("pushes most of the cell's dust into a pile on the facing cell", () => {
+  it("pushes most of the patch's dust into a pile on the facing cell", () => {
     const result = sweepAction()(
-      sweepingState({ dust: { "1,1": { walnut: 50 } } }),
+      sweepingState({ dust: { "6,8": { walnut: 50 } } }),
     );
     // 90% gathered, 10% film stays behind
-    assert.ok(Math.abs((result.dust["1,1"]?.walnut ?? 0) - 5) < 1e-9);
+    assert.ok(Math.abs((result.dust["6,8"]?.walnut ?? 0) - 5) < 1e-9);
     const pile = result.materialPiles.find(
       (pile) => pile.material.type === "sawdustPile",
     );
     assert.ok(pile);
-    assert.deepStrictEqual(pile.position, [2, 1]);
+    assert.deepStrictEqual(pile.position, [7, 8]);
     assert.ok(
       pile.material.type === "sawdustPile" &&
         Math.abs((pile.material.contents.walnut ?? 0) - 45) < 1e-9,
@@ -55,12 +55,16 @@ describe("sweepAction", () => {
     );
   });
 
-  it("pulls dust out from under adjacent machines at a reduced rate", () => {
-    // The workspace occupies [1,2], orthogonal to the player at [1,1]
+  it("pulls dust out from under machines in reach at a reduced rate", () => {
+    // The workspace occupies [2,2]; standing at [2,4] puts it just out of
+    // reach, [2,3] within the swept 3×3.
     const result = sweepAction()(
-      sweepingState({ dust: { "1,2": { pine: 20 } } }),
+      sweepingState({
+        dust: { "2,2": { pine: 20 } },
+        player: { ...initialGameState.player, position: [2, 3], direction: 0 },
+      }),
     );
-    assert.ok(Math.abs((result.dust["1,2"]?.pine ?? 0) - 10) < 1e-9);
+    assert.ok(Math.abs((result.dust["2,2"]?.pine ?? 0) - 10) < 1e-9);
     const pile = result.materialPiles.find(
       (pile) => pile.material.type === "sawdustPile",
     );
@@ -78,8 +82,8 @@ describe("sweepAction", () => {
     });
     const result = sweepAction()(
       sweepingState({
-        dust: { "1,1": { walnut: 50 } },
-        materialPiles: [{ material: existing, position: [2, 1] }],
+        dust: { "6,8": { walnut: 50 } },
+        materialPiles: [{ material: existing, position: [7, 8] }],
       }),
     );
     // Only 10 units fit; the rest stays on the floor
@@ -88,18 +92,18 @@ describe("sweepAction", () => {
     );
     assert.ok(pile && pile.material.type === "sawdustPile");
     assert.ok(Math.abs(dustTotal(pile.material.contents) - 100) < 1e-9);
-    assert.ok(Math.abs((result.dust["1,1"]?.walnut ?? 0) - 40) < 1e-9);
+    assert.ok(Math.abs((result.dust["6,8"]?.walnut ?? 0) - 40) < 1e-9);
   });
 
   it("piles up underfoot when facing a machine", () => {
-    // Direction 3 faces +y — straight at the workspace on [1,2]
+    // Direction 1 faces -y — straight at the workspace cell [2,2]
     const result = sweepAction()(
       sweepingState({
-        dust: { "1,1": { walnut: 50 } },
+        dust: { "2,3": { walnut: 50 } },
         player: {
           ...initialGameState.player,
-          position: [1, 1],
-          direction: 3,
+          position: [2, 3],
+          direction: 1,
         },
       }),
     );
@@ -107,7 +111,7 @@ describe("sweepAction", () => {
       (pile) => pile.material.type === "sawdustPile",
     );
     assert.ok(pile);
-    assert.deepStrictEqual(pile.position, [1, 1]);
+    assert.deepStrictEqual(pile.position, [2, 3]);
   });
 
   it("is a free no-op on a clean floor", () => {
@@ -118,7 +122,7 @@ describe("sweepAction", () => {
 
   it("grants no XP for token sweeps", () => {
     const result = sweepAction()(
-      sweepingState({ dust: { "1,1": { walnut: 2 } } }),
+      sweepingState({ dust: { "6,8": { walnut: 2 } } }),
     );
     assert.strictEqual(result.progression.xp, initialGameState.progression.xp);
   });

--- a/src/game/game-actions/dust-actions.ts
+++ b/src/game/game-actions/dust-actions.ts
@@ -1,10 +1,10 @@
 import {
   cellDust,
-  DUST_MAX_PER_CELL,
   dustKey,
   DustMap,
   dustTotal,
   inBounds,
+  SAWDUST_PILE_CAPACITY,
   SpeciesAmounts,
 } from "../Dust";
 import { GameAction, MaterialPile } from "../GameState";
@@ -28,12 +28,14 @@ const SWEEP_XP = 1;
 const XP_MINIMUM_GATHERED = 5;
 
 /**
- * Sweep the cell underfoot: gather most of its dust — plus a slower pull
- * from under orthogonally-adjacent machines — into a sawdust pile on the
- * cell the player faces (or underfoot, when facing a machine or wall).
- * Piles hold one full cell's worth; whatever doesn't fit stays on the
- * floor. Sweeping is the only thing that runs during its SWEEP_TICKS —
- * the busyTicks plumbing in tickAction handles the wait.
+ * Sweep the floor at hand: one broom pass gathers most of the dust from
+ * the 3×3 patch around the player (cells are one square foot — a body
+ * and a broom cover several), with a slower pull from the machine cells
+ * in reach, into a sawdust pile on the cell the player faces (or
+ * underfoot, when facing a machine or wall). Piles hold
+ * SAWDUST_PILE_CAPACITY; whatever doesn't fit stays on the floor.
+ * Sweeping is the only thing that runs during its SWEEP_TICKS — the
+ * busyTicks plumbing in tickAction handles the wait.
  */
 export function sweepAction(): GameAction {
   return (gameState) => {
@@ -64,17 +66,18 @@ export function sweepAction(): GameAction {
       }
     };
 
-    gatherFrom(player.position, SWEEP_EFFICIENCY);
-    const orthogonals: ReadonlyArray<Vector> = [
-      [1, 0],
-      [-1, 0],
-      [0, 1],
-      [0, -1],
-    ];
-    for (const delta of orthogonals) {
-      const neighbor = translateVec(player.position, delta);
-      if (cellMap.at(neighbor)?.machine) {
-        gatherFrom(neighbor, UNDER_MACHINE_EFFICIENCY);
+    for (let dy = -1; dy <= 1; dy++) {
+      for (let dx = -1; dx <= 1; dx++) {
+        const cell = translateVec(player.position, [dx, dy]);
+        if (!inBounds(cell, shopSize)) {
+          continue;
+        }
+        gatherFrom(
+          cell,
+          cellMap.at(cell)?.machine
+            ? UNDER_MACHINE_EFFICIENCY
+            : SWEEP_EFFICIENCY,
+        );
       }
     }
 
@@ -100,7 +103,7 @@ export function sweepAction(): GameAction {
         : {};
 
     // Only what fits in the pile leaves the floor
-    const room = DUST_MAX_PER_CELL - dustTotal(existingContents);
+    const room = SAWDUST_PILE_CAPACITY - dustTotal(existingContents);
     const gatheredTotal = gathered.reduce(
       (sum, { amounts }) => sum + dustTotal(amounts),
       0,
@@ -165,5 +168,13 @@ export function canSweepAt(gameState: {
   dust: DustMap;
   player: { position: Vector };
 }): boolean {
-  return cellDust(gameState.dust, gameState.player.position) > CLEAN_EPSILON;
+  for (let dy = -1; dy <= 1; dy++) {
+    for (let dx = -1; dx <= 1; dx++) {
+      const cell = translateVec(gameState.player.position, [dx, dy]);
+      if (cellDust(gameState.dust, cell) > CLEAN_EPSILON) {
+        return true;
+      }
+    }
+  }
+  return false;
 }

--- a/src/game/game-actions/machine-actions.test.ts
+++ b/src/game/game-actions/machine-actions.test.ts
@@ -120,7 +120,7 @@ describe("putting the carried machine down", () => {
       machines: [],
       player: {
         ...initialGameState.player,
-        position: [2, 2],
+        position: [5, 5],
         direction: 0,
         carriedMachine: carried,
         ...playerOverrides,
@@ -128,14 +128,14 @@ describe("putting the carried machine down", () => {
     });
 
   it("anchors the machine so the player stands at its operator cell", () => {
-    // The miter saw's operator cell is [0, 1] machine-local; at rotation 0
-    // the anchor lands one cell above the player (y - 1).
+    // The miter saw's operator cell is [0, 2] machine-local; at rotation 0
+    // the anchor lands two cells above the player (y - 2).
     const result = putDownCarriedMachineAction()(
       carryingState(machineAt("miterSaw", [0, 0])),
     );
     assert.strictEqual(result.player.carriedMachine, null);
     assert.strictEqual(result.machines.length, 1);
-    assert.deepStrictEqual(result.machines[0].position, [2, 1]);
+    assert.deepStrictEqual(result.machines[0].position, [5, 3]);
   });
 
   it("rotating spins the landing spot around the player", () => {
@@ -144,8 +144,8 @@ describe("putting the carried machine down", () => {
     );
     assert.strictEqual(rotated.player.carriedMachine?.rotation, 1);
     const placement = carriedMachinePlacement(rotated);
-    // Operator offset [0,1] rotated once becomes [1,0]: anchor sits left
-    assert.deepStrictEqual(placement?.position, [1, 2]);
+    // Operator offset [0,2] rotated once becomes [2,0]: anchor sits left
+    assert.deepStrictEqual(placement?.position, [3, 5]);
   });
 
   it("machines without an operator cell land on the faced cell", () => {
@@ -153,11 +153,11 @@ describe("putting the carried machine down", () => {
       carryingState(machineAt("garbageCan", [0, 0])),
     );
     // Facing direction 0 is +x
-    assert.deepStrictEqual(result.machines[0].position, [3, 2]);
+    assert.deepStrictEqual(result.machines[0].position, [6, 5]);
   });
 
   it("refuses when the landing cells are blocked", () => {
-    const blocker = machineAt("garbageCan", [2, 1]);
+    const blocker = machineAt("garbageCan", [4, 2]);
     const state = {
       ...carryingState(machineAt("miterSaw", [0, 0])),
       machines: [blocker],
@@ -166,16 +166,17 @@ describe("putting the carried machine down", () => {
     assert.strictEqual(putDownCarriedMachineAction()(state), state);
   });
 
-  it("sets a benchtop machine down onto an empty worktable cell", () => {
-    // Worktable at [2,1] with its operator cell at [2,2] (the player's cell)
-    const table = machineAt("worktable1x1", [2, 1]);
+  it("sets a benchtop machine down onto free worktable cells", () => {
+    // A long worktable spanning [1..6, 2..3]: the saw's whole 3×2
+    // footprint lands on the tabletop with the player at its operator cell
+    const table = machineAt("worktable1x3", [1, 2]);
     const state = {
       ...carryingState(machineAt("miterSaw", [0, 0])),
       machines: [table],
     };
     const result = putDownCarriedMachineAction()(state);
     assert.strictEqual(result.machines.length, 2);
-    assert.deepStrictEqual(result.machines[1].position, [2, 1]);
+    assert.deepStrictEqual(result.machines[1].position, [5, 3]);
   });
 });
 
@@ -204,7 +205,10 @@ describe("deliverMachineCrate", () => {
   it("lands the crate on the open floor nearest the entrance", () => {
     const machine = freshMachineState("miterSaw", initialGameState.progression);
     const result = deliverMachineCrate(initialGameState, machine);
-    assert.deepStrictEqual(result.machineCrates[0].position, [2, 5]);
+    assert.deepStrictEqual(
+      result.machineCrates[0].position,
+      initialGameState.shopInfo.entrancePosition,
+    );
   });
 
   it("skips cells that already hold a crate", () => {

--- a/src/game/game-actions/machine-actions.ts
+++ b/src/game/game-actions/machine-actions.ts
@@ -8,6 +8,7 @@ import {
   MachineType,
 } from "../Machine";
 import {
+  chebyshevDistance,
   Direction,
   rotateVec,
   scaleVec,
@@ -220,10 +221,13 @@ export function deliverMachineCrate(
 /**
  * Per-step busy ticks while lugging a machine. Benchtop machines tuck
  * under an arm; floor machines and benches are a slow shuffle that gets
- * slower the bigger the footprint.
+ * slower the bigger the footprint (measured in square feet — cells are
+ * 1 sq ft each).
  */
 export function carryMoveBusyTicks(machineType: MachineType): number {
-  return machineType.benchtop ? 0 : 1 + machineType.cellsOccupied.length;
+  return machineType.benchtop
+    ? 0
+    : 1 + Math.max(1, Math.round(machineType.cellsOccupied.length / 4));
 }
 
 /** The player's hands are genuinely free: no machine, no boards, no vac. */
@@ -280,11 +284,13 @@ export function pickUpMachineAction(machineState: MachineState): GameAction {
   };
 }
 
-/** Unpacks the crate underfoot straight into the player's arms. */
+/** Unpacks the crate at hand (underfoot or a neighboring cell — the body
+ * is bigger than a 1-ft cell) straight into the player's arms. */
 export function pickUpCrateAction(): GameAction {
   return (gameState) => {
-    const crate = gameState.machineCrates.find((candidate) =>
-      vectorEquals(candidate.position, gameState.player.position),
+    const crate = gameState.machineCrates.find(
+      (candidate) =>
+        chebyshevDistance(candidate.position, gameState.player.position) <= 1,
     );
     if (!crate || !handsFree(gameState)) {
       console.warn("No crate underfoot, or hands are full");

--- a/src/game/game-actions/player-actions.test.ts
+++ b/src/game/game-actions/player-actions.test.ts
@@ -43,18 +43,19 @@ describe("pickUpMaterialAction", () => {
   });
 
   it("refuses cells the board does not reach", () => {
+    // An 8' board spans four cells past its anchor; [1, 8] is beyond it
     const pile: MaterialPile = {
       material: board("pine", 8, 4, 1),
       position: [1, 3],
     };
-    const result = pickUpMaterialAction([pile])(stateWithPile(pile, [1, 5]));
+    const result = pickUpMaterialAction([pile])(stateWithPile(pile, [1, 8]));
     assert.strictEqual(result.materialPiles.length, 1);
     assert.strictEqual(result.player.inventory.length, 0);
   });
 
-  it("keeps short stock a one-cell grab", () => {
+  it("keeps foot-long stock a one-cell grab", () => {
     const pile: MaterialPile = {
-      material: board("pine", 2, 4, 1),
+      material: board("pine", 1, 4, 1),
       position: [1, 3],
     };
     const result = pickUpMaterialAction([pile])(stateWithPile(pile, [1, 2]));

--- a/src/game/game-actions/shop-vac-actions.test.ts
+++ b/src/game/game-actions/shop-vac-actions.test.ts
@@ -119,11 +119,12 @@ describe("shopVacTickPass", () => {
   });
 
   it("dumps the canister next to the garbage can", () => {
-    // The garbage can sits at [0,5]; standing at [0,4] is adjacent
+    // The garbage can occupies [0..1, 13..14]; standing at [0,12] is
+    // adjacent to its top edge
     const result = shopVacTickPass()(
       draggingState({
         shopVac: { position: null, canister: { walnut: 123 } },
-        player: { ...initialGameState.player, position: [0, 4], direction: 0 },
+        player: { ...initialGameState.player, position: [0, 12], direction: 0 },
       }),
     );
     assert.deepStrictEqual(result.shopVac?.canister, {});

--- a/src/game/game-actions/shop-vac-actions.ts
+++ b/src/game/game-actions/shop-vac-actions.ts
@@ -9,11 +9,28 @@ import {
   VACUUM_TICKS,
 } from "../ShopVac";
 import { Species } from "../Materials";
-import { translateVec, Vector, vectorEquals } from "../Vectors";
+import {
+  chebyshevDistance,
+  translateVec,
+  Vector,
+  vectorEquals,
+} from "../Vectors";
 import { withXp } from "./skill-actions";
 
 /** Adjacent tiles get most of a burst — the hose reaches, the nozzle wins. */
 const VACUUM_ADJACENT_EFFICIENCY = 0.6;
+
+/** The eight cells around one — a burst covers the 3×3 patch at hand. */
+const NEIGHBORS: ReadonlyArray<Vector> = [
+  [1, 0],
+  [-1, 0],
+  [0, 1],
+  [0, -1],
+  [1, 1],
+  [1, -1],
+  [-1, 1],
+  [-1, -1],
+];
 /** Vacuuming this much or more earns the token XP (mirrors sweeping). */
 const XP_MINIMUM_GATHERED = 5;
 const VACUUM_XP = 1;
@@ -63,7 +80,7 @@ export function toggleCarryShopVacAction(): GameAction {
         shopVac: { ...vac, position: gameState.player.position },
       };
     }
-    if (vectorEquals(vac.position, gameState.player.position)) {
+    if (chebyshevDistance(vac.position, gameState.player.position) <= 1) {
       return { ...gameState, shopVac: { ...vac, position: null } };
     }
     return gameState;
@@ -101,7 +118,7 @@ export function vacuumAction(): GameAction {
     };
 
     gatherFrom(gameState.player.position, 1);
-    for (const delta of ORTHOGONALS) {
+    for (const delta of NEIGHBORS) {
       gatherFrom(
         translateVec(gameState.player.position, delta),
         VACUUM_ADJACENT_EFFICIENCY,
@@ -238,7 +255,7 @@ export function canVacuumAt(gameState: GameState): boolean {
   if (cellDust(gameState.dust, gameState.player.position) > 0.05) {
     return true;
   }
-  return ORTHOGONALS.some(
+  return NEIGHBORS.some(
     (delta) =>
       cellDust(gameState.dust, translateVec(gameState.player.position, delta)) >
       0.05,

--- a/src/game/game-actions/store-actions.test.ts
+++ b/src/game/game-actions/store-actions.test.ts
@@ -93,7 +93,10 @@ describe("buyMachineAction", () => {
       "jobsiteTableSaw",
     );
     // The entrance cell itself is open in the starting shop
-    assert.deepStrictEqual(result.machineCrates[0].position, [2, 5]);
+    assert.deepStrictEqual(
+      result.machineCrates[0].position,
+      initialGameState.shopInfo.entrancePosition,
+    );
   });
 
   it("does nothing when the player cannot afford it", () => {

--- a/src/game/game-actions/tickAction.test.ts
+++ b/src/game/game-actions/tickAction.test.ts
@@ -11,7 +11,7 @@ import { GLUE_CURE_TICKS } from "../machines/workspace";
 import { tickAction } from "./tickAction";
 
 /** The fixture workspace sits at [1,2] rotation 0 — its operation cell. */
-const WORKSPACE_OPERATION_CELL: [number, number] = [1, 3];
+const WORKSPACE_OPERATION_CELL: [number, number] = [1, 4];
 
 function workspaceMachine(overrides: Partial<MachineState>): MachineState {
   return {
@@ -340,9 +340,10 @@ describe("tickAction operation phases", () => {
 
 describe("tickAction dust emission", () => {
   /**
-   * A planer at [1,1] (operation cell [1,2]) mid-way through planing
-   * walnut. The 5"-wide board is exactly the cut-load reference, so the
-   * dust numbers below read straight off dustOutput.
+   * A planer at [1,1] (footprint [1..2, 0..2], operation cell [1,3])
+   * mid-way through planing walnut. The 5"-wide board is exactly the
+   * cut-load reference, so the dust numbers below read straight off
+   * dustOutput.
    */
   function planingStateWith(
     overrides: Partial<GameState> = {},
@@ -367,7 +368,7 @@ describe("tickAction dust emission", () => {
     };
     return stateWith({
       machines: [planer],
-      player: { ...initialGameState.player, position: [1, 2] },
+      player: { ...initialGameState.player, position: [1, 3] },
       ...overrides,
     });
   }
@@ -375,11 +376,12 @@ describe("tickAction dust emission", () => {
   it("lands species-tagged dust around the machine while it cuts", () => {
     const result = tickAction(planingStateWith());
     assert.strictEqual(result.machines[0].operationProgress.ticksRemaining, 4);
-    // The planer's dustOutput (4/tick): 70% split over the two core cells
-    // (machine + operation position), 30% over the six ring cells
-    assert.ok(Math.abs(cellDust(result.dust, [1, 1]) - 1.4) < 1e-9);
-    assert.ok(Math.abs(cellDust(result.dust, [1, 2]) - 1.4) < 1e-9);
-    assert.ok(Math.abs(cellDust(result.dust, [2, 1]) - 0.2) < 1e-9);
+    // The planer's dustOutput (4/tick): 70% split over the seven core
+    // cells (six footprint cells + operation position), 30% over the
+    // eleven ring cells
+    assert.ok(Math.abs(cellDust(result.dust, [1, 1]) - 0.4) < 1e-9);
+    assert.ok(Math.abs(cellDust(result.dust, [1, 3]) - 0.4) < 1e-9);
+    assert.ok(Math.abs(cellDust(result.dust, [0, 1]) - 1.2 / 11) < 1e-9);
     assert.ok((result.dust["1,1"].walnut ?? 0) > 0);
   });
 
@@ -402,7 +404,7 @@ describe("tickAction dust emission", () => {
     for (let i = 0; i < 5; i++) {
       state = tickAction(state);
     }
-    assert.ok(Math.abs(cellDust(state.dust, [1, 1]) - 7) < 1e-9);
+    assert.ok(Math.abs(cellDust(state.dust, [1, 1]) - 2) < 1e-9);
   });
 
   it("power feed keeps cutting (and shedding dust) with the player away", () => {
@@ -476,9 +478,9 @@ describe("tickAction dust emission", () => {
     };
     const result = tickAction(withBag);
     // Planer emits 4/tick bare; the bag captures 60%, so 1.6 lands —
-    // 70% split over the two core cells
-    assert.ok(Math.abs(cellDust(result.dust, [1, 1]) - 0.56) < 1e-9);
-    assert.ok(Math.abs(cellDust(result.dust, [2, 1]) - 0.08) < 1e-9);
+    // 70% split over the seven core cells, 30% over the eleven ring cells
+    assert.ok(Math.abs(cellDust(result.dust, [1, 1]) - 0.16) < 1e-9);
+    assert.ok(Math.abs(cellDust(result.dust, [0, 1]) - 0.48 / 11) < 1e-9);
   });
 
   it("unlocks sweeping once the floor crosses the dust threshold", () => {

--- a/src/game/initialGameState.tsx
+++ b/src/game/initialGameState.tsx
@@ -21,7 +21,7 @@ export const initialGameState: GameState = {
   materialPiles: [
     {
       material: makePallet(),
-      position: [2, 4], // Positioned for easy access to workspace
+      position: [2, 5], // Positioned for easy access to workspace
     },
   ],
   // No starter kit: supplies come from the store, or back out of salvage
@@ -29,8 +29,8 @@ export const initialGameState: GameState = {
   consumables: NO_CONSUMABLES,
   player: {
     name: "Player",
-    position: [0, 0],
-    direction: 0,
+    position: [6, 12],
+    direction: 1,
     inventory: [],
     workQueue: [],
     canWork: true,
@@ -39,9 +39,10 @@ export const initialGameState: GameState = {
   },
   machines: [
     // Single workspace for tutorial, with the starter hammer mounted
-    machine("workspace", [1, 2], 0, ["hammer"]),
-    // Garbage can for disposing unwanted materials
-    machine("garbageCan", [0, 5], 0),
+    // (3×2 ft, against the back wall with its front apron open)
+    machine("workspace", [2, 2], 0, ["hammer"]),
+    // Garbage can for disposing unwanted materials (2×2 ft, in a corner)
+    machine("garbageCan", [0, 13], 0),
   ],
   machineCrates: [],
   storage: {
@@ -51,9 +52,10 @@ export const initialGameState: GameState = {
   shopInfo: {
     name: "One Car Garage",
     electricity: 120,
-    size: [4, 6],
-    materialDropoffPosition: [3, 5],
-    entrancePosition: defaultEntrancePosition([4, 6]),
+    // 12' × 16', in 1-ft cells
+    size: [12, 16],
+    materialDropoffPosition: [10, 13],
+    entrancePosition: defaultEntrancePosition([12, 16]),
   },
   progression: {
     tutorialStage: 0,

--- a/src/game/machine-collision-boxes.generated.ts
+++ b/src/game/machine-collision-boxes.generated.ts
@@ -9,9 +9,9 @@ import type { CollisionBox } from "./Machine";
  * cell's center.
  */
 export const GENERATED_COLLISION_BOXES = {
-  lunchboxPlaner: { min: [-0.25, -0.41], max: [0.328, 0.391] },
-  jointer: { min: [-0.168, -0.633], max: [0.328, 0.633] },
-  miterSaw: { min: [-0.437, -0.332], max: [0.438, 0.309] },
-  jobsiteTableSaw: { min: [-0.331, -0.303], max: [0.428, 0.303] },
-  workspace: { min: [-0.488, -0.367], max: [0.484, 0.301] },
+  lunchboxPlaner: { min: [-0.667, -1.094], max: [0.875, 1.042] },
+  jointer: { min: [-0.448, -1.687], max: [0.875, 1.688] },
+  miterSaw: { min: [-1.167, -0.885], max: [1.167, 0.823] },
+  jobsiteTableSaw: { min: [-0.883, -0.808], max: [1.142, 0.808] },
+  workspace: { min: [-1.302, -0.979], max: [1.292, 0.802] },
 } satisfies Record<string, CollisionBox>;

--- a/src/game/machine-collision.test.ts
+++ b/src/game/machine-collision.test.ts
@@ -1,29 +1,31 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
-import { CellInfo } from "./CellMap";
-import { CollisionBox, Machine } from "./Machine";
+import { CollisionBox, Machine, MACHINE_TYPES } from "./Machine";
 import {
-  cellObstruction,
-  machineCellInsets,
+  machineSolids,
   machineWorldBox,
-  MAX_COLLISION_INSET,
+  shopSolids,
 } from "./machine-collision";
-import { PLAYER_RADIUS, SOLID_CELL } from "./player-motion";
-import { Direction, Vector } from "./Vectors";
+import { PLAYER_RADIUS } from "./player-motion";
+import { Direction, rotateVec, translateVec, Vector } from "./Vectors";
 
 /**
  * A stand-in for a placed machine: the collision helpers only read the
- * type's box and the placement's position/rotation.
+ * type's box and footprint and the placement's position/rotation.
  */
 const placed = (
   collisionBox: CollisionBox | undefined,
   position: Vector = [0, 0],
   rotation: Direction = 0,
+  cellsOccupied: Vector[] = [[0, 0]],
 ): Machine =>
-  ({ type: { collisionBox }, position, rotation }) as unknown as Machine;
-
-const cellInfoWith = (partial: Partial<CellInfo>): CellInfo =>
-  partial as CellInfo;
+  ({
+    type: { collisionBox, cellsOccupied },
+    position,
+    rotation,
+    localToShop: (local: Vector) =>
+      translateVec(rotateVec(local, rotation), position),
+  }) as unknown as Machine;
 
 const assertClose = (actual: unknown, expected: unknown): void => {
   assert.deepStrictEqual(
@@ -60,106 +62,98 @@ describe("machineWorldBox", () => {
   });
 });
 
-describe("machineCellInsets", () => {
-  it("reports how far the box sits in from each tile edge", () => {
-    const insets = machineCellInsets(
-      placed({ min: [-0.35, -0.35], max: [0.35, 0.35] }),
-      [0, 0],
+describe("machineSolids", () => {
+  it("uses the collision box when the machine has one", () => {
+    const solids = machineSolids(
+      placed({ min: [-0.4, -0.4], max: [1.4, 0.4] }, [2, 2]),
     );
-    assertClose(insets, {
-      left: 0.15,
-      right: 0.15,
-      top: 0.15,
-      bottom: 0.15,
-    });
+    assert.strictEqual(solids.length, 1);
+    assertClose(solids[0].min, [2.1, 2.1]);
+    assertClose(solids[0].max, [3.9, 2.9]);
   });
 
-  it("caps insets below the player's radius", () => {
-    // A tiny box may not open the cell so far that the player's center
-    // could enter it.
-    const insets = machineCellInsets(
-      placed({ min: [-0.05, -0.05], max: [0.05, 0.05] }),
-      [0, 0],
+  it("blocks each occupied tile of a boxless machine", () => {
+    const solids = machineSolids(
+      placed(undefined, [4, 4], 0, [
+        [0, 0],
+        [1, 0],
+      ]),
     );
-    assertClose(insets, {
-      left: MAX_COLLISION_INSET,
-      right: MAX_COLLISION_INSET,
-      top: MAX_COLLISION_INSET,
-      bottom: MAX_COLLISION_INSET,
-    });
-    assert.ok(MAX_COLLISION_INSET < PLAYER_RADIUS);
+    assertClose(solids, [
+      { min: [4, 4], max: [5, 5] },
+      { min: [5, 4], max: [6, 5] },
+    ]);
   });
 
-  it("floors insets at zero when the art overhangs the tile", () => {
-    // The jointer's beds draw past its tile front and back.
-    const insets = machineCellInsets(
-      placed({ min: [-0.2, -0.65], max: [0.2, 0.65] }),
-      [0, 0],
+  it("rotates a boxless footprint's tiles with the machine", () => {
+    const solids = machineSolids(
+      placed(undefined, [4, 4], 1, [
+        [0, 0],
+        [1, 0],
+      ]),
     );
-    assertClose(insets, {
-      left: MAX_COLLISION_INSET,
-      right: MAX_COLLISION_INSET,
-      top: 0,
-      bottom: 0,
-    });
+    // rotateVec sends [1, 0] to [0, -1] at rotation 1
+    assertClose(solids, [
+      { min: [4, 4], max: [5, 5] },
+      { min: [4, 3], max: [5, 4] },
+    ]);
   });
 
-  it("only exposes a multi-cell box's outer faces", () => {
-    // A 1×2 machine's box spanning both tiles: the shared interior edge
-    // contributes no inset from either side.
-    const machine = placed({ min: [-0.4, -0.4], max: [0.4, 1.4] });
-    assertClose(machineCellInsets(machine, [0, 0]), {
-      left: 0.1,
-      right: 0.1,
-      top: 0.1,
-      bottom: 0,
-    });
-    assertClose(machineCellInsets(machine, [0, 1]), {
-      left: 0.1,
-      right: 0.1,
-      top: 0,
-      bottom: 0.1,
-    });
+  it("combines every machine's solids for the shop", () => {
+    const a = placed({ min: [-0.4, -0.4], max: [0.4, 0.4] }, [1, 1]);
+    const b = placed(undefined, [5, 5]);
+    assert.strictEqual(shopSolids([a, b]).length, 2);
   });
 });
 
-describe("cellObstruction", () => {
-  const slimBox: CollisionBox = { min: [-0.3, -0.3], max: [0.3, 0.3] };
-
-  it("treats off-floor as solid wall", () => {
-    assert.deepStrictEqual(cellObstruction(undefined, [9, 9]), SOLID_CELL);
+describe("real machine footprints", () => {
+  it("every machine's collision box stays within its occupied tiles by less than the body radius", () => {
+    // If a box hid deeper than PLAYER_RADIUS inside its footprint, the
+    // body's center could wander onto an occupied cell and the
+    // cell-underfoot bookkeeping would see the player standing "in" a
+    // machine. Overhang past the footprint is fine (art pokes out).
+    for (const type of Object.values(MACHINE_TYPES)) {
+      if (!type.collisionBox) continue;
+      const xs = type.cellsOccupied.map(([x]) => x);
+      const ys = type.cellsOccupied.map(([, y]) => y);
+      // Footprint bounds relative to the origin cell's center
+      const bounds = {
+        minX: Math.min(...xs) - 0.5,
+        maxX: Math.max(...xs) + 0.5,
+        minY: Math.min(...ys) - 0.5,
+        maxY: Math.max(...ys) + 0.5,
+      };
+      const { min, max } = type.collisionBox;
+      assert.ok(
+        min[0] - bounds.minX < PLAYER_RADIUS,
+        `${type.id}: box hides too deep on the left`,
+      );
+      assert.ok(
+        bounds.maxX - max[0] < PLAYER_RADIUS,
+        `${type.id}: box hides too deep on the right`,
+      );
+      assert.ok(
+        min[1] - bounds.minY < PLAYER_RADIUS,
+        `${type.id}: box hides too deep at the top`,
+      );
+      assert.ok(
+        bounds.maxY - max[1] < PLAYER_RADIUS,
+        `${type.id}: box hides too deep at the bottom`,
+      );
+    }
   });
 
-  it("leaves open floor passable", () => {
-    assert.strictEqual(
-      cellObstruction(cellInfoWith({ machine: undefined }), [0, 0]),
-      undefined,
-    );
-  });
-
-  it("uses the machine's box insets", () => {
-    const obstruction = cellObstruction(
-      cellInfoWith({ machine: placed(slimBox) }),
-      [0, 0],
-    );
-    assertClose(obstruction, {
-      left: 0.2,
-      right: 0.2,
-      top: 0.2,
-      bottom: 0.2,
-    });
-  });
-
-  it("keeps the worktable solid under a mounted benchtop machine", () => {
-    // The benchtop planer is slim, but the table it sits on fills the
-    // tile — mounting it must not open the tile up.
-    const obstruction = cellObstruction(
-      cellInfoWith({
-        machine: placed(slimBox),
-        tableMachine: placed(undefined),
-      }),
-      [0, 0],
-    );
-    assertClose(obstruction, SOLID_CELL);
+  it("every machine with an operation position keeps it outside the footprint", () => {
+    for (const type of Object.values(MACHINE_TYPES)) {
+      if (!type.operationPosition) continue;
+      assert.ok(
+        !type.cellsOccupied.some(
+          ([x, y]) =>
+            x === type.operationPosition![0] &&
+            y === type.operationPosition![1],
+        ),
+        `${type.id}: operation position sits on the machine itself`,
+      );
+    }
   });
 });

--- a/src/game/machine-collision.ts
+++ b/src/game/machine-collision.ts
@@ -1,31 +1,22 @@
-import { CellInfo } from "./CellMap";
 import { Machine } from "./Machine";
-import { CellInsets, SOLID_CELL } from "./player-motion";
+import { SolidBox } from "./player-motion";
 import { rotateVec, Vector } from "./Vectors";
 
 /**
- * Turns machines' collision boxes (MachineType.collisionBox) into the
- * per-cell edge insets the movement sweep collides against. Boxes live in
- * the machine's local frame; here they're rotated with the machine and
- * clipped to each occupied cell.
+ * Turns placed machines into the world-space solid boxes the movement
+ * sweep collides against (see stepPlayerMotion). A machine with a
+ * collision box (MachineType.collisionBox — measured from its sprite art
+ * or hand-set) blocks exactly that box, rotated with the placement; a
+ * machine without one blocks its whole occupied tiles. Placement,
+ * targeting, and attendance still work on whole cells — only the walking
+ * body sees these boxes.
  */
-
-/**
- * The most a machine's solid area may sit in from a tile edge. Strictly
- * below PLAYER_RADIUS so the player's center can never cross into an
- * occupied cell no matter how slim the art: GameState's cell-underfoot
- * bookkeeping (targeting, attendance, the inspector) never sees the player
- * standing "in" a machine. Enforced in machine-collision.test.ts.
- */
-export const MAX_COLLISION_INSET = 0.25;
 
 /**
  * A placed machine's collision box in world cell coordinates (cell [x, y]
  * spans x..x+1), or null when the type has none and its whole tiles block.
  */
-export function machineWorldBox(
-  machine: Machine,
-): { min: Vector; max: Vector } | null {
+export function machineWorldBox(machine: Machine): SolidBox | null {
   const box = machine.type.collisionBox;
   if (box === undefined) {
     return null;
@@ -39,55 +30,22 @@ export function machineWorldBox(
   };
 }
 
-const clampInset = (inset: number) =>
-  Math.min(Math.max(inset, 0), MAX_COLLISION_INSET);
-
-/** The machine's solid area clipped to one occupied cell, as edge insets. */
-export function machineCellInsets(
-  machine: Machine,
-  [x, y]: Vector,
-): CellInsets {
+/** The solid boxes one machine contributes: its collision box, or one
+ * full box per occupied tile when it has none. */
+export function machineSolids(machine: Machine): SolidBox[] {
   const box = machineWorldBox(machine);
-  if (box === null) {
-    return SOLID_CELL;
+  if (box !== null) {
+    return [box];
   }
-  return {
-    left: clampInset(box.min[0] - x),
-    right: clampInset(x + 1 - box.max[0]),
-    top: clampInset(box.min[1] - y),
-    bottom: clampInset(y + 1 - box.max[1]),
-  };
+  return machine.type.cellsOccupied.map((cell) => {
+    const [x, y] = machine.localToShop(cell);
+    return { min: [x, y] as Vector, max: [x + 1, y + 1] as Vector };
+  });
 }
 
-/** The tighter (more solid) of two obstructions, side by side. */
-function combineInsets(a: CellInsets, b: CellInsets): CellInsets {
-  return {
-    left: Math.min(a.left, b.left),
-    right: Math.min(a.right, b.right),
-    top: Math.min(a.top, b.top),
-    bottom: Math.min(a.bottom, b.bottom),
-  };
-}
-
-/**
- * What blocks walking at one cell: undefined for open floor, edge insets
- * otherwise. Off the floor entirely is solid wall; a machine blocks its
- * collision box; a benchtop machine mounted on a worktable contributes the
- * table's box too (the table is still under it).
- */
-export function cellObstruction(
-  info: CellInfo | undefined,
-  cell: Vector,
-): CellInsets | undefined {
-  if (info === undefined) {
-    return SOLID_CELL;
-  }
-  if (info.machine === undefined) {
-    return undefined;
-  }
-  let insets = machineCellInsets(info.machine, cell);
-  if (info.tableMachine !== undefined) {
-    insets = combineInsets(insets, machineCellInsets(info.tableMachine, cell));
-  }
-  return insets;
+/** Everything solid on the shop floor. A benchtop machine mounted on a
+ * worktable contributes its own box and the table contributes its tiles —
+ * overlapping solids just block twice, which is fine. */
+export function shopSolids(machines: ReadonlyArray<Machine>): SolidBox[] {
+  return machines.flatMap(machineSolids);
 }

--- a/src/game/machine-helpers.ts
+++ b/src/game/machine-helpers.ts
@@ -134,21 +134,25 @@ function getRequirementForSlotIndex(
  * @returns true if the machine has all required materials and can start operating, false otherwise
  */
 /**
- * Whether the player counts as attending this machine: standing at its
- * operation cell and not off on an away trip. Machines with no operation
- * cell can't be worked at all, so their (never-reachable) attended phases
- * are treated as satisfied rather than deadlocking.
+ * Whether the player counts as attending this machine: standing in its
+ * operation zone (the apron of cells around the operation position — a
+ * body is bigger than one 1-ft cell) and not off on an away trip.
+ * Machines with no operation cell can't be worked at all, so their
+ * (never-reachable) attended phases are treated as satisfied rather than
+ * deadlocking.
  */
 export function playerAttendsMachine(
   machine: Machine,
   playerPosition: Vector,
   playerIsAway: boolean,
 ): boolean {
-  const operationCell = machine.absoluteOperationPosition;
-  if (operationCell === null) {
+  const zone = machine.operationZone;
+  if (zone.length === 0) {
     return true;
   }
-  return !playerIsAway && vectorEquals(playerPosition, operationCell);
+  return (
+    !playerIsAway && zone.some((cell) => vectorEquals(cell, playerPosition))
+  );
 }
 
 /**

--- a/src/game/machines/garbageCan.ts
+++ b/src/game/machines/garbageCan.ts
@@ -6,10 +6,16 @@ export const garbageCan: MachineType = {
   name: "Garbage Can",
   description:
     "Dispose of unwanted materials and scraps. Materials are permanently removed.",
-  cellsOccupied: [[0, 0]],
+  // A full-size shop can (22" across) sits on a 2×2-ft patch of floor.
+  cellsOccupied: [
+    [0, 0],
+    [1, 0],
+    [0, 1],
+    [1, 1],
+  ],
   // Hand-set (the can is drawn procedurally, not from an image): the lid
-  // circle in GarbageCanSprite is 0.35 cells around the cell center.
-  collisionBox: { min: [-0.35, -0.35], max: [0.35, 0.35] },
+  // circle in GarbageCanSprite is 0.93 cells around the footprint center.
+  collisionBox: { min: [-0.43, -0.43], max: [1.43, 1.43] },
   freeCellsNeeded: [],
   cost: 0, // Free - basic quality of life feature
   materialStorage: 0,

--- a/src/game/machines/jobsiteTableSaw.ts
+++ b/src/game/machines/jobsiteTableSaw.ts
@@ -7,14 +7,25 @@ export const jobsiteTableSaw: MachineType = {
   id: "jobsiteTableSaw",
   name: "Jobsite Table Saw",
   description: "A portable table saw for cutting wood.",
-  cellsOccupied: [[0, 0]],
+  // A jobsite saw on its stand: about 24" × 19", table biased toward the
+  // infeed side — a 3×2-ft footprint with the tabletop overhanging the
+  // operator side a few inches (see the measured collision box).
+  cellsOccupied: [
+    [-1, -1],
+    [0, -1],
+    [1, -1],
+    [-1, 0],
+    [0, 0],
+    [1, 0],
+  ],
   collisionBox: GENERATED_COLLISION_BOXES.jobsiteTableSaw,
   freeCellsNeeded: [
     [0, 1],
-    [0, -1],
+    [0, 2],
+    [0, -2],
   ],
-  operationPosition: [0, 1],
-  outputPosition: [0, -1],
+  operationPosition: [0, 2],
+  outputPosition: [0, -2],
   cost: 300,
   materialStorage: 0,
   // One jig at a time — the crosscut sled is the first

--- a/src/game/machines/jointer.ts
+++ b/src/game/machines/jointer.ts
@@ -16,15 +16,27 @@ export const jointer: MachineType = {
   name: "Jointer",
   description:
     "Flattens a reference face and straightens an edge. Rough lumber starts here.",
-  cellsOccupied: [[0, 0]],
+  // A benchtop jointer: 16" wide with 40" of bed, so a 2×3-ft footprint
+  // with the tables running the long way (the beds overhang the footprint
+  // an inch or two each end — see the measured collision box).
+  cellsOccupied: [
+    [0, -1],
+    [0, 0],
+    [0, 1],
+    [1, -1],
+    [1, 0],
+    [1, 1],
+  ],
   collisionBox: GENERATED_COLLISION_BOXES.jointer,
   // Infeed and outfeed: boards travel the long way across the tables
   freeCellsNeeded: [
-    [0, 1],
-    [0, -1],
+    [0, 2],
+    [1, 2],
+    [0, -2],
+    [1, -2],
   ],
-  operationPosition: [0, 1],
-  outputPosition: [0, -1],
+  operationPosition: [0, 2],
+  outputPosition: [0, -2],
   cost: 600,
   materialStorage: 0,
   toolSlots: 1,

--- a/src/game/machines/lunchboxPlaner.ts
+++ b/src/game/machines/lunchboxPlaner.ts
@@ -30,16 +30,28 @@ export const lunchboxPlaner: MachineType = {
   id: "planer",
   name: "Planer",
   description: "A lunchbox planer",
-  cellsOccupied: [[0, 0]],
+  // A lunchbox planer on its stand: about 19" × 26", so a 2×3-ft
+  // footprint with stock feeding the long way (see the measured
+  // collision box for the exact solid area).
+  cellsOccupied: [
+    [0, -1],
+    [0, 0],
+    [0, 1],
+    [1, -1],
+    [1, 0],
+    [1, 1],
+  ],
   collisionBox: GENERATED_COLLISION_BOXES.lunchboxPlaner,
   // Feed-through: room to stand at the infeed and to catch stock at the
   // outfeed — a planer can't back onto a wall
   freeCellsNeeded: [
-    [0, 1],
-    [0, -1],
+    [0, 2],
+    [1, 2],
+    [0, -2],
+    [1, -2],
   ],
-  operationPosition: [0, 1],
-  outputPosition: [0, -1],
+  operationPosition: [0, 2],
+  outputPosition: [0, -2],
   cost: 450,
   materialStorage: 0,
   toolSlots: 1,

--- a/src/game/machines/miterSaw.ts
+++ b/src/game/machines/miterSaw.ts
@@ -28,10 +28,23 @@ export const miterSaw: MachineType = {
   id: "miterSaw",
   name: "Miter Saw",
   description: "A portable saw for cross cutting wood, square or at an angle.",
-  cellsOccupied: [[0, 0]],
+  // A miter saw is wide (28" across the fence wings) and shallow: a
+  // 3×2-ft footprint, with the handle overhanging the operator side (see
+  // the measured collision box).
+  cellsOccupied: [
+    [-1, -1],
+    [0, -1],
+    [1, -1],
+    [-1, 0],
+    [0, 0],
+    [1, 0],
+  ],
   collisionBox: GENERATED_COLLISION_BOXES.miterSaw,
-  freeCellsNeeded: [],
-  operationPosition: [0, 1],
+  freeCellsNeeded: [
+    [0, 1],
+    [0, 2],
+  ],
+  operationPosition: [0, 2],
   cost: 150,
   materialStorage: 0,
   toolSlots: 1,

--- a/src/game/machines/storageRack.ts
+++ b/src/game/machines/storageRack.ts
@@ -10,14 +10,23 @@ export const storageRack: MachineType = {
   id: "storageRack",
   name: "Storage Rack",
   description: "Cheap sheet on stout legs. Holds a small lumberyard.",
-  cellsOccupied: [[0, 0]],
-  // Hand-set (drawn procedurally): the deck in StorageRackSprite spans
-  // 0.42 cells around the cell center.
-  collisionBox: { min: [-0.42, -0.42], max: [0.42, 0.42] },
+  // A 2×2-ft rack: deep enough for sheet stock stood on edge.
+  cellsOccupied: [
+    [0, 0],
+    [1, 0],
+    [0, 1],
+    [1, 1],
+  ],
+  // Hand-set (drawn procedurally): the deck in StorageRackSprite fills
+  // the footprint to a small inset.
+  collisionBox: { min: [-0.44, -0.44], max: [1.44, 1.44] },
   // Stand at the front to stow and take — the shelf UI (and everything
   // else) hangs off the operation cell, rack or not.
-  freeCellsNeeded: [[0, 1]],
-  operationPosition: [0, 1],
+  freeCellsNeeded: [
+    [0, 2],
+    [1, 2],
+  ],
+  operationPosition: [0, 2],
   cost: 0,
   materialStorage: 8,
   toolSlots: 0,

--- a/src/game/machines/workspace.ts
+++ b/src/game/machines/workspace.ts
@@ -15,10 +15,23 @@ export const workspace: MachineType = {
   name: "Makeshift Workbench",
   description:
     "A plywood offcut over a few paint buckets. It wobbles, but it works.",
-  cellsOccupied: [[0, 0]],
+  // Plywood over paint buckets: about 31" × 21", so a 3×2-ft footprint
+  // with the front edge overhanging toward whoever's working at it (see
+  // the measured collision box).
+  cellsOccupied: [
+    [-1, -1],
+    [0, -1],
+    [1, -1],
+    [-1, 0],
+    [0, 0],
+    [1, 0],
+  ],
   collisionBox: GENERATED_COLLISION_BOXES.workspace,
-  freeCellsNeeded: [[0, 1]],
-  operationPosition: [0, 1],
+  freeCellsNeeded: [
+    [0, 1],
+    [0, 2],
+  ],
+  operationPosition: [0, 2],
   cost: 0,
   materialStorage: 0,
   // Two slots: the starter hammer plus room for a sander

--- a/src/game/machines/worktables.test.ts
+++ b/src/game/machines/worktables.test.ts
@@ -110,7 +110,7 @@ describe("worktable build recipes", () => {
     const state = stateWith({
       machines: [machine],
       // The workspace operation cell for position [1,2] rotation 0
-      player: { ...initialGameState.player, position: [1, 3] },
+      player: { ...initialGameState.player, position: [1, 4] },
     });
 
     const result = tickAction(state);
@@ -120,7 +120,7 @@ describe("worktable build recipes", () => {
       result.machineCrates[0].machine.machineTypeId,
       "worktable1x1",
     );
-    assert.deepStrictEqual(result.machineCrates[0].position, [1, 3]);
+    assert.deepStrictEqual(result.machineCrates[0].position, [1, 4]);
     assert.strictEqual(
       result.machines[0].operationProgress.status,
       "notStarted",
@@ -158,21 +158,21 @@ describe("benchtop mounting placement rules", () => {
     return CellMap.fromGameState(stateWith({ machines }));
   }
 
-  it("allows a benchtop machine on a free worktable cell", () => {
-    // Miter saw facing down from the table's middle cell: its operator
-    // cell [1,1] is open floor
+  it("allows a benchtop machine on free worktable cells", () => {
+    // Miter saw anchored at [1,1]: its whole 3×2 footprint lands on the
+    // table top and its operator cells are open floor below
     assert.ok(
-      canPlaceMachine(cellMapWith([table]), MACHINE_TYPES.miterSaw, [1, 0], 0),
+      canPlaceMachine(cellMapWith([table]), MACHINE_TYPES.miterSaw, [1, 1], 0),
     );
   });
 
-  it("rejects a benchtop machine on a table cell already hosting one", () => {
-    const saw = machineAt("miterSaw", [1, 0]);
+  it("rejects a benchtop machine on table cells already hosting one", () => {
+    const saw = machineAt("miterSaw", [1, 1]);
     assert.ok(
       !canPlaceMachine(
         cellMapWith([table, saw]),
         MACHINE_TYPES.lunchboxPlaner,
-        [1, 0],
+        [1, 1],
         0,
       ),
     );
@@ -201,26 +201,26 @@ describe("benchtop mounting placement rules", () => {
   });
 
   it("counts table cells as blocked for another machine's free cells", () => {
-    // Planer at [1,1] facing down: its infeed/outfeed cells sit at [1,0]
-    // (the table top) and [1,2] — the table blocks it
+    // Planer just below the table, feeding toward it: its outfeed
+    // clearance cells land on the table top — the table blocks it
     assert.ok(
       !canPlaceMachine(
         cellMapWith([table]),
         MACHINE_TYPES.lunchboxPlaner,
-        [1, 1],
+        [1, 3],
         0,
       ),
     );
   });
 
   it("stacks the cell map: benchtop on top, table underneath", () => {
-    const saw = machineAt("miterSaw", [1, 0]);
+    const saw = machineAt("miterSaw", [1, 1]);
     // Order in gameState.machines must not matter
     for (const machines of [
       [table, saw],
       [saw, table],
     ]) {
-      const cell = cellMapWith(machines).at([1, 0])!;
+      const cell = cellMapWith(machines).at([1, 1])!;
       assert.strictEqual(cell.machine?.type.id, "miterSaw");
       assert.strictEqual(cell.tableMachine?.type.id, "worktable1x3");
     }
@@ -229,7 +229,7 @@ describe("benchtop mounting placement rules", () => {
 
 describe("moving and removing tables", () => {
   const table = machineAt("worktable1x3", [0, 0]);
-  const saw = machineAt("miterSaw", [1, 0]);
+  const saw = machineAt("miterSaw", [1, 1]);
 
   it("reports machines mounted on a table", () => {
     const state = stateWith({ machines: [table, saw] });

--- a/src/game/machines/worktables.ts
+++ b/src/game/machines/worktables.ts
@@ -7,38 +7,63 @@ import { BENCH_OPERATIONS } from "./benchOperations";
  * benchOperations.ts; they're never sold). A bare worktable is the
  * makeshift workbench, upgraded: the same recipe list, run faster
  * (workSpeed), with more tool slots and a shelf underneath
- * (materialStorage). Each cell of the top can also carry one benchtop
- * machine — mounting the planer on a table's end leaves the rest of the
- * top free for bench work, and the shelf below doubles as the machine's
- * stand storage.
+ * (materialStorage). The top can also carry benchtop machines wherever
+ * their footprints fit — mounting the planer on a table's end leaves the
+ * rest of the top free for bench work, and the shelf below doubles as the
+ * machine's stand storage.
+ *
+ * All tables are two feet deep (cells are 1 sq ft); `widthFeet` sets the
+ * run of the top. The ids keep their old grid-era names for save
+ * compatibility.
  */
 function worktable(
   id: string,
   name: string,
   description: string,
-  cells: ReadonlyArray<Vector>,
-  operationPosition: Vector,
-  toolSlots: number,
+  widthFeet: number,
+  depthFeet: number,
+  stats: {
+    materialStorage: number;
+    toolSlots: number;
+    inputSpaces: number;
+    upgradeSlots: number;
+  },
 ): MachineType {
+  const cells: Vector[] = [];
+  for (let y = 0; y < depthFeet; y++) {
+    for (let x = 0; x < widthFeet; x++) {
+      cells.push([x, y]);
+    }
+  }
+  // Stand anywhere along the front: the operation cell anchors near the
+  // middle of the front edge, and the whole front row stays clear so the
+  // bench is workable along its length.
+  const operationPosition: Vector = [
+    Math.floor((widthFeet - 1) / 2),
+    depthFeet,
+  ];
+  const freeCellsNeeded: Vector[] = [];
+  for (let x = 0; x < widthFeet; x++) {
+    freeCellsNeeded.push([x, depthFeet]);
+  }
   return {
     id,
     name,
     description,
     cellsOccupied: cells,
-    freeCellsNeeded: [operationPosition],
+    freeCellsNeeded,
     operationPosition,
     cost: 0,
-    // The shelf underneath: three materials per cell of top
-    materialStorage: cells.length * 3,
-    toolSlots,
-    inputSpaces: 4 + cells.length,
+    materialStorage: stats.materialStorage,
+    toolSlots: stats.toolSlots,
+    inputSpaces: stats.inputSpaces,
     // A flat, solid top that holds the work still: attended hand work
     // runs a quarter faster than on the wobbly makeshift bench
     workSpeed: 1.25,
     worktable: true,
     // Room for a vise, drawers, a second shelf… bigger tables carry more
     // (see Upgrade.ts)
-    upgradeSlots: Math.min(cells.length, 3),
+    upgradeSlots: stats.upgradeSlots,
     operations: BENCH_OPERATIONS,
   };
 }
@@ -46,47 +71,35 @@ function worktable(
 export const worktable1x1 = worktable(
   "worktable1x1",
   "Small Worktable",
-  "A sturdy shop-built bench. Solid top, tool slots, and a shelf below.",
-  [[0, 0]],
-  [0, 1],
-  3,
+  "A sturdy shop-built bench, 2'×2'. Solid top, tool slots, and a shelf below.",
+  2,
+  2,
+  { materialStorage: 3, toolSlots: 3, inputSpaces: 5, upgradeSlots: 1 },
 );
 
 export const worktable1x2 = worktable(
   "worktable1x2",
   "Worktable",
-  "A full-size shop-built bench: room to work and a benchtop machine.",
-  [
-    [0, 0],
-    [1, 0],
-  ],
-  [0, 1],
+  "A full-size shop-built bench, 4'×2': room to work and a benchtop machine.",
   4,
+  2,
+  { materialStorage: 6, toolSlots: 4, inputSpaces: 6, upgradeSlots: 2 },
 );
 
 export const worktable1x3 = worktable(
   "worktable1x3",
   "Long Worktable",
-  "A long run of bench: machines on the ends, hand work in the middle.",
-  [
-    [0, 0],
-    [1, 0],
-    [2, 0],
-  ],
-  [0, 1],
-  5,
+  "A 6'×2' run of bench: machines on the ends, hand work in the middle.",
+  6,
+  2,
+  { materialStorage: 9, toolSlots: 5, inputSpaces: 7, upgradeSlots: 3 },
 );
 
 export const worktable2x2 = worktable(
   "worktable2x2",
   "Big Worktable",
-  "A deep island of bench space with a generous shelf underneath.",
-  [
-    [0, 0],
-    [1, 0],
-    [0, 1],
-    [1, 1],
-  ],
-  [0, 2],
-  6,
+  "A deep 4'×4' island of bench space with a generous shelf underneath.",
+  4,
+  4,
+  { materialStorage: 12, toolSlots: 6, inputSpaces: 8, upgradeSlots: 3 },
 );

--- a/src/game/marketplace.ts
+++ b/src/game/marketplace.ts
@@ -141,7 +141,10 @@ export function reviewReputationGain(
  * expected wait implied by the current sale chance.
  */
 export type ListingInterest =
-  "priced to move" | "should sell soon" | "expect a wait" | "ambitious";
+  | "priced to move"
+  | "should sell soon"
+  | "expect a wait"
+  | "ambitious";
 
 export function listingInterest(
   material: MaterialInstance,

--- a/src/game/pile-helpers.test.ts
+++ b/src/game/pile-helpers.test.ts
@@ -20,22 +20,23 @@ function boardPile(length: number, position: [number, number]): MaterialPile {
 }
 
 describe("pileFootprint", () => {
-  it("keeps short stock to its anchor cell", () => {
-    assert.deepStrictEqual(pileFootprint(boardPile(2, [3, 3])), [[3, 3]]);
-    assert.deepStrictEqual(pileFootprint(boardPile(4, [3, 3])), [[3, 3]]);
+  it("keeps foot-long stock to its anchor cell", () => {
+    assert.deepStrictEqual(pileFootprint(boardPile(1, [3, 3])), [[3, 3]]);
   });
 
-  it("extends long boards one cell each way along their length", () => {
-    assert.deepStrictEqual(pileFootprint(boardPile(6, [3, 3])), [
+  it("extends boards a cell per foot along their length", () => {
+    // Cells are a foot square, so a 2' board centered on its anchor
+    // reaches half a foot into each neighbor…
+    assert.deepStrictEqual(pileFootprint(boardPile(2, [3, 3])), [
       [3, 2],
       [3, 3],
       [3, 4],
     ]);
-    assert.deepStrictEqual(pileFootprint(boardPile(8, [3, 3])), [
-      [3, 2],
-      [3, 3],
-      [3, 4],
-    ]);
+    // …and an 8' board spans nine cells.
+    assert.deepStrictEqual(
+      pileFootprint(boardPile(8, [3, 5])),
+      [1, 2, 3, 4, 5, 6, 7, 8, 9].map((y) => [3, y]),
+    );
   });
 
   it("uses only the anchor cell for materials without a length", () => {
@@ -66,11 +67,12 @@ describe("pileFootprint", () => {
 
 describe("pileCoversCell", () => {
   it("accepts any overlapped cell and rejects the rest", () => {
-    const pile = boardPile(8, [3, 3]);
-    assert.ok(pileCoversCell(pile, [3, 3]));
-    assert.ok(pileCoversCell(pile, [3, 2]));
-    assert.ok(pileCoversCell(pile, [3, 4]));
-    assert.ok(!pileCoversCell(pile, [3, 5]));
-    assert.ok(!pileCoversCell(pile, [2, 3]));
+    const pile = boardPile(8, [3, 5]);
+    assert.ok(pileCoversCell(pile, [3, 5]));
+    assert.ok(pileCoversCell(pile, [3, 1]));
+    assert.ok(pileCoversCell(pile, [3, 9]));
+    assert.ok(!pileCoversCell(pile, [3, 0]));
+    assert.ok(!pileCoversCell(pile, [3, 10]));
+    assert.ok(!pileCoversCell(pile, [2, 5]));
   });
 });

--- a/src/game/pile-helpers.ts
+++ b/src/game/pile-helpers.ts
@@ -1,11 +1,6 @@
 import { MaterialPile } from "./GameState";
+import { INCHES_PER_CELL } from "./shop-scale";
 import { Vector, vectorEquals } from "./Vectors";
-
-/**
- * A shop cell is 32" on a side (PIXELS_PER_CELL / PIXELS_PER_INCH in
- * shop-scale.tsx), so long stock drawn at scale overhangs its anchor cell.
- */
-const INCHES_PER_CELL = 32;
 
 /**
  * How much of a board must reach into a cell before you can grab it from
@@ -16,9 +11,9 @@ const MIN_OVERLAP_CELLS = 0.25;
 /**
  * The cells a pile can be grabbed from: every cell its material meaningfully
  * overlaps. Piles render centered on their anchor cell with long stock lying
- * along the vertical axis (see MaterialPilesSprite), so an 8' board reaches
- * a full cell past its anchor in both directions while anything 4' or under
- * stays a one-cell grab.
+ * along the vertical axis (see MaterialPilesSprite), so with 1-ft cells an
+ * 8' board reaches four cells past its anchor in both directions while
+ * anything a foot or under stays a one-cell grab.
  */
 export function pileFootprint(pile: MaterialPile): Vector[] {
   const material = pile.material;

--- a/src/game/player-motion.test.ts
+++ b/src/game/player-motion.test.ts
@@ -3,154 +3,152 @@ import { describe, it } from "node:test";
 import { initialGameState } from "./initialGameState";
 import {
   BASE_WALK_SPEED,
-  CellInsets,
   cellCenter,
+  CollisionWorld,
   directionFromInput,
   motionCell,
   PLAYER_RADIUS,
   playerWalkSpeed,
-  SOLID_CELL,
+  SolidBox,
   stepPlayerMotion,
 } from "./player-motion";
 import { Vector } from "./Vectors";
+import { DUST_MAX_PER_CELL } from "./Dust";
 
-const openFloor = () => undefined;
+/** A roomy floor so wall clamping never interferes unless a test wants it. */
+const world = (
+  solids: SolidBox[] = [],
+  size: Vector = [100, 100],
+): CollisionWorld => ({ size, solids });
 
-/** Whole-tile machines at the given cells (walls, boxless machines). */
-const machineAt =
-  (...blocked: Vector[]) =>
-  ([x, y]: Vector) =>
-    blocked.some(([bx, by]) => bx === x && by === y) ? SOLID_CELL : undefined;
-
-/** A slim machine at one cell, its solid area inset from every tile edge. */
-const insetMachineAt =
-  (
-    [mx, my]: Vector,
-    inset: number,
-  ): ((cell: Vector) => CellInsets | undefined) =>
-  ([x, y]: Vector) =>
-    x === mx && y === my
-      ? { left: inset, right: inset, top: inset, bottom: inset }
-      : undefined;
+/** A whole-tile solid at a cell (a wall, or a machine with no box). */
+const tile = ([x, y]: Vector): SolidBox => ({
+  min: [x, y],
+  max: [x + 1, y + 1],
+});
 
 describe("stepPlayerMotion", () => {
   it("moves in the input direction at speed * dt", () => {
-    const next = stepPlayerMotion([0.5, 0.5], [1, 0], 2, 0.25, openFloor);
-    assert.strictEqual(next[0], 1);
-    assert.strictEqual(next[1], 0.5);
+    const next = stepPlayerMotion([5.5, 5.5], [1, 0], 2, 0.25, world());
+    assert.strictEqual(next[0], 6);
+    assert.strictEqual(next[1], 5.5);
   });
 
   it("stands still with no input", () => {
-    const next = stepPlayerMotion([0.5, 0.5], [0, 0], 2, 0.25, openFloor);
-    assert.deepStrictEqual(next, [0.5, 0.5]);
+    const next = stepPlayerMotion([5.5, 5.5], [0, 0], 2, 0.25, world());
+    assert.deepStrictEqual(next, [5.5, 5.5]);
   });
 
   it("normalizes diagonal input so it isn't faster", () => {
-    const next = stepPlayerMotion([0.5, 0.5], [1, 1], 1, 1, openFloor);
-    const traveled = Math.hypot(next[0] - 0.5, next[1] - 0.5);
+    const next = stepPlayerMotion([5.5, 5.5], [1, 1], 1, 1, world());
+    const traveled = Math.hypot(next[0] - 5.5, next[1] - 5.5);
     assert.ok(Math.abs(traveled - 1) < 1e-9);
   });
 
-  it("stops at a blocked cell's edge", () => {
-    const next = stepPlayerMotion([0.5, 0.5], [1, 0], 10, 1, machineAt([1, 0]));
-    assert.ok(next[0] <= 1 - PLAYER_RADIUS);
-    assert.ok(next[0] > 1 - PLAYER_RADIUS - 0.01);
-  });
-
-  it("stops at walls in the negative direction too", () => {
+  it("stops at a solid tile's face", () => {
     const next = stepPlayerMotion(
-      [0.5, 0.5],
-      [-1, 0],
-      10,
-      1,
-      machineAt([-1, 0]),
-    );
-    assert.ok(next[0] >= PLAYER_RADIUS);
-    assert.ok(next[0] < PLAYER_RADIUS + 0.01);
-  });
-
-  it("slides along a wall on diagonal input", () => {
-    // Wall of machines along y = -1; pushing up-right should still travel right
-    const isBlocked = ([, y]: Vector) => (y < 0 ? SOLID_CELL : undefined);
-    const next = stepPlayerMotion([0.5, 0.5], [1, -1], 2, 0.5, isBlocked);
-    assert.ok(next[0] > 0.5, "should slide along the x axis");
-    assert.ok(next[1] >= PLAYER_RADIUS, "should stay off the wall");
-  });
-
-  it("clips a shoulder poking into a blocked neighbor row", () => {
-    // Standing low in row 1, the body overlaps row 2; a machine at [1, 2]
-    // catches the shoulder even though the center row ahead is clear.
-    const next = stepPlayerMotion([0.5, 1.8], [1, 0], 10, 1, machineAt([1, 2]));
-    assert.ok(next[0] <= 1 - PLAYER_RADIUS, "corner clips the shoulder");
-  });
-
-  it("checks both rows the body overlaps, not just the center row", () => {
-    // Standing near the top edge of row 1: the body pokes into row 0, so a
-    // machine in row 0 ahead must still block.
-    const next = stepPlayerMotion(
-      [0.5, 1 + PLAYER_RADIUS / 2],
+      [5.5, 5.5],
       [1, 0],
       10,
       1,
-      machineAt([1, 0]),
+      world([tile([7, 5])]),
     );
-    assert.ok(next[0] <= 1 - PLAYER_RADIUS);
+    assert.ok(next[0] <= 7 - PLAYER_RADIUS);
+    assert.ok(next[0] > 7 - PLAYER_RADIUS - 0.01);
   });
 
-  it("walks up to a slim machine's box, past its tile edge", () => {
-    // A machine at [1, 0] inset 0.2 from every edge: the body's leading
-    // edge should rest at the box face (x = 1.2), not the tile edge.
+  it("stops at a solid approaching from the right too", () => {
     const next = stepPlayerMotion(
-      [0.5, 0.5],
-      [1, 0],
-      10,
-      1,
-      insetMachineAt([1, 0], 0.2),
-    );
-    assert.ok(next[0] <= 1.2 - PLAYER_RADIUS);
-    assert.ok(next[0] > 1.2 - PLAYER_RADIUS - 0.01);
-  });
-
-  it("stops at the far face approaching a slim machine from the right", () => {
-    const next = stepPlayerMotion(
-      [0.5, 0.5],
+      [5.5, 5.5],
       [-1, 0],
       10,
       1,
-      insetMachineAt([-1, 0], 0.2),
+      world([tile([3, 5])]),
     );
-    assert.ok(next[0] >= -0.2 + PLAYER_RADIUS);
-    assert.ok(next[0] < -0.2 + PLAYER_RADIUS + 0.01);
+    assert.ok(next[0] >= 4 + PLAYER_RADIUS);
+    assert.ok(next[0] < 4 + PLAYER_RADIUS + 0.01);
   });
 
-  it("slides along a slim machine's face while pressed into its tile", () => {
-    // Pressed flush against the box at [1, 0] (leading edge just short of
-    // x = 1.2, inside the machine's tile), walking down must not catch on
-    // the tile boundary.
-    const pressed: Vector = [1.2 - PLAYER_RADIUS - 1e-4, 0.5];
+  it("stops at the shop walls", () => {
+    const next = stepPlayerMotion([1, 1], [-1, -1], 10, 1, world([], [12, 16]));
+    assert.deepStrictEqual(next, [PLAYER_RADIUS, PLAYER_RADIUS]);
+  });
+
+  it("slides along a wall of solids on diagonal input", () => {
+    // Solids along the row above; pushing up-right should still travel right
+    const wall = { min: [0, 4] as Vector, max: [100, 5] as Vector };
     const next = stepPlayerMotion(
-      pressed,
-      [0, 1],
+      [5.5, 5 + PLAYER_RADIUS],
+      [1, -1],
       2,
-      1,
-      insetMachineAt([1, 0], 0.2),
+      0.5,
+      world([wall]),
     );
-    assert.strictEqual(next[0], pressed[0]);
-    assert.ok(next[1] > 2, "should walk down freely along the face");
+    assert.ok(next[0] > 5.5, "should slide along the x axis");
+    assert.ok(next[1] >= 5 + PLAYER_RADIUS - 1e-3, "should stay off the wall");
   });
 
-  it("lets a shoulder pass a neighbor cell whose box is inset out of reach", () => {
-    // Standing low in row 1 the body pokes into row 2, but the machine at
-    // [1, 2] holds its solid area 0.25 in from the shared edge — beyond
-    // the shoulder's reach, so the old corner clip doesn't happen.
+  it("clips a shoulder poking into a solid in a neighboring row", () => {
+    // The body is wider than a cell: standing with its center in one row,
+    // its shoulder overlaps the next row, so a solid there still blocks.
     const next = stepPlayerMotion(
-      [0.5, 1.8],
+      [5.5, 5.5 + PLAYER_RADIUS / 2],
       [1, 0],
       10,
       1,
-      insetMachineAt([1, 2], 0.25),
+      world([tile([7, 6])]),
     );
-    assert.ok(next[0] > 1, "shoulder passes the inset box");
+    assert.ok(next[0] <= 7 - PLAYER_RADIUS, "corner clips the shoulder");
+  });
+
+  it("walks up to a machine's box, past its tile edge", () => {
+    // A box inset 0.2 into its tile: the body's leading edge rests at the
+    // box face, not the tile boundary.
+    const box: SolidBox = { min: [7.2, 5.2], max: [7.8, 5.8] };
+    const next = stepPlayerMotion([5.5, 5.5], [1, 0], 10, 1, world([box]));
+    assert.ok(next[0] <= 7.2 - PLAYER_RADIUS);
+    assert.ok(next[0] > 7.2 - PLAYER_RADIUS - 0.01);
+  });
+
+  it("slides along a box's face while pressed against it", () => {
+    const box: SolidBox = { min: [7.2, 0], max: [7.8, 100] };
+    const pressed: Vector = [7.2 - PLAYER_RADIUS - 1e-4, 5.5];
+    const next = stepPlayerMotion(pressed, [0, 1], 2, 1, world([box]));
+    assert.strictEqual(next[0], pressed[0]);
+    assert.ok(next[1] > 7, "should walk down freely along the face");
+  });
+
+  it("lets a shoulder pass a box held out of reach", () => {
+    // The solid sits more than a body radius from the body's path, so
+    // walking past must not catch on it.
+    const box: SolidBox = {
+      min: [7, 5.5 + PLAYER_RADIUS + 0.05],
+      max: [8, 7],
+    };
+    const next = stepPlayerMotion([5.5, 5.5], [1, 0], 10, 1, world([box]));
+    assert.ok(next[0] > 8, "shoulder passes the distant box");
+  });
+
+  it("does not tunnel through a solid on a long step", () => {
+    const next = stepPlayerMotion(
+      [5.5, 5.5],
+      [1, 0],
+      1000,
+      1,
+      world([tile([7, 5])]),
+    );
+    assert.ok(next[0] <= 7 - PLAYER_RADIUS, "a dropped frame still stops");
+  });
+
+  it("can walk out of a box it starts inside, but not deeper in", () => {
+    // A fixture teleport can drop the body's margin over a solid; the
+    // sweep must allow escape and refuse to dig further.
+    const box: SolidBox = { min: [5, 5], max: [6, 6] };
+    const start: Vector = [5.5 + PLAYER_RADIUS, 5.5];
+    const out = stepPlayerMotion(start, [1, 0], 2, 1, world([box]));
+    assert.ok(out[0] > start[0], "walking away from the overlap works");
+    const deeper = stepPlayerMotion(start, [-1, 0], 2, 1, world([box]));
+    assert.ok(deeper[0] <= start[0], "cannot press further into the solid");
   });
 });
 
@@ -175,8 +173,12 @@ describe("playerWalkSpeed", () => {
   });
 
   it("slows to a wade in a deep drift", () => {
-    // A full cell of dust is +3 tick-equivalents: quarter speed
-    const state = { ...initialGameState, dust: { "0,0": { pine: 100 } } };
+    // A full cell of dust underfoot is +3 tick-equivalents: quarter speed
+    const underfoot = initialGameState.player.position.join(",");
+    const state = {
+      ...initialGameState,
+      dust: { [underfoot]: { pine: DUST_MAX_PER_CELL } },
+    };
     assert.strictEqual(playerWalkSpeed(state), BASE_WALK_SPEED / 4);
   });
 });

--- a/src/game/player-motion.ts
+++ b/src/game/player-motion.ts
@@ -12,21 +12,26 @@ import { Direction, Vector } from "./Vectors";
  * here is pure so it can be unit-tested without PIXI or React.
  */
 
-/** Walking pace on a clean floor, in cells per second. */
-export const BASE_WALK_SPEED = 3.5;
+/** Walking pace on a clean floor, in cells (feet) per second. */
+export const BASE_WALK_SPEED = 9.3;
 
-/** Body radius in cells — small enough to slip down one-cell aisles. */
-export const PLAYER_RADIUS = 0.3;
+/**
+ * Body radius in cells (feet) — just under 10 inches, so a 2-cell gap
+ * between machines is a walkable aisle and a 1-cell gap is not. The body
+ * spans several 1-ft cells; only the cell under its center is the "cell
+ * underfoot" the simulation tracks.
+ */
+export const PLAYER_RADIUS = 0.8;
 
-/** Keeps a resting body from straddling a cell boundary exactly. */
+/** Keeps a resting body from sitting exactly on a solid's face. */
 const EDGE_EPSILON = 1e-4;
 
 /**
  * The player's walking speed right now, in cells per second. The old
  * grid walk charged extra ticks per step (deep sawdust, dragging the
  * vac, a machine over the shoulders); those same penalties now stretch
- * the time a cell takes to cross instead: each extra tick-equivalent
- * divides speed by one more.
+ * the time a stretch of floor takes to cross instead: each extra
+ * tick-equivalent divides speed by one more.
  */
 export function playerWalkSpeed(gameState: GameState): number {
   const carried = gameState.player.carriedMachine;
@@ -57,42 +62,44 @@ export function directionFromInput(
 }
 
 /**
- * How far a blocked cell's solid area sits in from each tile edge, in
- * cells: `left`/`right` from the low-x/high-x edges, `top`/`bottom` from
- * the low-y/high-y edges (screen y grows downward). All zeros — the whole
- * tile is solid — is a wall or a machine with no collision box; a slim
- * machine reports positive insets so the body can walk up to what's
- * actually drawn. Insets are capped below PLAYER_RADIUS (see
- * MAX_COLLISION_INSET in machine-collision.ts) so the body's center can
- * never cross into a blocked cell.
+ * An axis-aligned solid the body cannot enter, in continuous cell
+ * coordinates (cell [x, y] spans x..x+1). Machines contribute their
+ * collision boxes (or their whole occupied tiles when they have none);
+ * the shop walls are handled separately as the world bounds. See
+ * machine-collision.ts.
  */
-export type CellInsets = {
-  readonly left: number;
-  readonly right: number;
-  readonly top: number;
-  readonly bottom: number;
-};
+export interface SolidBox {
+  readonly min: Vector;
+  readonly max: Vector;
+}
 
-/** A cell whose whole tile blocks: walls, and machines without a box. */
-export const SOLID_CELL: CellInsets = { left: 0, right: 0, top: 0, bottom: 0 };
+/** What the body collides with: the shop's floor rectangle and solids. */
+export interface CollisionWorld {
+  /** Shop size in cells; the walls are the rectangle's edges. */
+  readonly size: Vector;
+  readonly solids: ReadonlyArray<SolidBox>;
+}
 
 /**
  * Advance the player's continuous position by one frame: normalize the
- * input, integrate, and slide along anything solid. `obstructionAt` gives
- * a cell's solid area as edge insets, or undefined for open floor (see
- * cellObstruction in machine-collision.ts).
+ * input, integrate, and slide along anything solid.
  *
- * Collision is axis-separated circle-vs-box: each axis moves on its own
- * and clamps against the face of any solid area the body would overlap.
- * Running diagonally into a machine therefore glides along its face
- * instead of sticking — most of what makes walking feel physical.
+ * Collision is axis-separated body-vs-box: each axis moves on its own and
+ * clamps the body's leading edge against any solid whose cross-axis span
+ * it overlaps. Running diagonally into a machine therefore glides along
+ * its face instead of sticking — most of what makes walking feel physical.
+ * The clamp compares the start and end of the whole step, so a long step
+ * (a dropped frame) stops at the face instead of tunneling through. A box
+ * the body already overlaps (a fixture teleport, a machine set down over
+ * the body's margin) never clamps — the body can always walk out, it just
+ * can't press further in.
  */
 export function stepPlayerMotion(
   pos: Vector,
   input: Vector,
   speed: number,
   dt: number,
-  obstructionAt: (cell: Vector) => CellInsets | undefined,
+  world: CollisionWorld,
   radius: number = PLAYER_RADIUS,
 ): Vector {
   let [dx, dy] = input;
@@ -106,89 +113,59 @@ export function stepPlayerMotion(
   }
 
   let [x, y] = pos;
-
-  // Each axis sweeps every cell boundary the leading edge crosses, so a
-  // long step (a dropped frame) clamps at the first solid cell instead
-  // of tunneling through it. A lane only counts when the body actually
-  // overlaps its solid span on the cross axis — pressed flush against a
-  // slim machine, the body edge sits inside the machine's *tile* but not
-  // its box, and must still slide freely along its face.
-  x = sweepAxis(x, dx * speed * dt, radius, (lane, dir) => {
-    let inset: number | undefined;
-    for (const row of cellSpan(y, radius)) {
-      const o = obstructionAt([lane, row]);
-      if (o === undefined) continue;
-      if (y + radius - EDGE_EPSILON <= row + o.top) continue;
-      if (y - radius + EDGE_EPSILON >= row + 1 - o.bottom) continue;
-      const face = dir > 0 ? o.left : o.right;
-      inset = inset === undefined ? face : Math.min(inset, face);
-    }
-    return inset;
-  });
-  y = sweepAxis(y, dy * speed * dt, radius, (lane, dir) => {
-    let inset: number | undefined;
-    for (const col of cellSpan(x, radius)) {
-      const o = obstructionAt([col, lane]);
-      if (o === undefined) continue;
-      if (x + radius - EDGE_EPSILON <= col + o.left) continue;
-      if (x - radius + EDGE_EPSILON >= col + 1 - o.right) continue;
-      const face = dir > 0 ? o.top : o.bottom;
-      inset = inset === undefined ? face : Math.min(inset, face);
-    }
-    return inset;
-  });
-
+  x = sweepAxis(x, y, dx * speed * dt, radius, world, 0);
+  y = sweepAxis(y, x, dy * speed * dt, radius, world, 1);
   return [x, y];
 }
 
 /**
- * Move one coordinate by `step`, stopping the body's leading edge at the
- * first blocked lane (column when sweeping x, row when sweeping y).
- * `laneInset` reports how far the approached face of a lane's solid area
- * sits in from the tile boundary — undefined when the lane is passable at
- * the body's current cross-axis position.
+ * Move one coordinate by `step`, clamping the body's leading edge against
+ * the walls and every solid it would press into. `axis` is the moving
+ * axis (0 = x, 1 = y); `cross` is the body's current position on the
+ * other axis.
  */
 function sweepAxis(
   center: number,
+  cross: number,
   step: number,
   radius: number,
-  laneInset: (lane: number, dir: 1 | -1) => number | undefined,
+  world: CollisionWorld,
+  axis: 0 | 1,
 ): number {
-  if (step === 0) {
-    return center;
-  }
   let next = center + step;
-  if (step > 0) {
-    const first = Math.floor(center + radius + EDGE_EPSILON);
-    const last = Math.floor(next + radius);
-    for (let lane = first; lane <= last; lane++) {
-      const inset = laneInset(lane, 1);
-      if (inset !== undefined) {
-        return Math.min(next, lane + inset - radius - EDGE_EPSILON);
-      }
+
+  // The walls: clamp to the floor rectangle. This also gently pulls in a
+  // body teleported onto the margin (fixtures, loaded saves).
+  const wallMax = world.size[axis] - radius;
+  next = Math.min(Math.max(next, radius), wallMax);
+  if (step === 0) {
+    return next;
+  }
+
+  const crossAxis = (1 - axis) as 0 | 1;
+  for (const solid of world.solids) {
+    // Only solids whose cross-axis span the body actually overlaps can
+    // block this axis — pressed flush alongside a box, the body must
+    // still slide freely along its face.
+    if (
+      cross + radius - EDGE_EPSILON <= solid.min[crossAxis] ||
+      cross - radius + EDGE_EPSILON >= solid.max[crossAxis]
+    ) {
+      continue;
     }
-  } else {
-    const first = Math.floor(center - radius - EDGE_EPSILON);
-    const last = Math.floor(next - radius);
-    for (let lane = first; lane >= last; lane--) {
-      const inset = laneInset(lane, -1);
-      if (inset !== undefined) {
-        return Math.max(next, lane + 1 - inset + radius + EDGE_EPSILON);
+    if (step > 0) {
+      // Clamp only when the step starts outside the box, so a body that
+      // already overlaps one (teleport) can escape but never digs deeper.
+      if (center + radius - EDGE_EPSILON <= solid.min[axis]) {
+        next = Math.min(next, solid.min[axis] - radius - EDGE_EPSILON);
+      }
+    } else {
+      if (center - radius + EDGE_EPSILON >= solid.max[axis]) {
+        next = Math.max(next, solid.max[axis] + radius + EDGE_EPSILON);
       }
     }
   }
   return next;
-}
-
-/** The cell indices a body at `center` with `radius` overlaps on one axis. */
-function cellSpan(center: number, radius: number): number[] {
-  const first = Math.floor(center - radius + EDGE_EPSILON);
-  const last = Math.floor(center + radius - EDGE_EPSILON);
-  const span = [];
-  for (let i = first; i <= last; i++) {
-    span.push(i);
-  }
-  return span;
 }
 
 /** The cell a continuous position stands in. */

--- a/src/game/saveLoad.test.ts
+++ b/src/game/saveLoad.test.ts
@@ -100,10 +100,11 @@ describe("migrateV16toV17", () => {
     assert.strictEqual(planer.selectedOperationId, "plane");
     // The crank position carries over
     assert.deepStrictEqual(planer.selectedParameters, { targetThickness: 3 });
-    // Staged stock lands as a pile at the infeed cell
+    // Staged stock lands as a pile at the infeed cell (computed with the
+    // current planer footprint — v24 relocates every pile anyway)
     assert.deepStrictEqual(planer.inputMaterials, []);
     assert.deepStrictEqual(migrated.materialPiles, [
-      { material: staged, position: [1, 2] },
+      { material: staged, position: [1, 3] },
     ]);
     // Other machines untouched
     assert.strictEqual(migrated.machines[1].selectedOperationId, "jointFace");
@@ -151,10 +152,11 @@ describe("migrateV17toV18", () => {
     };
     const migrated = migrateV17toV18(old);
     const saw = migrated.machines[0];
-    // The staged board lands at the saw's operator cell
+    // The staged board lands at the saw's operator cell (computed with
+    // the current footprint — v24 relocates every pile anyway)
     assert.deepStrictEqual(saw.inputMaterials, []);
     assert.deepStrictEqual(migrated.materialPiles, [
-      { material: staged, position: [2, 5] },
+      { material: staged, position: [2, 6] },
     ]);
     // Dialed settings survive, with the operation's other defaults beneath
     // (the stray targetLength rides along until v20 → v21 converts it)

--- a/src/game/saveLoad.ts
+++ b/src/game/saveLoad.ts
@@ -7,7 +7,7 @@ import { defaultParametersFor } from "./operation-helpers";
 import { defaultEntrancePosition } from "./ShopInfo";
 
 const SAVE_KEY = "woodworking-tycoon-save";
-const SAVE_VERSION = 23; // Increment this when GameState structure changes
+const SAVE_VERSION = 24; // Increment this when GameState structure changes
 
 interface SaveData {
   version: number;
@@ -107,6 +107,11 @@ export function loadGame(): GameState | null {
     if (saveData.version === 22) {
       saveData.gameState = migrateV22toV23(saveData.gameState);
       saveData.version = 23;
+    }
+
+    if (saveData.version === 23) {
+      saveData.gameState = migrateV23toV24(saveData.gameState);
+      saveData.version = 24;
     }
 
     // Check version - if it doesn't match, the save is incompatible
@@ -226,6 +231,100 @@ export function migrateV13toV14(old: any): GameState {
         machineId === "makeshiftBench" ? "worktable1x1" : machineId,
       ),
     },
+  };
+}
+
+/**
+ * v23 → v24: the grid went from 32-inch cells to 1-ft cells and every
+ * machine grew a real multi-cell footprint, so old-grid coordinates mean
+ * nothing anymore. There's no clean mapping (32/12 isn't an integer), so
+ * the migration is moving day: the shop becomes the new 12'×16' garage,
+ * every placed machine is re-crated by the door (tools, upgrades, and
+ * shelf stock ride along inside; work-in-progress materials land as piles
+ * at the dropoff), floor piles stack at the dropoff, and the floor comes
+ * up swept. Money, reputation, skills, listings, and jobs are untouched.
+ */
+export function migrateV23toV24(old: any): GameState {
+  const size: [number, number] = [12, 16];
+  const entrancePosition = defaultEntrancePosition(size);
+  const materialDropoffPosition: [number, number] = [10, 13];
+
+  // Crates line up in rows working back from the door, two cells apart so
+  // each stays reachable.
+  const cratePosition = (index: number): [number, number] => [
+    1 + (index % 5) * 2,
+    12 - Math.floor(index / 5) * 2,
+  ];
+
+  const strandedMaterials: any[] = [];
+  const crateMachine = (machineState: any) => {
+    strandedMaterials.push(
+      ...machineState.inputMaterials,
+      ...machineState.processingMaterials,
+      ...machineState.outputMaterials,
+    );
+    return {
+      ...machineState,
+      position: [0, 0],
+      rotation: 0,
+      inputMaterials: [],
+      processingMaterials: [],
+      outputMaterials: [],
+      operationProgress: {
+        status: "notStarted",
+        phaseIndex: 0,
+        ticksRemaining: 0,
+      },
+    };
+  };
+
+  const cratedMachines = [
+    ...old.machines.map(crateMachine),
+    ...(old.player.carriedMachine
+      ? [crateMachine(old.player.carriedMachine)]
+      : []),
+    ...old.machineCrates.map((crate: any) => crateMachine(crate.machine)),
+  ];
+
+  return {
+    ...old,
+    shopInfo: {
+      ...old.shopInfo,
+      size,
+      entrancePosition,
+      materialDropoffPosition,
+    },
+    machines: [],
+    machineCrates: cratedMachines.map((machine: any, index: number) => ({
+      machine,
+      position: cratePosition(index),
+    })),
+    materialPiles: [
+      ...old.materialPiles.map((pile: any) => ({
+        ...pile,
+        position: materialDropoffPosition,
+      })),
+      ...strandedMaterials.map((material: any) => ({
+        material,
+        position: materialDropoffPosition,
+      })),
+    ],
+    shopVac: old.shopVac
+      ? {
+          ...old.shopVac,
+          position:
+            old.shopVac.position === null ? null : materialDropoffPosition,
+        }
+      : null,
+    player: {
+      ...old.player,
+      position: [6, 12],
+      direction: 1,
+      carriedMachine: null,
+      workQueue: [],
+      busyTicks: 0,
+    },
+    dust: {},
   };
 }
 

--- a/src/game/shop-scale.ts
+++ b/src/game/shop-scale.ts
@@ -1,0 +1,27 @@
+/**
+ * The shop's physical scale. One grid cell is one square foot of floor —
+ * the grid exists for machine placement and cell-based bookkeeping (dust,
+ * piles, targeting); the player's body moves continuously through it (see
+ * docs/continuous-movement.md).
+ *
+ * This is the game-logic side of the scale. Rendering constants
+ * (pixels per inch, pixels per cell) live in
+ * src/components/shop-view/shop-scale.tsx and derive from these.
+ */
+export const INCHES_PER_FOOT = 12;
+
+/** Side length of one grid cell, in inches. A cell is one square foot. */
+export const INCHES_PER_CELL = 12;
+
+/** Grid cells per foot of real shop. With 1-ft cells this is 1, so feet
+ * and cells are interchangeable — kept as a named constant so the
+ * conversion sites stay findable if the grid ever changes again. */
+export const CELLS_PER_FOOT = INCHES_PER_FOOT / INCHES_PER_CELL;
+
+export function feetToCells(feet: number): number {
+  return feet * CELLS_PER_FOOT;
+}
+
+export function inchesToCells(inches: number): number {
+  return inches / INCHES_PER_CELL;
+}

--- a/src/game/shortcuts.ts
+++ b/src/game/shortcuts.ts
@@ -19,7 +19,11 @@ export type ShortcutScope = "global" | "home" | "modal";
 
 /** Cheat-sheet section. Order here is the order rendered. */
 export type ShortcutGroup =
-  "Time" | "Movement" | "Materials" | "Machines" | "General";
+  | "Time"
+  | "Movement"
+  | "Materials"
+  | "Machines"
+  | "General";
 
 export const SHORTCUT_GROUPS: readonly ShortcutGroup[] = [
   "Movement",

--- a/tests/attended-operations.spec.ts
+++ b/tests/attended-operations.spec.ts
@@ -9,7 +9,7 @@ declare global {
   }
 }
 
-const WORKSPACE_CELL: [number, number] = [1, 3];
+const WORKSPACE_CELL: [number, number] = [1, 4];
 const FAR_AWAY: [number, number] = [0, 0];
 
 function workspaceCard(page: any) {

--- a/tests/carry-machines.spec.ts
+++ b/tests/carry-machines.spec.ts
@@ -49,7 +49,7 @@ test.describe("Carrying machines", () => {
     });
 
     await test.step("the carry verb hides until unlocked", async () => {
-      await teleportPlayer(page, [2, 5]);
+      await teleportPlayer(page, [6, 8]);
       // A miter saw anywhere re-unlocks the flag on the next tick, so gate
       // the check on a jointer crate — jointers don't trip the unlock
       await page.evaluate(() => {
@@ -68,7 +68,7 @@ test.describe("Carrying machines", () => {
       expect(await carried(page)).toBeNull();
       // Back to the real fixture for the rest of the walkthrough
       await loadFixture(page, "miter-saw-crate-shop");
-      await teleportPlayer(page, [2, 5]);
+      await teleportPlayer(page, [6, 8]);
     });
 
     await test.step("unpack the delivered crate underfoot", async () => {
@@ -95,7 +95,7 @@ test.describe("Carrying machines", () => {
     });
 
     await test.step("set it down standing at its operator cell", async () => {
-      await teleportPlayer(page, [2, 2]);
+      await teleportPlayer(page, [6, 8]);
       await page.keyboard.press("l");
       await page.waitForTimeout(200);
       const state = await page.evaluate(() => window.__GET_GAME_STATE__());
@@ -103,8 +103,8 @@ test.describe("Carrying machines", () => {
       const saw = state.machines.find(
         (m: any) => m.machineTypeId === "miterSaw",
       );
-      // Anchored one cell in front: the player's cell is the operator cell
-      expect(saw.position).toEqual([2, 1]);
+      // Anchored two cells in front: the player's cell is the operator cell
+      expect(saw.position).toEqual([6, 6]);
     });
 
     await test.step("lift the placed machine back up from the same spot", async () => {
@@ -120,9 +120,9 @@ test.describe("Carrying machines", () => {
 
     await test.step("a loaded machine refuses to be lifted", async () => {
       await loadFixture(page, "layout-with-placed-machines");
-      // The fixture's miter saw at [2,4] holds a board; stand at its
+      // The fixture's miter saw at [6,3] holds a board; stand at its
       // operator cell and try
-      await teleportPlayer(page, [2, 5]);
+      await teleportPlayer(page, [6, 5]);
       await expect(page.getByText("Pick up Miter Saw")).toHaveCount(0);
       await page.keyboard.press("l");
       await page.waitForTimeout(200);
@@ -130,8 +130,8 @@ test.describe("Carrying machines", () => {
     });
 
     await test.step("carry a worktable to a new spot", async () => {
-      // The fixture's small worktable at [0,4] operates from [0,5]
-      await teleportPlayer(page, [0, 5]);
+      // The fixture's small worktable at [9,2] operates from [9,4]
+      await teleportPlayer(page, [9, 4]);
       const machineHint = page.getByText(/plans & tools/i);
       await expect(machineHint.first()).toBeVisible();
       await page.keyboard.press("l");
@@ -140,7 +140,7 @@ test.describe("Carrying machines", () => {
       // Hands full: the machine's hint chips are suppressed
       await expect(machineHint).toHaveCount(0);
 
-      await teleportPlayer(page, [1, 5]);
+      await teleportPlayer(page, [5, 10]);
       await page.keyboard.press("l");
       await page.waitForTimeout(200);
       const state = await page.evaluate(() => window.__GET_GAME_STATE__());
@@ -148,7 +148,7 @@ test.describe("Carrying machines", () => {
       const table = state.machines.find(
         (m: any) => m.machineTypeId === "worktable1x1",
       );
-      expect(table.position).toEqual([1, 4]);
+      expect(table.position).toEqual([5, 8]);
       // Standing at the freshly placed table's operator cell brings it back
       await expect(page.getByText(/plans & tools/i).first()).toBeVisible();
     });
@@ -174,8 +174,8 @@ test.describe("Carrying machines", () => {
       expect(state.machineCrates[0].machine.machineTypeId).toBe(
         "jobsiteTableSaw",
       );
-      // Nearest open floor to the entrance [2,5]
-      expect(state.machineCrates[0].position).toEqual([2, 5]);
+      // Nearest open floor to the entrance [6,15]
+      expect(state.machineCrates[0].position).toEqual([6, 15]);
     });
   });
 });

--- a/tests/end-grain.spec.ts
+++ b/tests/end-grain.spec.ts
@@ -16,8 +16,8 @@ declare global {
   }
 }
 
-const WORKSPACE_CELL: [number, number] = [1, 3];
-const SAW_CELL: [number, number] = [2, 5];
+const WORKSPACE_CELL: [number, number] = [1, 4];
+const SAW_CELL: [number, number] = [6, 5];
 
 function card(page: any, name: string) {
   return page.locator("section", { hasText: name });
@@ -166,7 +166,7 @@ test.describe("End-Grain Boards", () => {
         page,
         "Jobsite Table Saw",
         `(mat) => mat.type === "endGrainSlice"`,
-        [2, 3], // the saw's outfeed cell
+        [6, 1], // the saw's outfeed cell
         "Feed",
       );
       const sliceCount = await page.evaluate(

--- a/tests/fixtures/consumables-shop.ts
+++ b/tests/fixtures/consumables-shop.ts
@@ -18,7 +18,7 @@ export const consumablesShop: GameState = {
   consumables: NO_CONSUMABLES,
   player: {
     name: "Player",
-    position: [1, 3], // the workspace's operation cell
+    position: [1, 4], // the workspace's operation cell
     direction: 0,
     inventory: [
       {
@@ -76,9 +76,9 @@ export const consumablesShop: GameState = {
   shopInfo: {
     name: "One Car Garage",
     electricity: 120,
-    size: [4, 6],
-    materialDropoffPosition: [3, 5],
-    entrancePosition: [2, 5],
+    size: [12, 16],
+    materialDropoffPosition: [10, 13],
+    entrancePosition: [6, 15],
   },
   progression: {
     tutorialStage: 2,

--- a/tests/fixtures/cutting-board-shop.ts
+++ b/tests/fixtures/cutting-board-shop.ts
@@ -42,7 +42,7 @@ export const cuttingBoardShop: GameState = {
   materialPiles: [],
   player: {
     name: "Player",
-    position: [1, 3], // the workspace's operation cell
+    position: [1, 4], // the workspace's operation cell
     direction: 0,
     inventory: Array.from({ length: 5 }, (_, i) => ({
       id: `test-strip-${i}`,
@@ -69,9 +69,9 @@ export const cuttingBoardShop: GameState = {
   shopInfo: {
     name: "One Car Garage",
     electricity: 120,
-    size: [4, 6],
-    materialDropoffPosition: [3, 5],
-    entrancePosition: [2, 5],
+    size: [12, 16],
+    materialDropoffPosition: [10, 13],
+    entrancePosition: [6, 15],
   },
   progression: {
     tutorialStage: 2,

--- a/tests/fixtures/end-grain-shop.ts
+++ b/tests/fixtures/end-grain-shop.ts
@@ -74,7 +74,7 @@ export const endGrainShop: GameState = {
   materialPiles: [],
   player: {
     name: "Player",
-    position: [1, 3], // the workspace's operation cell
+    position: [1, 4], // the workspace's operation cell
     direction: 0,
     inventory: [
       sandedBlank,
@@ -88,7 +88,7 @@ export const endGrainShop: GameState = {
   },
   machines: [
     idleMachine("workspace", [1, 2], "dismantlePallet", ["randomOrbitSander"]),
-    idleMachine("jobsiteTableSaw", [2, 4], "ripBoard"),
+    idleMachine("jobsiteTableSaw", [6, 3], "ripBoard"),
   ],
   machineCrates: [],
   storage: {
@@ -98,9 +98,9 @@ export const endGrainShop: GameState = {
   shopInfo: {
     name: "One Car Garage",
     electricity: 120,
-    size: [4, 6],
-    materialDropoffPosition: [3, 5],
-    entrancePosition: [2, 5],
+    size: [12, 16],
+    materialDropoffPosition: [10, 13],
+    entrancePosition: [6, 15],
   },
   progression: {
     tutorialStage: 2,

--- a/tests/fixtures/hand-tools-shop.ts
+++ b/tests/fixtures/hand-tools-shop.ts
@@ -32,7 +32,7 @@ export const handToolsShop: GameState = {
   consumables: NO_CONSUMABLES,
   player: {
     name: "Player",
-    position: [1, 3], // the workspace's operation cell
+    position: [1, 4], // the workspace's operation cell
     direction: 0,
     inventory: [
       deckBoard("fx-long-board", 3),
@@ -71,9 +71,9 @@ export const handToolsShop: GameState = {
   shopInfo: {
     name: "One Car Garage",
     electricity: 120,
-    size: [4, 6],
-    materialDropoffPosition: [3, 5],
-    entrancePosition: [2, 5],
+    size: [12, 16],
+    materialDropoffPosition: [10, 13],
+    entrancePosition: [6, 15],
   },
   progression: {
     tutorialStage: 2,

--- a/tests/fixtures/layout-with-placed-machines.ts
+++ b/tests/fixtures/layout-with-placed-machines.ts
@@ -21,12 +21,12 @@ export const layoutWithPlacedMachines: GameState = {
         jointedFaces: 1,
         jointedEdges: 2,
       },
-      position: [2, 1],
+      position: [4, 5],
     },
   ],
   player: {
     name: "Player",
-    position: [0, 0],
+    position: [5, 6],
     direction: 0,
     inventory: [],
     workQueue: [],
@@ -53,7 +53,7 @@ export const layoutWithPlacedMachines: GameState = {
     },
     {
       machineTypeId: "miterSaw",
-      position: [2, 4],
+      position: [6, 3],
       rotation: 0,
       inputMaterials: [],
       processingMaterials: [],
@@ -83,7 +83,7 @@ export const layoutWithPlacedMachines: GameState = {
     },
     {
       machineTypeId: "worktable1x1",
-      position: [0, 4],
+      position: [9, 2],
       rotation: 0,
       inputMaterials: [],
       processingMaterials: [],
@@ -105,9 +105,9 @@ export const layoutWithPlacedMachines: GameState = {
   shopInfo: {
     name: "One Car Garage",
     electricity: 120,
-    size: [4, 6],
-    materialDropoffPosition: [3, 5],
-    entrancePosition: [2, 5],
+    size: [12, 16],
+    materialDropoffPosition: [10, 13],
+    entrancePosition: [6, 15],
   },
   progression: {
     tutorialStage: 2,

--- a/tests/fixtures/marketplace-shop.ts
+++ b/tests/fixtures/marketplace-shop.ts
@@ -49,9 +49,9 @@ export const marketplaceShop: GameState = {
   shopInfo: {
     name: "One Car Garage",
     electricity: 120,
-    size: [4, 6],
-    materialDropoffPosition: [3, 5],
-    entrancePosition: [2, 5],
+    size: [12, 16],
+    materialDropoffPosition: [10, 13],
+    entrancePosition: [6, 15],
   },
   progression: {
     tutorialStage: 2,

--- a/tests/fixtures/milling-shop.ts
+++ b/tests/fixtures/milling-shop.ts
@@ -46,11 +46,12 @@ function roughWalnut(id: string): Board {
 }
 
 /**
- * The full milling chain, ready to run: jointer (op cell [1,2], where the
- * player starts), planer (op cell [3,2]), table saw with the straight-line
- * sled mounted (op cell [1,5]), and a workspace ([3,5]). Two rough walnut
- * boards in the player's pockets, 22 reputation so every lumber channel is
- * open in the store, and jigsAndFixtures unlocked so the sled operates.
+ * The full milling chain, ready to run: jointer (op cell [2,4], where the
+ * player starts), planer (op cell [6,4]), table saw with the straight-line
+ * sled mounted (op cell [3,11]), and a workspace (op cell [8,11]). Two
+ * rough walnut boards in the player's pockets, 22 reputation so every
+ * lumber channel is open in the store, and jigsAndFixtures unlocked so
+ * the sled operates.
  */
 export const millingShop: GameState = {
   tick: 0,
@@ -60,7 +61,7 @@ export const millingShop: GameState = {
   materialPiles: [],
   player: {
     name: "Player",
-    position: [1, 2], // the jointer's operation cell
+    position: [2, 4], // the jointer's operation cell
     direction: 0,
     inventory: [roughWalnut("test-rough-1"), roughWalnut("test-rough-2")],
     workQueue: [],
@@ -69,14 +70,14 @@ export const millingShop: GameState = {
     away: null,
   },
   machines: [
-    idleMachine("jointer", [1, 1], "jointFace"),
-    idleMachine("lunchboxPlaner", [3, 1], "plane", {
+    idleMachine("jointer", [2, 2], "jointFace"),
+    idleMachine("lunchboxPlaner", [6, 2], "plane", {
       targetThickness: 4,
     }),
-    idleMachine("jobsiteTableSaw", [1, 4], "ripBoard", { targetWidth: 4 }, [
+    idleMachine("jobsiteTableSaw", [3, 9], "ripBoard", { targetWidth: 4 }, [
       "straightLineSled",
     ]),
-    idleMachine("workspace", [3, 4], "glueUpPanel"),
+    idleMachine("workspace", [8, 9], "glueUpPanel"),
   ],
   machineCrates: [],
   storage: {
@@ -86,9 +87,9 @@ export const millingShop: GameState = {
   shopInfo: {
     name: "One Car Garage",
     electricity: 120,
-    size: [4, 6],
-    materialDropoffPosition: [3, 5],
-    entrancePosition: [2, 5],
+    size: [12, 16],
+    materialDropoffPosition: [10, 13],
+    entrancePosition: [6, 15],
   },
   progression: {
     tutorialStage: 2,

--- a/tests/fixtures/miter-frame-shop.ts
+++ b/tests/fixtures/miter-frame-shop.ts
@@ -56,8 +56,8 @@ function rail(id: string): Board {
 }
 
 /**
- * The picture frame chain, ready to run: a miter saw (op cell [1,2], where
- * the player starts) and a workspace ([3,2]). One long stick of walnut
+ * The picture frame chain, ready to run: a miter saw (op cell [2,4], where
+ * the player starts) and a workspace (op cell [7,4]). One long stick of walnut
  * frame stock to cut the last rail from, three rails already mitered,
  * nails in the drawer, and the miteredFrames skill unlocked.
  */
@@ -69,7 +69,7 @@ export const miterFrameShop: GameState = {
   materialPiles: [],
   player: {
     name: "Player",
-    position: [1, 2], // the miter saw's operation cell
+    position: [2, 4], // the miter saw's operation cell
     direction: 0,
     inventory: [
       frameStock("test-stock-1", 8),
@@ -83,11 +83,11 @@ export const miterFrameShop: GameState = {
     away: null,
   },
   machines: [
-    idleMachine("miterSaw", [1, 1], "cutBoard", {
+    idleMachine("miterSaw", [2, 2], "cutBoard", {
       angle: 0,
       cutPosition: 4,
     }),
-    idleMachine("workspace", [3, 1], "buildPictureFrame"),
+    idleMachine("workspace", [7, 2], "buildPictureFrame"),
   ],
   machineCrates: [],
   storage: {
@@ -97,9 +97,9 @@ export const miterFrameShop: GameState = {
   shopInfo: {
     name: "One Car Garage",
     electricity: 120,
-    size: [4, 6],
-    materialDropoffPosition: [3, 5],
-    entrancePosition: [2, 5],
+    size: [12, 16],
+    materialDropoffPosition: [10, 13],
+    entrancePosition: [6, 15],
   },
   progression: {
     tutorialStage: 2,

--- a/tests/fixtures/miter-saw-crate-shop.ts
+++ b/tests/fixtures/miter-saw-crate-shop.ts
@@ -57,7 +57,7 @@ export const miterSawCrateShop: GameState = {
           ticksRemaining: 0,
         },
       },
-      position: [2, 5],
+      position: [6, 8],
     },
   ],
   storage: {
@@ -67,9 +67,9 @@ export const miterSawCrateShop: GameState = {
   shopInfo: {
     name: "One Car Garage",
     electricity: 120,
-    size: [4, 6],
-    materialDropoffPosition: [3, 5],
-    entrancePosition: [2, 5],
+    size: [12, 16],
+    materialDropoffPosition: [10, 13],
+    entrancePosition: [6, 15],
   },
   progression: {
     tutorialStage: 2,

--- a/tests/fixtures/pattern-board-shop.ts
+++ b/tests/fixtures/pattern-board-shop.ts
@@ -77,7 +77,7 @@ export const patternBoardShop: GameState = {
   materialPiles: [],
   player: {
     name: "Player",
-    position: [1, 3], // the workspace's operation cell
+    position: [1, 4], // the workspace's operation cell
     direction: 0,
     inventory: [
       stripedBlank,
@@ -104,9 +104,9 @@ export const patternBoardShop: GameState = {
   shopInfo: {
     name: "One Car Garage",
     electricity: 120,
-    size: [4, 6],
-    materialDropoffPosition: [3, 5],
-    entrancePosition: [2, 5],
+    size: [12, 16],
+    materialDropoffPosition: [10, 13],
+    entrancePosition: [6, 15],
   },
   progression: {
     tutorialStage: 2,

--- a/tests/milling.spec.ts
+++ b/tests/milling.spec.ts
@@ -146,7 +146,7 @@ test.describe("Milling chain (rough lumber to S4S)", () => {
       await waitForBoard(page, "b.jointedFaces === 1");
       // Finished stock lands at the outfeed side — collect it there
       // (Shift+E takes everything within reach)
-      await movePlayerTo(page, [1, 0]);
+      await movePlayerTo(page, [2, 0]);
       await takeAllHere(page);
       // One flat face and the label says so
       await expect(
@@ -157,18 +157,18 @@ test.describe("Milling chain (rough lumber to S4S)", () => {
       ).toBeVisible();
       // Back around to the infeed; feeding the same board again is now an
       // edge pass — the flat face rides the fence
-      await movePlayerTo(page, [1, 2]);
+      await movePlayerTo(page, [2, 4]);
       await openStationSheet(page);
       await machineCard(page, "Jointer")
         .getByRole("button", { name: "Feed" })
         .click();
       await waitForBoard(page, "b.jointedFaces === 1 && b.jointedEdges === 1");
-      await movePlayerTo(page, [1, 0]);
+      await movePlayerTo(page, [2, 0]);
       await takeAllHere(page);
     });
 
     await test.step("table saw: an edge-jointed board rips against the fence", async () => {
-      await movePlayerTo(page, [1, 5]);
+      await movePlayerTo(page, [3, 11]);
       // P flips the switch on the machine the player is standing at
       await page.keyboard.press("p");
       await openStationSheet(page);
@@ -180,12 +180,12 @@ test.describe("Milling chain (rough lumber to S4S)", () => {
         .click();
       // The kept piece has both edges straight; the offcut keeps one
       await waitForBoard(page, "b.width === 4 && b.jointedEdges === 2");
-      await movePlayerTo(page, [1, 3]);
+      await movePlayerTo(page, [3, 7]);
       await takeAllHere(page);
     });
 
     await test.step("planer: no load step — stock feeds straight from the hands", async () => {
-      await movePlayerTo(page, [3, 2]);
+      await movePlayerTo(page, [6, 4]);
       // No input bay: the inventory offers no load button for the planer
       await expect(page.getByRole("button", { name: "→ Planer" })).toHaveCount(
         0,
@@ -217,7 +217,7 @@ test.describe("Milling chain (rough lumber to S4S)", () => {
         page,
         "b.jointedFaces === 2 && b.jointedEdges === 2 && b.thickness === 4 && b.surface === 'smooth'",
       );
-      await movePlayerTo(page, [3, 0]);
+      await movePlayerTo(page, [6, 0]);
       await takeAllHere(page);
       // The inventory names the finished state
       await expect(
@@ -229,7 +229,7 @@ test.describe("Milling chain (rough lumber to S4S)", () => {
     });
 
     await test.step("planer: a full-depth pass takes exactly one detent off", async () => {
-      await movePlayerTo(page, [3, 2]);
+      await movePlayerTo(page, [6, 4]);
       // One detent under the 4/4 stock: a full bite. The first carried
       // piece this setting can take is the 2"-wide rip offcut.
       await setParameter(page, "Planer", "Cut Height", "3/4");
@@ -240,7 +240,7 @@ test.describe("Milling chain (rough lumber to S4S)", () => {
         page,
         "b.width === 2 && b.thickness === 3 && b.surface === 'smooth'",
       );
-      await movePlayerTo(page, [3, 0]);
+      await movePlayerTo(page, [6, 0]);
       await takeAllHere(page);
       await expect(
         page
@@ -252,10 +252,10 @@ test.describe("Milling chain (rough lumber to S4S)", () => {
 
     await test.step("straight-line sled: a rough board rides the sled, not the fence", async () => {
       // Fetch the spare rough board parked by the jointer at the start
-      await movePlayerTo(page, [1, 2]);
+      await movePlayerTo(page, [2, 4]);
       await page.getByRole("button", { name: "Pick Up" }).click();
       await page.waitForTimeout(200);
-      await movePlayerTo(page, [1, 5]);
+      await movePlayerTo(page, [3, 11]);
       // No mode: a rough edge can't ride the fence, so feeding this board
       // runs the mounted straight-line sled
       await openStationSheet(page);

--- a/tests/miter-frame.spec.ts
+++ b/tests/miter-frame.spec.ts
@@ -145,7 +145,7 @@ test.describe("Miter cuts and the picture frame", () => {
     });
 
     await test.step("four rails and four nails become a walnut picture frame", async () => {
-      await movePlayerTo(page, [3, 2]);
+      await movePlayerTo(page, [7, 4]);
       await selectMode(page, "Makeshift Workbench", "Build Picture Frame");
       for (let i = 0; i < 4; i++) {
         await page

--- a/tests/shortcuts.spec.ts
+++ b/tests/shortcuts.spec.ts
@@ -57,10 +57,10 @@ test.describe("Keyboard shortcuts", () => {
     };
 
     await test.step("WASD and the arrow keys both walk the player", async () => {
-      expect(await playerPosition(page)).toEqual([0, 0]);
-      await walkUntil("d", [1, 0]);
-      await walkUntil("ArrowDown", [1, 1]);
-      await walkUntil("a", [0, 1]);
+      expect(await playerPosition(page)).toEqual([5, 6]);
+      await walkUntil("d", [6, 6]);
+      await walkUntil("ArrowDown", [6, 7]);
+      await walkUntil("a", [5, 7]);
     });
 
     await test.step("letter keys open the pocket overlays and toggle shut", async () => {


### PR DESCRIPTION
## What this is

The grid conversion we discussed: one cell is now **one square foot** (was 32"). The grid keeps doing what it's good at — machine snapping, placement, dust/pile bookkeeping — while the player stops feeling it. This also replaces the per-cell collision-inset hack with a standard collision system, and lays the groundwork for #68 (clearance in real feet) and #69 (tier-2 machine footprints).

## The scale

- `INCHES_PER_CELL` 32 → 12, now defined once in `src/game/shop-scale.ts` (game side) and re-exported by the render-side `shop-scale.tsx`. `PIXELS_PER_INCH` is unchanged, so everything drawn in inches/feet (boards, sheets, machine art) keeps its exact physical size on screen.
- The starting shop is a **12'×16' one-car garage** (was 4×6 cells ≈ 10'8"×16').
- Walk speed and the player's body size are physically unchanged (`BASE_WALK_SPEED` 9.3 cells/s, `PLAYER_RADIUS` 0.8 cells ≈ 10").

## General-purpose collision

`stepPlayerMotion` now sweeps the body against the shop walls plus a flat list of **world-space solid boxes** (`machine-collision.ts: shopSolids`) — a machine contributes its art-measured collision box, or its occupied tiles if it has none. `CellInsets` / `MAX_COLLISION_INSET` and the per-cell clipping are gone. The sweep clamps across the whole step (no tunneling) and never clamps a box it starts inside, so teleports and set-down overlaps always resolve by walking out. A 2-cell gap is a walkable aisle; a 1-cell gap is not.

## Interaction zones

A body is bigger than a 1-ft tile, so exact-cell checks became small zones:

- **Attendance/operability**: `Machine.operationZone` — the operation cell plus its neighbors, registered in `CellMap`, so targeting, hint chips, station sheets, loading, and attended-phase progression all work anywhere in the apron in front of a machine. Outfeed collection (`outputZone`) works the same way.
- **The garage door** is a 7-ft strip (`DOOR_HALF_WIDTH`), drawn full-width by `EntranceSprite`.
- Crates, the shop vac, and the vac's garbage-can dump all work from any adjacent cell.

## Machine footprints

Every machine got a real footprint refit from its art (collision boxes regenerated at 96 px/cell):

| Machine | Footprint |
|---|---|
| Workspace, miter saw, jobsite table saw | 3×2 ft |
| Planer, jointer | 2×3 ft (feed the long way, infeed/outfeed clearance rows required) |
| Garbage can, storage rack | 2×2 ft |
| Worktables | 2×2 / 4×2 / 6×2 / 4×4 ft (ids unchanged for save compat; stats unchanged) |

Benchtop machines mount onto tables wherever their footprint fits on the top — the existing per-cell placement rules handle multi-cell-on-multi-cell naturally.

## Dust

`DUST_MAX_PER_CELL` 100 → 15 (same sawdust depth, less floor per cell); slowdown ramps are relative so they carried over. Sweeping and vac bursts cover the 3×3 patch at hand, and swept piles hold a new `SAWDUST_PILE_CAPACITY` (a real pile, not one square foot's dusting).

## Save migration (v23 → v24)

There's no integer mapping from 32" cells to 1-ft cells, so migration is moving day: placed machines are **re-crated by the door** (tools, upgrades, and shelf stock ride along inside; work-in-progress materials land as piles at the dropoff), floor piles stack at the dropoff, dust is swept, and money/reputation/skills/listings/jobs are untouched.

## Tests

- `npm run tsc` clean; **519/519 unit tests pass** (motion/collision tests rewritten for the box system, including a new invariant test that every machine's box reaches within the body radius of its footprint edges, so the cell underfoot can never be a machine's).
- All 10 E2E fixtures and the spec choreography re-laid for the 12×16 shop. **12/17 specs pass in a full parallel run, 14/17 solo**; the remaining failures reproduce identically on `main` in this sandbox (a proxy `ERR_CONNECTION_RESET` console error breaks `basic`/`game-sounds`/`settings`, and long specs time out under parallel load — `skills` and `carry-machines` pass solo). Worth a local `npm run test:e2e` on your machine to confirm they're green outside the sandbox.

## Worth eyeballing in-game

Numbers chosen by math, not playtesting — the feel is the thing to check:

- Walking between machines with the 0.8-cell body (`?collision` overlay shows the solid boxes)
- The starting layout (workspace against the back wall, can in the corner, pallet by the bench)
- Dust spread/slowdown pacing after the per-cell rescale
- Sprite chrome that hangs off `PIXELS_PER_CELL` (status badges, dust bags, crate/vac/rack sizes) — all rescaled to keep physical size, but a visual pass would be wise

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AiXW9SFhr5MXCBrSRDm3jK

---
_Generated by [Claude Code](https://claude.ai/code/session_01AiXW9SFhr5MXCBrSRDm3jK)_