### PR TITLE
Extend commissions to 15, add 8 products, and overhaul the job board

### DIFF
--- a/src/components/material-sprites/CuttingBoardSprite.tsx
+++ b/src/components/material-sprites/CuttingBoardSprite.tsx
@@ -62,6 +62,25 @@ export const CuttingBoardSprite: React.FC<
       g.roundRect(-width / 2, -height / 2, width, height, radius);
       g.fill(colorBySpecies[species].primary);
 
+      // checkers: a true two-tone grid, every other block the accent wood
+      if (type === "checkerboardCuttingBoard" && accentSpecies) {
+        const block = 2 * PIXELS_PER_INCH;
+        for (let row = 0; -height / 2 + row * block < height / 2; row++) {
+          for (let col = 0; -width / 2 + col * block < width / 2; col++) {
+            if ((row + col) % 2 === 0) {
+              continue;
+            }
+            g.rect(
+              -width / 2 + col * block,
+              -height / 2 + row * block,
+              Math.min(block, width / 2 - (-width / 2 + col * block)),
+              Math.min(block, height / 2 - (-height / 2 + row * block)),
+            );
+            g.fill(colorBySpecies[accentSpecies].primary);
+          }
+        }
+      }
+
       // end grain reads as a brick grid of glued blocks
       if (type === "endGrainCuttingBoard") {
         const block = 2 * PIXELS_PER_INCH;
@@ -81,8 +100,9 @@ export const CuttingBoardSprite: React.FC<
         }
       }
 
-      // accent stripes over the base wood, patterned by tier
-      if (accentSpecies) {
+      // accent stripes over the base wood, patterned by tier (the
+      // checkerboard already painted its accent as a grid)
+      if (accentSpecies && type !== "checkerboardCuttingBoard") {
         for (const [offset, stripeWidth] of accentStripes(type)) {
           g.rect(
             -width / 2 + offset * PIXELS_PER_INCH,

--- a/src/components/material-sprites/MaterialSprite.tsx
+++ b/src/components/material-sprites/MaterialSprite.tsx
@@ -43,6 +43,9 @@ export const MaterialSprite: React.FC<{
       );
 
     case "jewelryBox":
+    case "birdhouse":
+    case "crate":
+    case "stepStool":
       return (
         <FinishedBoxSprite
           material={material as FinishedProduct}
@@ -55,6 +58,7 @@ export const MaterialSprite: React.FC<{
       return <PanelSprite panel={material} alpha={alpha} tint={tint} />;
 
     case "pictureFrame":
+    case "hexFrame":
       return (
         <PictureFrameSprite
           material={material as FinishedProduct}
@@ -82,6 +86,8 @@ export const MaterialSprite: React.FC<{
     case "stripedCuttingBoard":
     case "sunriseCuttingBoard":
     case "endGrainCuttingBoard":
+    case "checkerboardCuttingBoard":
+    case "servingTray":
       return (
         <CuttingBoardSprite material={material} alpha={alpha} tint={tint} />
       );

--- a/src/game/GameState.ts
+++ b/src/game/GameState.ts
@@ -82,6 +82,13 @@ export interface GameState {
   readonly listings: ReadonlyArray<MarketListing>;
   /** Open job offers the player hasn't accepted (refreshed daily). */
   readonly jobBoard: ReadonlyArray<JobOffer>;
+  /**
+   * Job template ids that were available at the last board refresh. A
+   * template appearing for the first time (new machine, tool, or skill)
+   * gets a guaranteed burst of offers — word gets around. See
+   * job-generation.ts.
+   */
+  readonly seenJobTemplateIds: ReadonlyArray<string>;
   /** Jobs the player has accepted and not yet delivered or cancelled. */
   readonly acceptedJobs: ReadonlyArray<AcceptedJob>;
   /**

--- a/src/game/Machine.ts
+++ b/src/game/Machine.ts
@@ -190,8 +190,19 @@ export type InputMaterial<T extends MaterialInstance = MaterialInstance> = {
    * Escape hatch for constraints the flat allowed-values fields can't
    * express (e.g. conditions on a panel's strip list). Checked in addition
    * to the flat fields by materialMeetsInput.
+   *
+   * NOT serializable — recipe constants only. Requirements that live in
+   * GameState (job offers, commissions) must stay declarative or they'd
+   * silently lose the predicate on save/load.
    */
   readonly matches?: (material: MaterialInstance) => boolean;
+  /**
+   * Minimum derived width in inches for panel requirements — a panel's
+   * width lives in its strip list, not a flat field, so allowed-value
+   * arrays can't express "at least this wide". Serializable, unlike
+   * `matches`, so generated job offers can ask for wide glue-ups.
+   */
+  readonly minPanelWidth?: number;
 };
 
 export type InputMaterialWithQuantity<
@@ -389,7 +400,9 @@ export class Machine {
    * station whose recipes are all still locked, or "none").
    */
   get selectedOperationOrNull():
-    MachineOperation | ParameterizedOperation | null {
+    | MachineOperation
+    | ParameterizedOperation
+    | null {
     return (
       this.operations.find((op) => op.id === this.state.selectedOperationId) ??
       null

--- a/src/game/Materials.ts
+++ b/src/game/Materials.ts
@@ -246,7 +246,15 @@ export type FinishedProduct = {
     | "simpleCuttingBoard"
     | "stripedCuttingBoard"
     | "sunriseCuttingBoard"
-    | "endGrainCuttingBoard";
+    | "endGrainCuttingBoard"
+    | "birdhouse"
+    | "crate"
+    | "stepStool"
+    | "hexFrame"
+    | "servingTray"
+    | "bookshelf"
+    | "sideTable"
+    | "checkerboardCuttingBoard";
   readonly species: Species;
   /** Second wood in a two-tone piece (e.g. striped cutting boards). */
   readonly accentSpecies?: Species;

--- a/src/game/Skill.ts
+++ b/src/game/Skill.ts
@@ -20,6 +20,10 @@ export const SKILL_IDS = [
   "sunriseBoards",
   "jigsAndFixtures",
   "endGrainBoards",
+  "polygonJoinery",
+  "trayWork",
+  "furnitureBasics",
+  "checkerboards",
 ] as const;
 export type SkillId = (typeof SKILL_IDS)[number];
 
@@ -156,6 +160,38 @@ export const SKILL_TYPES: Record<SkillId, SkillType> = {
       "Slice a panel, stand the grain on end, glue it again. Butcher-block money.",
     branch: "finishing",
     requires: ["surfacePrep", "jigsAndFixtures"],
+  },
+  polygonJoinery: {
+    id: "polygonJoinery",
+    name: "Polygon Joinery",
+    description:
+      "Six corners at 30°, eight at 22.5°. The saw's other angle stops finally earn their keep.",
+    branch: "joinery",
+    requires: ["miteredFrames"],
+  },
+  trayWork: {
+    id: "trayWork",
+    name: "Tray Work",
+    description:
+      "A sanded panel wrapped in mitered rails: the serving tray. Panels meet miters.",
+    branch: "joinery",
+    requires: ["miteredFrames", "panelWork"],
+  },
+  furnitureBasics: {
+    id: "furnitureBasics",
+    name: "Furniture Basics",
+    description:
+      "A wide glued top on four square legs. The side table is the first piece that furnishes a room.",
+    branch: "joinery",
+    requires: ["fineShelving", "freeformLamination"],
+  },
+  checkerboards: {
+    id: "checkerboards",
+    name: "Checkerboards",
+    description:
+      "Two-tone end-grain slices, every other one flipped. The pattern hiding inside the block.",
+    branch: "finishing",
+    requires: ["endGrainBoards"],
   },
 };
 

--- a/src/game/commissionSequence.test.ts
+++ b/src/game/commissionSequence.test.ts
@@ -26,6 +26,38 @@ describe("COMMISSION_SEQUENCE", () => {
       );
     }
   });
+
+  it("has non-decreasing reputation rewards", () => {
+    for (let i = 1; i < COMMISSION_SEQUENCE.length; i++) {
+      assert.ok(
+        COMMISSION_SEQUENCE[i].rewardReputation >=
+          COMMISSION_SEQUENCE[i - 1].rewardReputation,
+        `${COMMISSION_SEQUENCE[i].id} should not drop reputation below ${COMMISSION_SEQUENCE[i - 1].id}`,
+      );
+    }
+  });
+
+  it("covers the full sequence through the butcher's block finale", () => {
+    assert.strictEqual(COMMISSION_SEQUENCE.length, 15);
+    assert.strictEqual(
+      COMMISSION_SEQUENCE[COMMISSION_SEQUENCE.length - 1].id,
+      "the-butchers-block",
+    );
+  });
+
+  it("never uses non-serializable matches predicates in requirements", () => {
+    // Commission requirements must stay declarative so the UI can render
+    // them and createMockMaterial can price them.
+    for (const commission of COMMISSION_SEQUENCE) {
+      for (const requirement of commission.requiredMaterials) {
+        assert.strictEqual(
+          requirement.matches,
+          undefined,
+          `${commission.id} uses a matches predicate`,
+        );
+      }
+    }
+  });
 });
 
 describe("getActiveCommission", () => {

--- a/src/game/commissionSequence.ts
+++ b/src/game/commissionSequence.ts
@@ -15,6 +15,14 @@ import { REAL_WOOD_SPECIES } from "./Materials";
  * into a (rough) panel, and finishes a sanded single-species hardwood panel
  * into a cutting board. Tools before machines: the sander era (commission 4)
  * comes well before the planer era (commission 7).
+ *
+ * From commission 10 on, skills enter the picture. Skills are bought with
+ * points the player earns from XP levels (see Skill.ts), so these
+ * commissions can't grant them — instead each description points at the
+ * journal, and the ordering respects every prerequisite chain (boxJoinery
+ * needs fineShelving, sunrise needs striped + freeform, end-grain needs
+ * jigs). Commission XP alone (rewardMoney / 5, see store-actions) funds
+ * roughly seven points by the finale; operations and jobs cover the rest.
  */
 export const COMMISSION_SEQUENCE: ReadonlyArray<Commission> = [
   {
@@ -127,6 +135,113 @@ export const COMMISSION_SEQUENCE: ReadonlyArray<Commission> = [
     ],
     rewardMoney: 1200,
     rewardReputation: 7,
+  },
+  {
+    id: "balcony-garden",
+    name: "Balcony Garden",
+    description:
+      "An apartment gardener wants planter boxes that survive the weather. Nails work loose in wet soil — you'll need a drill and a box of screws.",
+    requiredMaterials: [
+      { type: ["planterBox"], species: ["pallet"], quantity: 2 },
+    ],
+    rewardMoney: 1400,
+    rewardReputation: 8,
+  },
+  {
+    id: "oiled-and-ready",
+    name: "Oiled & Ready",
+    description:
+      "A kitchen shop will stock your boards — if they arrive finished. Wipe on mineral oil at the workspace and let it soak in.",
+    requiredMaterials: [
+      {
+        type: ["simpleCuttingBoard"],
+        species: REAL_WOOD_SPECIES,
+        finish: ["mineralOil"],
+        quantity: 2,
+      },
+    ],
+    rewardMoney: 1600,
+    rewardReputation: 8,
+  },
+  {
+    id: "gallery-wall",
+    name: "Gallery Wall",
+    description:
+      "A photographer needs hardwood frames with corners that close tight. Study Mitered Frames in your journal, then swing the saw to its 45° stops.",
+    requiredMaterials: [
+      { type: ["pictureFrame"], species: REAL_WOOD_SPECIES, quantity: 2 },
+    ],
+    rewardMoney: 1900,
+    rewardReputation: 9,
+  },
+  {
+    id: "shelving-but-nice",
+    name: "Shelving, But Nice",
+    description:
+      "The cafe is renovating — no more rustic. They want real hardwood shelves, sanded clean. The journal calls it Fine Shelving.",
+    requiredMaterials: [
+      { type: ["shelf"], species: REAL_WOOD_SPECIES, quantity: 2 },
+    ],
+    rewardMoney: 2200,
+    rewardReputation: 10,
+  },
+  {
+    id: "stripes",
+    name: "Stripes",
+    description:
+      "A food blogger wants a striped board — walnut and maple in strict alternation. Work up through Two-Tone and Striped Boards in your journal.",
+    requiredMaterials: [
+      {
+        type: ["stripedCuttingBoard"],
+        species: ["walnut", "maple"],
+        accentSpecies: ["walnut", "maple"],
+        quantity: 1,
+      },
+    ],
+    rewardMoney: 2500,
+    rewardReputation: 10,
+  },
+  {
+    id: "small-treasures",
+    name: "Small Treasures",
+    description:
+      "A jeweler wants boxes worthy of what goes inside. Box Joinery takes thin stock — this is what you bought the planer for.",
+    requiredMaterials: [
+      { type: ["jewelryBox"], species: REAL_WOOD_SPECIES, quantity: 2 },
+    ],
+    rewardMoney: 2800,
+    rewardReputation: 11,
+  },
+  {
+    id: "the-sunrise-board",
+    name: "The Sunrise Board",
+    description:
+      "A wedding gift: one wood fading into another, strip by strip. Freeform Lamination lets you glue any widths; Sunrise Boards makes them sing.",
+    requiredMaterials: [
+      {
+        type: ["sunriseCuttingBoard"],
+        species: REAL_WOOD_SPECIES,
+        quantity: 1,
+      },
+    ],
+    rewardMoney: 3200,
+    rewardReputation: 12,
+  },
+  {
+    id: "the-butchers-block",
+    name: "The Butcher's Block",
+    description:
+      "The restaurant wants a true end-grain block, oiled and food-ready. Build a crosscut sled, slice a panel, stand the grain on end, and glue it all again. Everything you know, in one board.",
+    requiredMaterials: [
+      {
+        type: ["endGrainCuttingBoard"],
+        species: REAL_WOOD_SPECIES,
+        finish: ["mineralOil"],
+        quantity: 1,
+      },
+    ],
+    rewardMoney: 4000,
+    rewardReputation: 15,
   },
 ];
 

--- a/src/game/game-actions/marketplace-actions.ts
+++ b/src/game/game-actions/marketplace-actions.ts
@@ -1,6 +1,6 @@
 import { GameAction, MarketListing } from "../GameState";
 import { MaterialInstance } from "../Materials";
-import { generateJobBoard } from "../job-generation";
+import { availableJobTemplateIds, generateJobBoard } from "../job-generation";
 import {
   DEMAND_DIP_PER_SALE,
   DEMAND_RECOVERY_PER_TICK,
@@ -348,5 +348,12 @@ function refreshJobBoard(
     }
     jobBoard.push(offer);
   }
-  return { ...gameState, jobBoard };
+  // Record what the board could offer this refresh: anything that appears
+  // in this list for the first time next refresh is a new capability and
+  // gets its guaranteed burst (see generateJobBoard).
+  return {
+    ...gameState,
+    jobBoard,
+    seenJobTemplateIds: availableJobTemplateIds(gameState),
+  };
 }

--- a/src/game/initialGameState.tsx
+++ b/src/game/initialGameState.tsx
@@ -74,6 +74,7 @@ export const initialGameState: GameState = {
   },
   listings: [],
   jobBoard: [],
+  seenJobTemplateIds: [],
   acceptedJobs: [],
   categoryDemand: {},
   dust: {},

--- a/src/game/job-generation.test.ts
+++ b/src/game/job-generation.test.ts
@@ -1,0 +1,215 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { GameState } from "./GameState";
+import { initialGameState } from "./initialGameState";
+import { availableJobTemplateIds, generateJobBoard } from "./job-generation";
+import { createMockMaterial } from "./material-helpers";
+import { getSellValue } from "./material-values";
+import { SkillId } from "./Skill";
+
+/** rng that always rolls 0 — every pick takes the first option. */
+const zeroRng = () => 0;
+
+function stateWith(
+  overrides: Partial<GameState> & {
+    skills?: ReadonlyArray<SkillId>;
+  } = {},
+): GameState {
+  const { skills, ...rest } = overrides;
+  return {
+    ...initialGameState,
+    progression: {
+      ...initialGameState.progression,
+      marketplaceUnlocked: true,
+      unlockedSkills: [
+        ...initialGameState.progression.unlockedSkills,
+        ...(skills ?? []),
+      ],
+    },
+    ...rest,
+  };
+}
+
+/** True when some offer on the board asks for the given material type. */
+function boardAsksFor(
+  board: ReturnType<typeof generateJobBoard>,
+  type: string,
+): boolean {
+  return board.some((offer) =>
+    offer.requiredMaterials.some((req) => req.type?.includes(type as never)),
+  );
+}
+
+describe("generateJobBoard", () => {
+  it("always includes a zero-material-cost offer", () => {
+    const board = generateJobBoard(stateWith());
+    assert.ok(board.some((offer) => offer.materialCostFree));
+  });
+
+  it("bursts offers for a template the board has never had before", () => {
+    // Everything currently available has been seen — except nothing yet:
+    // mark all seen, then check no burst; then forget one and check it
+    // lands a guaranteed offer.
+    const allSeen = stateWith({});
+    const seen = availableJobTemplateIds(allSeen);
+    assert.ok(seen.includes("crates"), "starter hammer offers crate work");
+
+    const forgotten = stateWith({
+      seenJobTemplateIds: seen.filter((id) => id !== "crates"),
+    });
+    // Deterministic: unseen templates are guaranteed a slot
+    const board = generateJobBoard(forgotten, zeroRng);
+    assert.ok(boardAsksFor(board, "crate"));
+  });
+
+  it("guarantees an offer from the player's top tier", () => {
+    const master = stateWith({
+      skills: ["checkerboards"],
+      seenJobTemplateIds: [], // irrelevant: mark seen below
+    });
+    const board = generateJobBoard(
+      { ...master, seenJobTemplateIds: availableJobTemplateIds(master) },
+      zeroRng,
+    );
+    // checkerboard-boards is the lone top-tier template here
+    assert.ok(boardAsksFor(board, "checkerboardCuttingBoard"));
+  });
+
+  it("scales low-tier batches with reputation", () => {
+    const seenAll = (state: GameState) => ({
+      ...state,
+      seenJobTemplateIds: availableJobTemplateIds(state),
+    });
+    const humble = generateJobBoard(seenAll(stateWith()), zeroRng);
+    const famous = generateJobBoard(
+      seenAll(stateWith({ reputation: 60 })),
+      zeroRng,
+    );
+    // With a zero rng both boards lead with the pallet-boards income floor
+    assert.strictEqual(humble[0].requiredMaterials[0].quantity, 3);
+    assert.strictEqual(famous[0].requiredMaterials[0].quantity, 3 + 5);
+  });
+
+  it("pays more for an oiled ask than a raw one", () => {
+    const raw = getSellValue(
+      createMockMaterial({
+        type: ["simpleCuttingBoard"],
+        species: ["walnut"],
+        quantity: 1,
+      }),
+    );
+    const oiled = getSellValue(
+      createMockMaterial({
+        type: ["simpleCuttingBoard"],
+        species: ["walnut"],
+        finish: ["mineralOil"],
+        quantity: 1,
+      }),
+    );
+    assert.ok(oiled > raw);
+  });
+
+  it("keeps every generated requirement declarative (serializable)", () => {
+    // Job offers live in GameState and round-trip through JSON — a matches
+    // predicate would silently vanish. Sample many boards across a spread
+    // of capability envelopes.
+    const states = [
+      stateWith(),
+      stateWith({ reputation: 30, skills: ["miteredFrames", "fineShelving"] }),
+      stateWith({
+        reputation: 60,
+        skills: [
+          "miteredFrames",
+          "fineShelving",
+          "boxJoinery",
+          "twoToneBoards",
+          "stripedBoards",
+          "freeformLamination",
+          "sunriseBoards",
+          "jigsAndFixtures",
+          "endGrainBoards",
+          "polygonJoinery",
+          "trayWork",
+          "furnitureBasics",
+          "checkerboards",
+        ],
+      }),
+    ];
+    for (const state of states) {
+      for (let i = 0; i < 20; i++) {
+        for (const offer of generateJobBoard(state)) {
+          for (const req of offer.requiredMaterials) {
+            assert.strictEqual(
+              req.matches,
+              undefined,
+              `offer "${offer.description}" uses a matches predicate`,
+            );
+            assert.strictEqual(
+              JSON.parse(JSON.stringify(req)).quantity,
+              req.quantity,
+            );
+          }
+        }
+      }
+    }
+  });
+
+  it("asks only for what the capability envelope can produce", () => {
+    // A fresh shop can't be asked for hardwood products
+    const board = generateJobBoard(stateWith());
+    assert.ok(!boardAsksFor(board, "simpleCuttingBoard"));
+    assert.ok(!boardAsksFor(board, "sideTable"));
+  });
+});
+
+describe("availableJobTemplateIds", () => {
+  it("grows as skills unlock", () => {
+    const before = availableJobTemplateIds(stateWith());
+    const after = availableJobTemplateIds(
+      stateWith({ skills: ["polygonJoinery"] }),
+    );
+    assert.ok(!before.includes("hex-frames"));
+    assert.ok(after.includes("hex-frames"));
+  });
+});
+
+describe("minPanelWidth matching", () => {
+  it("accepts only panels at least that wide", async () => {
+    const { materialMeetsInput } = await import("./material-helpers");
+    const { panel } = await import("./panel-helpers");
+    const requirement = {
+      type: ["panel" as const],
+      minPanelWidth: 12,
+      quantity: 1,
+    };
+    const strips = (count: number) =>
+      Array.from({ length: count }, () => ({
+        species: "maple" as const,
+        width: 2 as const,
+      }));
+    assert.ok(
+      materialMeetsInput(panel(strips(6), 2, 4, "sanded"), requirement),
+    );
+    assert.ok(
+      !materialMeetsInput(panel(strips(5), 2, 4, "sanded"), requirement),
+    );
+  });
+
+  it("survives a JSON round-trip, unlike matches", async () => {
+    const { materialMeetsInput } = await import("./material-helpers");
+    const { panel } = await import("./panel-helpers");
+    const requirement = JSON.parse(
+      JSON.stringify({ type: ["panel"], minPanelWidth: 12, quantity: 1 }),
+    );
+    const narrow = panel(
+      Array.from({ length: 5 }, () => ({
+        species: "maple" as const,
+        width: 2 as const,
+      })),
+      2,
+      4,
+      "sanded",
+    );
+    assert.ok(!materialMeetsInput(narrow, requirement));
+  });
+});

--- a/src/game/job-generation.ts
+++ b/src/game/job-generation.ts
@@ -5,7 +5,9 @@ import { getSellValue } from "./material-values";
 import { roundToCents } from "./marketplace";
 import { ownsMachine, ownsTool } from "./progression-helpers";
 import { hasSkill } from "./skill-helpers";
-import { BoardDimension, REAL_WOOD_SPECIES } from "./Materials";
+import { unlockedLumberChannels } from "./lumberStock";
+import { BoardDimension, REAL_WOOD_SPECIES, Species } from "./Materials";
+import { humanizeString } from "../utils/humanizeString";
 import { idMaker } from "../utils/idMaker";
 
 const makeJobId = idMaker();
@@ -15,6 +17,11 @@ const makeJobId = idMaker();
  * player's capability envelope — what they can actually build right now —
  * so the board never asks for the impossible, and it skews toward the most
  * advanced capability so new equipment immediately brings matching work.
+ *
+ * Requirements here must stay DECLARATIVE (no `matches` predicates):
+ * offers live in GameState and round-trip through JSON save/load, which
+ * would silently drop a function. `minPanelWidth` exists for exactly this
+ * reason (see Machine.ts).
  */
 
 /** The board holds this many open offers after a refresh. */
@@ -25,7 +32,22 @@ export const JOB_BOARD_MAX_OFFERS = 5;
 const JOB_PAY_MULTIPLIER_MIN = 1.5;
 const JOB_PAY_MULTIPLIER_MAX = 2.0;
 
+/**
+ * How often a hardwood product ask names one specific species ("in walnut,
+ * to match the counters"). Specific asks pay their species' full value —
+ * that flows through fair-value pricing on its own — and tip extra
+ * reputation for hitting the constraint.
+ */
+const SPECIES_REQUEST_CHANCE = 0.4;
+
 interface JobTemplate {
+  /**
+   * Stable identity for capability tracking: ids the player has never had
+   * available before get a burst of guaranteed offers on the next refresh
+   * (see generateJobBoard), so new equipment and skills bring work the
+   * moment word gets around.
+   */
+  readonly id: string;
   /**
    * Higher tiers need more advanced equipment. Generation is weighted
    * toward the highest available tier — the board fills with work for
@@ -38,7 +60,7 @@ interface JobTemplate {
    */
   readonly zeroMaterialCost: boolean;
   readonly available: (gameState: GameState) => boolean;
-  readonly generate: (rng: () => number) => GeneratedJob;
+  readonly generate: (rng: () => number, gameState: GameState) => GeneratedJob;
 }
 
 interface GeneratedJob {
@@ -75,20 +97,73 @@ const hasAnySander = (gameState: GameState) =>
   ownsTool(gameState, "sandingBlock") ||
   ownsTool(gameState, "randomOrbitSander");
 
+const hasAnySaw = (gameState: GameState) =>
+  ownsMachine(gameState, "miterSaw") || ownsTool(gameState, "handSaw");
+
+/**
+ * An established shop's low-tier work arrives in bigger batches — the old
+ * templates scale up with reputation instead of going stale.
+ */
+function repBatchBonus(gameState: GameState): number {
+  return Math.min(6, Math.floor(gameState.reputation / 12));
+}
+
+/** The real-wood species the player can currently buy, across both stores. */
+function buyableHardwoods(gameState: GameState): ReadonlyArray<Species> {
+  const channels = [
+    ...unlockedLumberChannels(gameState.reputation, "orangeBox"),
+    ...unlockedLumberChannels(gameState.reputation, "lumberyard"),
+  ];
+  return [...new Set(channels.flatMap((channel) => channel.species))];
+}
+
+/** "walnut", "purple heart" — species ids in client-request language. */
+function speciesLabel(species: Species): string {
+  return humanizeString(species).toLowerCase();
+}
+
+/**
+ * A hardwood product ask, sometimes narrowed to one specific buyable
+ * species. The clause slots into the description ("a walnut cutting
+ * board"); specific asks tip +1 reputation.
+ */
+function speciesRequest(
+  rng: () => number,
+  gameState: GameState,
+): {
+  readonly species: ReadonlyArray<Species>;
+  readonly clause: string;
+  readonly repBonus: number;
+} {
+  const buyable = buyableHardwoods(gameState);
+  if (buyable.length > 0 && rng() < SPECIES_REQUEST_CHANCE) {
+    const chosen = pick(rng, buyable);
+    return {
+      species: [chosen],
+      clause: speciesLabel(chosen),
+      repBonus: 1,
+    };
+  }
+  return { species: REAL_WOOD_SPECIES, clause: "hardwood", repBonus: 0 };
+}
+
 /**
  * Everything here must stay producible from the capabilities its
  * `available` predicate checks — the pallet chain yields 3×4×1 deck boards
  * and 4×6×3 stringers, the miter saw cuts length, the table saw rips
- * width, sanders raise surface, the planer reduces thickness.
+ * width, sanders raise surface, the planer reduces thickness, and the
+ * bench recipes assemble the products (see benchOperations.ts and the
+ * hammer/drill tool recipes).
  */
 const JOB_TEMPLATES: ReadonlyArray<JobTemplate> = [
   {
     // The guaranteed path back to solvency: free wood, starter tools.
+    id: "pallet-boards",
     tier: 0,
     zeroMaterialCost: true,
     available: () => true,
-    generate: (rng) => {
-      const quantity = intBetween(rng, 3, 6);
+    generate: (rng, gameState) => {
+      const quantity = intBetween(rng, 3, 6) + repBatchBonus(gameState);
       return {
         description: `Needs ${quantity} reclaimed pallet boards for a weekend project. Any condition.`,
         requiredMaterials: [
@@ -106,16 +181,19 @@ const JOB_TEMPLATES: ReadonlyArray<JobTemplate> = [
     },
   },
   {
+    id: "rustic-shelves",
     tier: 0,
     zeroMaterialCost: true,
     available: () => true,
-    generate: (rng) => {
-      const quantity = intBetween(rng, 1, 2);
+    generate: (rng, gameState) => {
+      const quantity =
+        intBetween(rng, 1, 2) +
+        Math.min(3, Math.floor(repBatchBonus(gameState) / 2));
       return {
         description:
           quantity === 1
             ? "Wants a rustic pallet-wood shelf for the garage. Rougher the better."
-            : "Wants a pair of rustic pallet-wood shelves. Rougher the better.",
+            : `Wants ${quantity} rustic pallet-wood shelves. Rougher the better.`,
         requiredMaterials: [
           { type: ["rusticShelf"], species: ["pallet"], quantity },
         ],
@@ -124,12 +202,43 @@ const JOB_TEMPLATES: ReadonlyArray<JobTemplate> = [
     },
   },
   {
+    id: "birdhouses",
+    tier: 1,
+    zeroMaterialCost: true,
+    available: (gameState) =>
+      ownsTool(gameState, "hammer") && hasAnySaw(gameState),
+    generate: (rng, gameState) => {
+      const quantity = intBetween(rng, 2, 4) + repBatchBonus(gameState);
+      return {
+        description: `The garden club wants ${quantity} birdhouses for the spring fair. Pallet wood is fine — the birds don't mind.`,
+        requiredMaterials: [{ type: ["birdhouse"], quantity }],
+        baseReputation: 1,
+      };
+    },
+  },
+  {
+    id: "crates",
+    tier: 1,
+    zeroMaterialCost: true,
+    available: (gameState) => ownsTool(gameState, "hammer"),
+    generate: (rng, gameState) => {
+      const quantity =
+        intBetween(rng, 2, 3) + Math.min(3, repBatchBonus(gameState));
+      return {
+        description: `Needs ${quantity} slatted crates for market-stall storage. Sturdy beats pretty.`,
+        requiredMaterials: [{ type: ["crate"], quantity }],
+        baseReputation: 1,
+      };
+    },
+  },
+  {
+    id: "miter-crosscuts",
     tier: 1,
     zeroMaterialCost: true,
     available: (gameState) => ownsMachine(gameState, "miterSaw"),
-    generate: (rng) => {
+    generate: (rng, gameState) => {
       const length = pick(rng, [1, 2] as const) satisfies BoardDimension;
-      const quantity = intBetween(rng, 3, 6);
+      const quantity = intBetween(rng, 3, 6) + repBatchBonus(gameState);
       return {
         description: `Needs ${quantity} pallet boards crosscut to ${length}' exactly. Bring your miter saw game.`,
         requiredMaterials: [
@@ -147,12 +256,13 @@ const JOB_TEMPLATES: ReadonlyArray<JobTemplate> = [
     },
   },
   {
+    id: "ripped-slats",
     tier: 1,
     zeroMaterialCost: true,
     available: (gameState) => ownsMachine(gameState, "jobsiteTableSaw"),
-    generate: (rng) => {
+    generate: (rng, gameState) => {
       const width = pick(rng, [1, 2] as const) satisfies BoardDimension;
-      const quantity = intBetween(rng, 3, 6);
+      const quantity = intBetween(rng, 3, 6) + repBatchBonus(gameState);
       return {
         description: `Needs ${quantity} slats ripped to ${width}" wide from pallet stock.`,
         requiredMaterials: [
@@ -170,11 +280,12 @@ const JOB_TEMPLATES: ReadonlyArray<JobTemplate> = [
     },
   },
   {
+    id: "sanded-boards",
     tier: 2,
     zeroMaterialCost: true,
     available: hasAnySander,
-    generate: (rng) => {
-      const quantity = intBetween(rng, 2, 4);
+    generate: (rng, gameState) => {
+      const quantity = intBetween(rng, 2, 4) + repBatchBonus(gameState);
       return {
         description: `Needs ${quantity} pallet boards sanded baby-smooth for a craft project.`,
         requiredMaterials: [
@@ -193,11 +304,54 @@ const JOB_TEMPLATES: ReadonlyArray<JobTemplate> = [
     },
   },
   {
+    // Screwed assembly: work for the drill. The wood is free pallet
+    // stock, but the screws are bought — so it never anchors the board.
+    // The box's slats are 2' crosscuts, so a saw has to be on hand too.
+    id: "planter-boxes",
+    tier: 2,
+    zeroMaterialCost: false,
+    available: (gameState) =>
+      ownsTool(gameState, "drill") && hasAnySaw(gameState),
+    generate: (rng) => {
+      const quantity = intBetween(rng, 1, 2);
+      return {
+        description:
+          quantity === 1
+            ? "Wants a pallet-wood planter box for the balcony herbs. Screwed together, please — it'll live outside."
+            : "Wants two matching pallet-wood planter boxes for the front steps.",
+        requiredMaterials: [
+          { type: ["planterBox"], species: ["pallet"], quantity },
+        ],
+        baseReputation: 2,
+      };
+    },
+  },
+  {
+    id: "step-stools",
+    tier: 2,
+    zeroMaterialCost: false,
+    available: (gameState) =>
+      ownsTool(gameState, "drill") && hasAnySaw(gameState),
+    generate: (rng) => {
+      const quantity = intBetween(rng, 1, 2);
+      return {
+        description:
+          quantity === 1
+            ? "Wants a step stool sturdy enough for the top shelf and the grandkids both."
+            : "The preschool needs two step stools for the sinks.",
+        requiredMaterials: [{ type: ["stepStool"], quantity }],
+        baseReputation: 2,
+      };
+    },
+  },
+  {
+    id: "planed-stringers",
     tier: 3,
     zeroMaterialCost: true,
     available: (gameState) => ownsMachine(gameState, "lunchboxPlaner"),
-    generate: (rng) => {
-      const quantity = intBetween(rng, 2, 3);
+    generate: (rng, gameState) => {
+      const quantity =
+        intBetween(rng, 2, 3) + Math.min(3, repBatchBonus(gameState));
       return {
         description: `Needs ${quantity} pallet stringers planed down to 2/4 thickness. Smooth faces, please.`,
         requiredMaterials: [
@@ -216,73 +370,329 @@ const JOB_TEMPLATES: ReadonlyArray<JobTemplate> = [
     },
   },
   {
-    // Screwed assembly: work for the drill. The wood is free pallet
-    // stock, but the screws are bought — so it never anchors the board.
-    // The box's slats are 2' crosscuts, so a saw has to be on hand too.
-    tier: 2,
-    zeroMaterialCost: false,
-    available: (gameState) =>
-      ownsTool(gameState, "drill") &&
-      (ownsMachine(gameState, "miterSaw") || ownsTool(gameState, "handSaw")),
-    generate: (rng) => {
-      const quantity = intBetween(rng, 1, 2);
-      return {
-        description:
-          quantity === 1
-            ? "Wants a pallet-wood planter box for the balcony herbs. Screwed together, please — it'll live outside."
-            : "Wants two matching pallet-wood planter boxes for the front steps.",
-        requiredMaterials: [
-          { type: ["planterBox"], species: ["pallet"], quantity },
-        ],
-        baseReputation: 2,
-      };
-    },
-  },
-  {
     // Hardwood work: requires bought lumber, so it's never the only job.
+    id: "cutting-boards",
     tier: 4,
     zeroMaterialCost: false,
     available: (gameState) =>
       // The proper-cutting-board commission taught the glue-up chain
       gameState.progression.commissionsCompleted >= 6,
-    generate: (rng) => {
+    generate: (rng, gameState) => {
       const quantity = intBetween(rng, 1, 2);
+      const request = speciesRequest(rng, gameState);
       return {
         description:
           quantity === 1
-            ? "Wants a real hardwood cutting board as a housewarming gift."
-            : "Wants two hardwood cutting boards — wedding season.",
+            ? `Wants a real ${request.clause} cutting board as a housewarming gift.`
+            : `Wants two ${request.clause} cutting boards — wedding season.`,
         requiredMaterials: [
           {
             type: ["simpleCuttingBoard"],
-            species: REAL_WOOD_SPECIES,
+            species: request.species,
             quantity,
           },
         ],
-        baseReputation: 3,
+        baseReputation: 3 + request.repBonus,
       };
     },
   },
   {
     // Precision work: offered once the player has learned the angle stops.
+    id: "picture-frames",
     tier: 4,
     zeroMaterialCost: false,
     available: (gameState) => hasSkill(gameState.progression, "miteredFrames"),
-    generate: (rng) => {
+    generate: (rng, gameState) => {
       const quantity = intBetween(rng, 1, 2);
+      const request = speciesRequest(rng, gameState);
       return {
         description:
           quantity === 1
-            ? "Wants a hardwood picture frame for a wedding photo. Tight miters, please."
-            : "The gallery around the corner needs two matching hardwood picture frames.",
+            ? `Wants a ${request.clause} picture frame for a wedding photo. Tight miters, please.`
+            : `The gallery around the corner needs two matching ${request.clause} picture frames.`,
         requiredMaterials: [
-          { type: ["pictureFrame"], species: REAL_WOOD_SPECIES, quantity },
+          { type: ["pictureFrame"], species: request.species, quantity },
         ],
-        baseReputation: 3,
+        baseReputation: 3 + request.repBonus,
+      };
+    },
+  },
+  {
+    // Finished goods: the oiled-and-ready commission taught the wipe-down.
+    id: "oiled-boards",
+    tier: 5,
+    zeroMaterialCost: false,
+    available: (gameState) => gameState.progression.commissionsCompleted >= 9,
+    generate: (rng, gameState) => {
+      const quantity = intBetween(rng, 1, 2);
+      const request = speciesRequest(rng, gameState);
+      return {
+        description: `The kitchen shop wants ${quantity === 1 ? "a" : quantity} ${request.clause} cutting board${quantity === 1 ? "" : "s"}, oiled and ready to sell.`,
+        requiredMaterials: [
+          {
+            type: ["simpleCuttingBoard"],
+            species: request.species,
+            finish: ["mineralOil"],
+            quantity,
+          },
+        ],
+        baseReputation: 3 + request.repBonus,
+      };
+    },
+  },
+  {
+    id: "fine-shelves",
+    tier: 5,
+    zeroMaterialCost: false,
+    available: (gameState) => hasSkill(gameState.progression, "fineShelving"),
+    generate: (rng, gameState) => {
+      const quantity = intBetween(rng, 1, 2);
+      const request = speciesRequest(rng, gameState);
+      return {
+        description:
+          quantity === 1
+            ? `Wants a clean-lined ${request.clause} shelf for the living room.`
+            : `A boutique is fitting out — two matching ${request.clause} shelves.`,
+        requiredMaterials: [
+          { type: ["shelf"], species: request.species, quantity },
+        ],
+        baseReputation: 3 + request.repBonus,
+      };
+    },
+  },
+  {
+    id: "jewelry-boxes",
+    tier: 5,
+    zeroMaterialCost: false,
+    available: (gameState) => hasSkill(gameState.progression, "boxJoinery"),
+    generate: (rng, gameState) => {
+      const quantity = intBetween(rng, 1, 2);
+      const request = speciesRequest(rng, gameState);
+      return {
+        description:
+          quantity === 1
+            ? `Wants a ${request.clause} jewelry box — an anniversary is coming.`
+            : `Wants two ${request.clause} jewelry boxes for the graduating twins.`,
+        requiredMaterials: [
+          { type: ["jewelryBox"], species: request.species, quantity },
+        ],
+        baseReputation: 3 + request.repBonus,
+      };
+    },
+  },
+  {
+    id: "bookshelves",
+    tier: 6,
+    zeroMaterialCost: false,
+    available: (gameState) =>
+      hasSkill(gameState.progression, "fineShelving") &&
+      ownsTool(gameState, "drill"),
+    generate: (rng, gameState) => {
+      const request = speciesRequest(rng, gameState);
+      return {
+        description: `A book collector wants a proper ${request.clause} bookshelf. No wobble, no veneer.`,
+        requiredMaterials: [
+          { type: ["bookshelf"], species: request.species, quantity: 1 },
+        ],
+        baseReputation: 4 + request.repBonus,
+      };
+    },
+  },
+  {
+    id: "frame-batch",
+    tier: 6,
+    zeroMaterialCost: false,
+    available: (gameState) => hasSkill(gameState.progression, "miteredFrames"),
+    generate: (rng, gameState) => {
+      const quantity = intBetween(rng, 3, 4);
+      const request = speciesRequest(rng, gameState);
+      return {
+        description: `The gallery is hanging a new show: ${quantity} matching ${request.clause} frames, all corners tight.`,
+        requiredMaterials: [
+          { type: ["pictureFrame"], species: request.species, quantity },
+        ],
+        baseReputation: 4 + request.repBonus,
+      };
+    },
+  },
+  {
+    id: "hex-frames",
+    tier: 6,
+    zeroMaterialCost: false,
+    available: (gameState) => hasSkill(gameState.progression, "polygonJoinery"),
+    generate: (rng, gameState) => {
+      const quantity = intBetween(rng, 1, 2);
+      const request = speciesRequest(rng, gameState);
+      return {
+        description:
+          quantity === 1
+            ? `Wants a hexagonal ${request.clause} frame for a macramé mirror. Six corners, no gaps.`
+            : `The plant café wants two hexagonal ${request.clause} frames for the wall.`,
+        requiredMaterials: [
+          { type: ["hexFrame"], species: request.species, quantity },
+        ],
+        baseReputation: 4 + request.repBonus,
+      };
+    },
+  },
+  {
+    // Sells lamination itself: a raw glued blank, no product type needed.
+    id: "panel-blank",
+    tier: 6,
+    zeroMaterialCost: false,
+    available: (gameState) =>
+      hasSkill(gameState.progression, "freeformLamination"),
+    generate: (rng) => {
+      const minWidth = pick(rng, [12, 14, 16] as const);
+      return {
+        description: `A furniture maker wants a glued table-top blank, at least ${minWidth}" wide, faces dressed. They'll do the rest.`,
+        requiredMaterials: [
+          {
+            type: ["panel"],
+            length: [2],
+            thickness: [4],
+            surface: ["smooth", "sanded"],
+            minPanelWidth: minWidth,
+            quantity: 1,
+          },
+        ],
+        baseReputation: 4,
+      };
+    },
+  },
+  {
+    id: "striped-boards",
+    tier: 6,
+    zeroMaterialCost: false,
+    available: (gameState) => hasSkill(gameState.progression, "stripedBoards"),
+    generate: (rng, gameState) => {
+      const buyable = buyableHardwoods(gameState);
+      if (buyable.length >= 2 && rng() < SPECIES_REQUEST_CHANCE) {
+        const first = pick(rng, buyable);
+        const second = pick(
+          rng,
+          buyable.filter((species) => species !== first),
+        );
+        return {
+          description: `Wants a striped cutting board — ${speciesLabel(first)} and ${speciesLabel(second)}, strict alternation.`,
+          requiredMaterials: [
+            {
+              type: ["stripedCuttingBoard"],
+              species: [first, second],
+              accentSpecies: [first, second],
+              quantity: 1,
+            },
+          ],
+          baseReputation: 5,
+        };
+      }
+      return {
+        description:
+          "Wants a striped two-wood cutting board. Dealer's choice on the woods — make them argue.",
+        requiredMaterials: [{ type: ["stripedCuttingBoard"], quantity: 1 }],
+        baseReputation: 4,
+      };
+    },
+  },
+  {
+    id: "serving-trays",
+    tier: 7,
+    zeroMaterialCost: false,
+    available: (gameState) => hasSkill(gameState.progression, "trayWork"),
+    generate: (rng, gameState) => {
+      const request = speciesRequest(rng, gameState);
+      return {
+        description: `The bed-and-breakfast wants a ${request.clause} serving tray — panel bottom, mitered rails, no rattles.`,
+        requiredMaterials: [
+          { type: ["servingTray"], species: request.species, quantity: 1 },
+        ],
+        baseReputation: 4 + request.repBonus,
+      };
+    },
+  },
+  {
+    id: "sunrise-boards",
+    tier: 7,
+    zeroMaterialCost: false,
+    available: (gameState) => hasSkill(gameState.progression, "sunriseBoards"),
+    generate: () => {
+      return {
+        description:
+          "Saw your sunrise board at the market. Wants one — the fade, the whole thing.",
+        requiredMaterials: [{ type: ["sunriseCuttingBoard"], quantity: 1 }],
+        baseReputation: 5,
+      };
+    },
+  },
+  {
+    id: "end-grain-boards",
+    tier: 8,
+    zeroMaterialCost: false,
+    available: (gameState) => hasSkill(gameState.progression, "endGrainBoards"),
+    generate: (rng, gameState) => {
+      const request = speciesRequest(rng, gameState);
+      return {
+        description: `A chef wants a true end-grain ${request.clause} block. Knife-friendly, heavy, forever.`,
+        requiredMaterials: [
+          {
+            type: ["endGrainCuttingBoard"],
+            species: request.species,
+            quantity: 1,
+          },
+        ],
+        baseReputation: 5 + request.repBonus,
+      };
+    },
+  },
+  {
+    id: "side-tables",
+    tier: 8,
+    zeroMaterialCost: false,
+    available: (gameState) =>
+      hasSkill(gameState.progression, "furnitureBasics"),
+    generate: (rng, gameState) => {
+      const request = speciesRequest(rng, gameState);
+      return {
+        description: `Wants a ${request.clause} side table — a wide glued top on square legs. Real furniture, from your shop.`,
+        requiredMaterials: [
+          { type: ["sideTable"], species: request.species, quantity: 1 },
+        ],
+        baseReputation: 6 + request.repBonus,
+      };
+    },
+  },
+  {
+    id: "checkerboard-boards",
+    tier: 9,
+    zeroMaterialCost: false,
+    available: (gameState) => hasSkill(gameState.progression, "checkerboards"),
+    generate: () => {
+      return {
+        description:
+          "Wants a checkerboard end-grain board — two woods, every other block flipped. The showpiece.",
+        requiredMaterials: [
+          { type: ["checkerboardCuttingBoard"], quantity: 1 },
+        ],
+        baseReputation: 6,
       };
     },
   },
 ];
+
+/** The templates the player's current capabilities can fulfill. */
+function availableTemplates(gameState: GameState): ReadonlyArray<JobTemplate> {
+  return JOB_TEMPLATES.filter((template) => template.available(gameState));
+}
+
+/**
+ * The ids of currently-available templates — stored on GameState after
+ * each refresh so the next refresh knows which capabilities are new.
+ */
+export function availableJobTemplateIds(
+  gameState: GameState,
+): ReadonlyArray<string> {
+  return availableTemplates(gameState).map((template) => template.id);
+}
 
 /** Fair value of everything a job asks for, via representative materials. */
 function jobFairValue(
@@ -299,9 +709,9 @@ function jobFairValue(
 function makeOffer(
   template: JobTemplate,
   rng: () => number,
-  tick: number,
+  gameState: GameState,
 ): JobOffer {
-  const generated = template.generate(rng);
+  const generated = template.generate(rng, gameState);
   const multiplier =
     JOB_PAY_MULTIPLIER_MIN +
     rng() * (JOB_PAY_MULTIPLIER_MAX - JOB_PAY_MULTIPLIER_MIN);
@@ -314,7 +724,7 @@ function makeOffer(
       jobFairValue(generated.requiredMaterials) * multiplier,
     ),
     baseReputation: generated.baseReputation,
-    postedAtTick: tick,
+    postedAtTick: gameState.tick,
     materialCostFree: template.zeroMaterialCost,
   };
 }
@@ -344,26 +754,50 @@ function pickTemplate(
 }
 
 /**
- * A fresh set of open offers for the daily board refresh. Always includes
- * at least one zero-material-cost job, so a broke player always has a path
- * back to solvency.
+ * A fresh set of open offers for the daily board refresh. Three
+ * guarantees shape the set before weighted picks fill it out:
+ *
+ * 1. Income floor: at least one zero-material-cost job, so a broke player
+ *    always has a path back to solvency.
+ * 2. New-capability burst: templates whose ids aren't in
+ *    `seenJobTemplateIds` (word hasn't gotten around yet) each land one
+ *    guaranteed offer, up to two — new gear brings work immediately.
+ * 3. Top-tier guarantee: at least one offer from the highest available
+ *    tier, so the board always shows the player's best work is wanted.
  */
 export function generateJobBoard(
   gameState: GameState,
   rng: () => number = Math.random,
 ): JobOffer[] {
-  const available = JOB_TEMPLATES.filter((template) =>
-    template.available(gameState),
-  );
+  const available = availableTemplates(gameState);
   const count = intBetween(rng, JOB_BOARD_MIN_OFFERS, JOB_BOARD_MAX_OFFERS);
-  const offers: JobOffer[] = [];
+  const chosen: JobTemplate[] = [];
 
   const zeroCost = available.filter((template) => template.zeroMaterialCost);
-  offers.push(makeOffer(pick(rng, zeroCost), rng, gameState.tick));
+  chosen.push(pick(rng, zeroCost));
 
-  while (offers.length < count) {
-    const template = pickTemplate(rng, available, gameState.reputation);
-    offers.push(makeOffer(template, rng, gameState.tick));
+  const unseen = available.filter(
+    (template) => !gameState.seenJobTemplateIds.includes(template.id),
+  );
+  for (const template of unseen.slice(0, 2)) {
+    if (!chosen.includes(template)) {
+      chosen.push(template);
+    }
   }
-  return offers;
+
+  const topTier = Math.max(...available.map((template) => template.tier));
+  if (!chosen.some((template) => template.tier === topTier)) {
+    chosen.push(
+      pick(
+        rng,
+        available.filter((template) => template.tier === topTier),
+      ),
+    );
+  }
+
+  while (chosen.length < count) {
+    chosen.push(pickTemplate(rng, available, gameState.reputation));
+  }
+
+  return chosen.map((template) => makeOffer(template, rng, gameState));
 }

--- a/src/game/machines/benchOperations.ts
+++ b/src/game/machines/benchOperations.ts
@@ -589,6 +589,7 @@ export const BENCH_OPERATIONS: ReadonlyArray<MachineOperation> = [
           "stripedCuttingBoard",
           "sunriseCuttingBoard",
           "endGrainCuttingBoard",
+          "checkerboardCuttingBoard",
         ],
         quantity: 1,
         // Boards only get oiled once
@@ -679,6 +680,179 @@ export const BENCH_OPERATIONS: ReadonlyArray<MachineOperation> = [
           makeMaterial<FinishedProduct>({
             type: "pictureFrame",
             species: rails[0].species,
+          }),
+        ],
+      };
+    },
+  },
+  {
+    name: "Finish Checkerboard Board",
+    id: "finishCheckerboardBoard",
+    requiredSkill: "checkerboards",
+    duration: 55,
+    inputMaterials: [
+      {
+        type: ["panel"],
+        length: [1],
+        thickness: [8],
+        surface: ["sanded"],
+        quantity: 1,
+        // An end-grain blank glued from STRIPED slices: two real woods in
+        // strict alternation. Flipping every other slice at the glue-up is
+        // what turns the stripes into checkers.
+        matches: (material) =>
+          isPanel(material) &&
+          material.grain === "end" &&
+          panelWidth(material) >= 10 &&
+          panelSpecies(material).length === 2 &&
+          material.strips.every((strip) => strip.species !== "pallet") &&
+          stripsAlternate(material.strips),
+      },
+    ],
+    output: (materials: ReadonlyArray<MaterialInstance>) => {
+      const blank = materials[0];
+      if (!isPanel(blank)) {
+        throw new Error("Input material is not a panel");
+      }
+      const species = dominantSpecies(blank.strips);
+      const accentSpecies = panelSpecies(blank).find((s) => s !== species)!;
+      return {
+        inputs: [],
+        outputs: [
+          makeMaterial<FinishedProduct>({
+            type: "checkerboardCuttingBoard",
+            species,
+            accentSpecies,
+          }),
+        ],
+      };
+    },
+  },
+  {
+    name: "Build Hex Frame",
+    id: "buildHexFrame",
+    requiredSkill: "polygonJoinery",
+    duration: 35,
+    // Twelve miters joined with brads, like the picture frame's four
+    requiredConsumables: [{ id: "nails", amount: 6 }],
+    inputMaterials: [
+      {
+        type: ["board"],
+        species: REAL_WOOD_SPECIES,
+        length: [1],
+        width: [1],
+        thickness: [1],
+        surface: ["sanded"],
+        quantity: 6,
+        // Six rails mitered at the 30° stop, mirrored so a hexagon closes
+        matches: (material) =>
+          isBoard(material) && isMiteredFrameRail(material, 30),
+      },
+    ],
+    output: (materials: ReadonlyArray<MaterialInstance>) => {
+      const rails = materials.filter(isBoard);
+      if (rails.length !== 6) {
+        throw new Error("Need exactly 6 rails to build a hex frame");
+      }
+      return {
+        inputs: [],
+        outputs: [
+          makeMaterial<FinishedProduct>({
+            type: "hexFrame",
+            species: rails[0].species,
+          }),
+        ],
+      };
+    },
+  },
+  {
+    name: "Build Serving Tray",
+    id: "buildServingTray",
+    requiredSkill: "trayWork",
+    duration: 35,
+    requiredConsumables: [{ id: "nails", amount: 8 }],
+    inputMaterials: [
+      {
+        type: ["panel"],
+        length: [2],
+        thickness: [3, 4],
+        surface: ["sanded"],
+        quantity: 1,
+        // A real-wood panel bottom at least 8" wide
+        matches: (material) =>
+          isPanel(material) &&
+          panelWidth(material) >= 8 &&
+          material.strips.every((strip) => strip.species !== "pallet"),
+      },
+      {
+        // Four frame rails wrap the panel — the picture frame's stock
+        type: ["board"],
+        species: REAL_WOOD_SPECIES,
+        length: [2],
+        width: [1],
+        thickness: [1],
+        surface: ["sanded"],
+        quantity: 4,
+        matches: (material) =>
+          isBoard(material) && isMiteredFrameRail(material, 45),
+      },
+    ],
+    output: (materials: ReadonlyArray<MaterialInstance>) => {
+      const base = materials.find(isPanel);
+      if (!base) {
+        throw new Error("Serving tray needs a panel bottom");
+      }
+      return {
+        inputs: [],
+        outputs: [
+          makeMaterial<FinishedProduct>({
+            type: "servingTray",
+            species: dominantSpecies(base.strips),
+          }),
+        ],
+      };
+    },
+  },
+  {
+    name: "Build Side Table",
+    id: "buildSideTable",
+    requiredSkill: "furnitureBasics",
+    duration: 60,
+    requiredConsumables: [{ id: "screws", amount: 8 }],
+    inputMaterials: [
+      {
+        type: ["panel"],
+        length: [2],
+        thickness: [4],
+        surface: ["sanded"],
+        quantity: 1,
+        // A wide glued top — past what any single board can be
+        matches: (material) =>
+          isPanel(material) &&
+          panelWidth(material) >= 12 &&
+          material.strips.every((strip) => strip.species !== "pallet"),
+      },
+      {
+        // Four square legs from 8/4 stock, ripped and crosscut
+        type: ["board"],
+        length: [2],
+        width: [2],
+        thickness: [6, 8],
+        surface: ["smooth", "sanded"],
+        quantity: 4,
+      },
+    ],
+    output: (materials: ReadonlyArray<MaterialInstance>) => {
+      const top = materials.find(isPanel);
+      if (!top) {
+        throw new Error("Side table needs a panel top");
+      }
+      return {
+        inputs: [],
+        outputs: [
+          makeMaterial<FinishedProduct>({
+            type: "sideTable",
+            species: dominantSpecies(top.strips),
           }),
         ],
       };

--- a/src/game/machines/expanded-products.test.ts
+++ b/src/game/machines/expanded-products.test.ts
@@ -1,0 +1,257 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { board } from "../board-helpers";
+import { MachineOperation } from "../Machine";
+import {
+  isFinishedProduct,
+  makeMaterial,
+  materialMeetsInput,
+} from "../material-helpers";
+import { getSellValue } from "../material-values";
+import { Board, FinishedProduct, Panel, SignedMiterAngle } from "../Materials";
+import { panel } from "../panel-helpers";
+import { TOOL_TYPES } from "../Tool";
+import { workspace } from "./workspace";
+
+function benchOp(id: string): MachineOperation {
+  const op = workspace.operations.find((o) => o.id === id);
+  assert.ok(op, `bench operation ${id} exists`);
+  return op as MachineOperation;
+}
+
+function toolOp(toolId: keyof typeof TOOL_TYPES, id: string): MachineOperation {
+  const op = TOOL_TYPES[toolId].operations.find((o) => o.id === id);
+  assert.ok(op, `${toolId} operation ${id} exists`);
+  return op as MachineOperation;
+}
+
+/** A frame rail: both ends mitered at the stop, mirrored so corners close. */
+function rail(
+  species: Board["species"],
+  length: Board["length"],
+  angle: SignedMiterAngle,
+): Board {
+  return makeMaterial<Board>({
+    ...board(species, length, 1, 1, "sanded"),
+    ends: {
+      left: { kind: "mitered", angle },
+      right: { kind: "mitered", angle: -angle as SignedMiterAngle },
+    },
+  });
+}
+
+describe("buildBirdhouse", () => {
+  it("takes short deck-board crosscuts and yields a birdhouse", () => {
+    const op = toolOp("hammer", "buildBirdhouse");
+    const requirement = op.inputMaterials[0];
+    assert.ok(materialMeetsInput(board("pallet", 1, 4, 1), requirement));
+    // Whole deck boards are too long
+    assert.ok(!materialMeetsInput(board("pallet", 3, 4, 1), requirement));
+
+    const inputs = Array.from({ length: 4 }, () => board("pallet", 1, 4, 1));
+    const { outputs } = op.output(inputs);
+    assert.ok(isFinishedProduct(outputs[0]));
+    assert.strictEqual(outputs[0].type, "birdhouse");
+    assert.strictEqual(outputs[0].species, "pallet");
+  });
+});
+
+describe("buildCrate", () => {
+  it("takes six whole deck boards", () => {
+    const op = toolOp("hammer", "buildCrate");
+    const inputs = Array.from({ length: 6 }, () => board("pallet", 3, 4, 1));
+    const { outputs } = op.output(inputs);
+    assert.ok(isFinishedProduct(outputs[0]));
+    assert.strictEqual(outputs[0].type, "crate");
+  });
+});
+
+describe("buildStepStool", () => {
+  it("takes stout sides plus thinner treads", () => {
+    const op = toolOp("drill", "buildStepStool");
+    const [sides, treads] = op.inputMaterials;
+    // Crosscut pallet stringers qualify as sides
+    assert.ok(materialMeetsInput(board("pallet", 2, 6, 3), sides));
+    // Deck-board crosscuts qualify as treads
+    assert.ok(materialMeetsInput(board("pallet", 2, 4, 1), treads));
+    // A tread is too thin to be a side
+    assert.ok(!materialMeetsInput(board("pallet", 2, 4, 1), sides));
+
+    const { outputs } = op.output([
+      board("pallet", 2, 6, 3),
+      board("pallet", 2, 6, 3),
+      board("pallet", 2, 4, 1),
+      board("pallet", 2, 4, 1),
+    ]);
+    assert.ok(isFinishedProduct(outputs[0]));
+    assert.strictEqual(outputs[0].type, "stepStool");
+  });
+});
+
+describe("buildBookshelf", () => {
+  it("takes four sanded hardwood boards — twice the single shelf", () => {
+    const op = toolOp("drill", "buildBookshelf");
+    const requirement = op.inputMaterials[0];
+    assert.ok(materialMeetsInput(board("oak", 4, 6, 4, "sanded"), requirement));
+    assert.ok(
+      !materialMeetsInput(board("pallet", 4, 6, 4, "sanded"), requirement),
+    );
+
+    const inputs = Array.from({ length: 4 }, () =>
+      board("oak", 4, 6, 4, "sanded"),
+    );
+    const { outputs } = op.output(inputs);
+    assert.ok(isFinishedProduct(outputs[0]));
+    assert.strictEqual(outputs[0].type, "bookshelf");
+    assert.strictEqual(outputs[0].species, "oak");
+  });
+});
+
+describe("buildHexFrame", () => {
+  const op = benchOp("buildHexFrame");
+  const requirement = op.inputMaterials[0];
+
+  it("wants rails mitered at the 30° stop, mirrored", () => {
+    assert.ok(materialMeetsInput(rail("cherry", 1, 30), requirement));
+    // The picture frame's 45° rails don't close a hexagon
+    assert.ok(!materialMeetsInput(rail("cherry", 1, 45), requirement));
+    // Square-ended stock isn't a rail at all
+    assert.ok(
+      !materialMeetsInput(board("cherry", 1, 1, 1, "sanded"), requirement),
+    );
+  });
+
+  it("produces a hex frame of the rail species", () => {
+    const inputs = Array.from({ length: 6 }, () => rail("cherry", 1, 30));
+    const { outputs } = op.output(inputs);
+    assert.ok(isFinishedProduct(outputs[0]));
+    assert.strictEqual(outputs[0].type, "hexFrame");
+    assert.strictEqual(outputs[0].species, "cherry");
+  });
+});
+
+describe("buildServingTray", () => {
+  const op = benchOp("buildServingTray");
+
+  const bottom = (species: "maple" | "pallet" = "maple"): Panel =>
+    panel(
+      Array.from({ length: 4 }, () => ({
+        species,
+        width: 2 as const,
+      })),
+      2,
+      3,
+      "sanded",
+    );
+
+  it("wants a sanded real-wood panel bottom and 45° rails", () => {
+    const [panelReq, railReq] = op.inputMaterials;
+    assert.ok(materialMeetsInput(bottom(), panelReq));
+    assert.ok(!materialMeetsInput(bottom("pallet"), panelReq));
+    assert.ok(materialMeetsInput(rail("maple", 2, 45), railReq));
+  });
+
+  it("produces a tray named for the panel's dominant wood", () => {
+    const { outputs } = op.output([
+      bottom(),
+      ...Array.from({ length: 4 }, () => rail("maple", 2, 45)),
+    ]);
+    assert.ok(isFinishedProduct(outputs[0]));
+    assert.strictEqual(outputs[0].type, "servingTray");
+    assert.strictEqual(outputs[0].species, "maple");
+  });
+});
+
+describe("buildSideTable", () => {
+  const op = benchOp("buildSideTable");
+
+  it("wants a wide sanded top — wider than any single board", () => {
+    const topReq = op.inputMaterials[0];
+    const wide = panel(
+      Array.from({ length: 6 }, () => ({
+        species: "walnut" as const,
+        width: 2 as const,
+      })),
+      2,
+      4,
+      "sanded",
+    );
+    const narrow = panel(
+      Array.from({ length: 4 }, () => ({
+        species: "walnut" as const,
+        width: 2 as const,
+      })),
+      2,
+      4,
+      "sanded",
+    );
+    assert.ok(materialMeetsInput(wide, topReq));
+    assert.ok(!materialMeetsInput(narrow, topReq));
+  });
+
+  it("wants square 8/4 legs", () => {
+    const legReq = op.inputMaterials[1];
+    assert.ok(materialMeetsInput(board("walnut", 2, 2, 8, "sanded"), legReq));
+    // Thin stock can't hold up a table
+    assert.ok(!materialMeetsInput(board("walnut", 2, 2, 4, "sanded"), legReq));
+  });
+});
+
+describe("finishCheckerboardBoard", () => {
+  const op = benchOp("finishCheckerboardBoard");
+  const requirement = op.inputMaterials[0];
+
+  const blank = (
+    strips: ReadonlyArray<{ species: "walnut" | "maple"; width: 2 }>,
+  ): Panel =>
+    makeMaterial<Panel>({
+      type: "panel",
+      grain: "end",
+      strips,
+      length: 1,
+      thickness: 8,
+      surface: "sanded",
+    });
+
+  const alternating = Array.from({ length: 5 }, (_, i) => ({
+    species: i % 2 === 0 ? ("walnut" as const) : ("maple" as const),
+    width: 2 as const,
+  }));
+
+  it("accepts a striped two-species end-grain blank", () => {
+    assert.ok(materialMeetsInput(blank(alternating), requirement));
+  });
+
+  it("rejects a single-species blank (that's a butcher block)", () => {
+    const uniform = Array.from({ length: 5 }, () => ({
+      species: "walnut" as const,
+      width: 2 as const,
+    }));
+    assert.ok(!materialMeetsInput(blank(uniform), requirement));
+  });
+
+  it("rejects long-grain panels outright", () => {
+    const longGrain = panel(alternating, 1, 8, "sanded");
+    assert.ok(!materialMeetsInput(longGrain, requirement));
+  });
+
+  it("produces the priciest board on the roster", () => {
+    const { outputs } = op.output([blank(alternating)]);
+    assert.ok(isFinishedProduct(outputs[0]));
+    assert.strictEqual(outputs[0].type, "checkerboardCuttingBoard");
+    assert.strictEqual(outputs[0].species, "walnut");
+    assert.strictEqual(outputs[0].accentSpecies, "maple");
+    // Beats the plain end-grain block in the same woods
+    const endGrain = makeMaterial<FinishedProduct>({
+      type: "endGrainCuttingBoard",
+      species: "walnut",
+    });
+    assert.ok(getSellValue(outputs[0]) > getSellValue(endGrain));
+  });
+
+  it("is oilable like every other cutting board", () => {
+    const oil = benchOp("oilCuttingBoard");
+    const { outputs } = op.output([blank(alternating)]);
+    assert.ok(materialMeetsInput(outputs[0], oil.inputMaterials[0]));
+  });
+});

--- a/src/game/material-helpers.ts
+++ b/src/game/material-helpers.ts
@@ -62,6 +62,14 @@ const FINISHED_PRODUCT_TYPES: ReadonlyArray<MaterialInstance["type"]> = [
   "stripedCuttingBoard",
   "sunriseCuttingBoard",
   "endGrainCuttingBoard",
+  "birdhouse",
+  "crate",
+  "stepStool",
+  "hexFrame",
+  "servingTray",
+  "bookshelf",
+  "sideTable",
+  "checkerboardCuttingBoard",
 ];
 
 /**
@@ -298,13 +306,21 @@ export function getMaterialInventorySize(material: MaterialInstance): number {
 
     case "shelf":
     case "planterBox":
+    case "crate":
+    case "stepStool":
+    case "bookshelf":
+    case "sideTable":
       return 20;
 
     case "simpleCuttingBoard":
     case "stripedCuttingBoard":
     case "sunriseCuttingBoard":
     case "endGrainCuttingBoard":
+    case "checkerboardCuttingBoard":
     case "endGrainSlice":
+    case "birdhouse":
+    case "hexFrame":
+    case "servingTray":
       return 10;
 
     case "plywood": {
@@ -346,9 +362,16 @@ export function materialInputMismatches(
   if (inputMaterial.matches && !inputMaterial.matches(material)) {
     mismatches.push("matches");
   }
+  if (
+    inputMaterial.minPanelWidth !== undefined &&
+    (material.type !== "panel" ||
+      panelWidth(material) < inputMaterial.minPanelWidth)
+  ) {
+    mismatches.push("minPanelWidth");
+  }
   for (const key of Object.keys(inputMaterial)) {
-    // Skip quantity and matches: they're not properties of the material
-    if (key === "quantity" || key === "matches") {
+    // Skip the constraint keys that aren't properties of the material
+    if (key === "quantity" || key === "matches" || key === "minPanelWidth") {
       continue;
     } else if (
       !(key in material) ||
@@ -441,23 +464,42 @@ export function createMockMaterial(
     case "stripedCuttingBoard":
     case "sunriseCuttingBoard":
     case "endGrainCuttingBoard":
+    case "birdhouse":
+    case "crate":
+    case "stepStool":
+    case "hexFrame":
+    case "servingTray":
+    case "bookshelf":
+    case "sideTable":
+    case "checkerboardCuttingBoard": {
+      // Carry accent and finish through so requirement-priced work (job
+      // pay, commission previews) values an oiled or two-tone ask correctly
+      const r = requirement as InputMaterialWithQuantity<FinishedProduct>;
       return makeMaterial<FinishedProduct>({
         type: requirement.type[0],
-        species:
-          "species" in requirement
-            ? (requirement.species?.[0] ?? "pine")
-            : "pine",
+        species: r.species?.[0] ?? "pine",
+        ...(r.accentSpecies?.[0] !== undefined
+          ? { accentSpecies: r.accentSpecies[0] }
+          : {}),
+        ...(r.finish?.[0] !== undefined ? { finish: r.finish[0] } : {}),
       });
+    }
 
     case "panel": {
-      // Placeholder display only; a representative single-species blank
+      // Placeholder display only; a representative single-species blank.
+      // Wide-panel requirements get enough strips to actually meet (and
+      // price at) their minimum width.
       const r = requirement as InputMaterialWithQuantity<Panel>;
+      const stripCount = Math.max(
+        5,
+        Math.ceil((requirement.minPanelWidth ?? 0) / 2),
+      );
       return makeMaterial<Panel>({
         type: "panel",
         length: 2,
         thickness: r.thickness?.[0] || 4,
         surface: r.surface?.[0] || "rough",
-        strips: Array.from({ length: 5 }, () => ({
+        strips: Array.from({ length: stripCount }, () => ({
           species: "maple",
           width: 2,
         })),
@@ -538,6 +580,8 @@ const DESCRIBABLE_ATTRIBUTES: Partial<
 // description honest — every key here is a key the matcher enforces.
 const DESCRIBABLE_KEYS: ReadonlyArray<string> = [
   "species",
+  "accentSpecies",
+  "finish",
   "kind",
   "surface",
   "grain",
@@ -668,6 +712,10 @@ export function describeMaterialRequirement(
         );
       }
     }
+  }
+
+  if (req.minPanelWidth !== undefined) {
+    dimClauses.push(`at least ${req.minPanelWidth}" wide`);
   }
 
   const details = [...qualifiers, ...dimClauses];

--- a/src/game/material-values.ts
+++ b/src/game/material-values.ts
@@ -58,6 +58,20 @@ const PRODUCT_VALUES: Record<FinishedProduct["type"], number> = {
   jewelryBox: 90,
   // Eight miters that all have to close up — precision money
   pictureFrame: 55,
+  // The rustic tier below the shelf: quick nailed builds from scrap
+  birdhouse: 35,
+  crate: 50,
+  // Screwed like the planter box, but it has to hold a person
+  stepStool: 70,
+  // Twelve 30° miters — the saw's other stops earning their keep
+  hexFrame: 75,
+  // A panel wrapped in mitered rails: two systems in one piece
+  servingTray: 90,
+  bookshelf: 130,
+  // The first real furniture: a wide glued top on four legs
+  sideTable: 220,
+  // Striped slices, alternated: the showpiece above the butcher block
+  checkerboardCuttingBoard: 250,
 };
 
 /**
@@ -182,7 +196,15 @@ export function getSellValue(material: MaterialInstance): number {
     case "simpleCuttingBoard":
     case "stripedCuttingBoard":
     case "sunriseCuttingBoard":
-    case "endGrainCuttingBoard": {
+    case "endGrainCuttingBoard":
+    case "birdhouse":
+    case "crate":
+    case "stepStool":
+    case "hexFrame":
+    case "servingTray":
+    case "bookshelf":
+    case "sideTable":
+    case "checkerboardCuttingBoard": {
       // Two-tone pieces average their species and add a style premium
       const speciesMultiplier = material.accentSpecies
         ? ((SPECIES_VALUE_MULTIPLIER[material.species] +

--- a/src/game/operation-helpers.ts
+++ b/src/game/operation-helpers.ts
@@ -184,7 +184,16 @@ function generateSingleMockMaterial(
     case "pictureFrame":
     case "simpleCuttingBoard":
     case "stripedCuttingBoard":
-    case "sunriseCuttingBoard": {
+    case "sunriseCuttingBoard":
+    case "endGrainCuttingBoard":
+    case "birdhouse":
+    case "crate":
+    case "stepStool":
+    case "hexFrame":
+    case "servingTray":
+    case "bookshelf":
+    case "sideTable":
+    case "checkerboardCuttingBoard": {
       const reqAny = req as any;
       const product: FinishedProduct = makeMaterial<FinishedProduct>({
         type: materialType as FinishedProduct["type"],

--- a/src/game/saveLoad.ts
+++ b/src/game/saveLoad.ts
@@ -7,7 +7,7 @@ import { defaultParametersFor } from "./operation-helpers";
 import { defaultEntrancePosition } from "./ShopInfo";
 
 const SAVE_KEY = "woodworking-tycoon-save";
-const SAVE_VERSION = 23; // Increment this when GameState structure changes
+const SAVE_VERSION = 24; // Increment this when GameState structure changes
 
 interface SaveData {
   version: number;
@@ -107,6 +107,11 @@ export function loadGame(): GameState | null {
     if (saveData.version === 22) {
       saveData.gameState = migrateV22toV23(saveData.gameState);
       saveData.version = 23;
+    }
+
+    if (saveData.version === 23) {
+      saveData.gameState = migrateV23toV24(saveData.gameState);
+      saveData.version = 24;
     }
 
     // Check version - if it doesn't match, the save is incompatible
@@ -519,5 +524,29 @@ export function migrateV22toV23(old: any): GameState {
       ...old.progression,
       lumberyardUnlocked: old.reputation >= LUMBERYARD_MIN_REPUTATION,
     },
+  };
+}
+
+/**
+ * v23 → v24: the job board tracks which job templates it has already
+ * offered work for, so newly-gained capabilities get a burst of matching
+ * offers. Seeded with the templates that existed before this version —
+ * the capabilities an old save already had shouldn't burst, while the
+ * templates new in this version announce themselves on the next refresh.
+ */
+export function migrateV23toV24(old: any): GameState {
+  return {
+    ...old,
+    seenJobTemplateIds: [
+      "pallet-boards",
+      "rustic-shelves",
+      "miter-crosscuts",
+      "ripped-slats",
+      "sanded-boards",
+      "planed-stringers",
+      "planter-boxes",
+      "cutting-boards",
+      "picture-frames",
+    ],
   };
 }

--- a/src/game/tools/drill.ts
+++ b/src/game/tools/drill.ts
@@ -1,4 +1,8 @@
-import { FinishedProduct, MaterialInstance } from "../Materials";
+import {
+  FinishedProduct,
+  MaterialInstance,
+  REAL_WOOD_SPECIES,
+} from "../Materials";
 import { makeMaterial } from "../material-helpers";
 import { ToolType } from "../Tool";
 
@@ -47,6 +51,81 @@ export const drill: ToolType = {
             makeMaterial<FinishedProduct>({
               type: "planterBox",
               species: "pallet",
+            }),
+          ],
+        };
+      },
+    },
+    {
+      name: "Build Step Stool",
+      id: "buildStepStool",
+      requiredSkill: "rusticCarpentry",
+      duration: 30,
+      // It has to hold a person, so every joint gets a screw
+      requiredConsumables: [{ id: "screws", amount: 10 }],
+      inputMaterials: [
+        // Two stout sides — crosscut stringers or thick hardwood
+        {
+          type: ["board"],
+          width: [6],
+          length: [2],
+          thickness: [3, 4],
+          quantity: 2,
+        },
+        // Two treads of thinner stock
+        {
+          type: ["board"],
+          width: [4],
+          length: [2],
+          thickness: [1, 2],
+          quantity: 2,
+        },
+      ],
+      output: (materials: ReadonlyArray<MaterialInstance>) => {
+        const boards = materials.filter((m) => m.type === "board");
+        if (boards.length !== 4) {
+          throw new Error("Need exactly 4 boards to build a step stool");
+        }
+        return {
+          inputs: [],
+          outputs: [
+            makeMaterial<FinishedProduct>({
+              type: "stepStool",
+              species: boards[0].species,
+            }),
+          ],
+        };
+      },
+    },
+    {
+      name: "Build Bookshelf",
+      id: "buildBookshelf",
+      requiredSkill: "fineShelving",
+      duration: 40,
+      requiredConsumables: [{ id: "screws", amount: 12 }],
+      inputMaterials: [
+        // Twice the stock of a single shelf: two shelves, two sides
+        {
+          type: ["board"],
+          species: REAL_WOOD_SPECIES,
+          length: [4],
+          width: [6],
+          thickness: [4],
+          surface: ["sanded"],
+          quantity: 4,
+        },
+      ],
+      output: (materials: ReadonlyArray<MaterialInstance>) => {
+        const boards = materials.filter((m) => m.type === "board");
+        if (boards.length !== 4) {
+          throw new Error("Need exactly 4 boards to build a bookshelf");
+        }
+        return {
+          inputs: [],
+          outputs: [
+            makeMaterial<FinishedProduct>({
+              type: "bookshelf",
+              species: boards[0].species,
             }),
           ],
         };

--- a/src/game/tools/hammer.ts
+++ b/src/game/tools/hammer.ts
@@ -58,5 +58,73 @@ export const hammer: ToolType = {
         };
       },
     },
+    {
+      name: "Build Birdhouse",
+      id: "buildBirdhouse",
+      requiredSkill: "rusticCarpentry",
+      duration: 20,
+      requiredConsumables: [{ id: "nails", amount: 6 }],
+      inputMaterials: [
+        // Short deck-board crosscuts: walls, floor, and a pitched roof
+        {
+          type: ["board"],
+          width: [4],
+          length: [1],
+          thickness: [1],
+          quantity: 4,
+        },
+      ],
+      output: (materials: ReadonlyArray<MaterialInstance>) => {
+        const boards = materials.filter(
+          (m: MaterialInstance): m is Board => m.type === "board",
+        );
+        if (boards.length !== 4) {
+          throw new Error("Need exactly 4 boards to build a birdhouse");
+        }
+        return {
+          inputs: [],
+          outputs: [
+            makeMaterial<FinishedProduct>({
+              type: "birdhouse",
+              species: boards[0].species,
+            }),
+          ],
+        };
+      },
+    },
+    {
+      name: "Build Crate",
+      id: "buildCrate",
+      requiredSkill: "rusticCarpentry",
+      duration: 25,
+      requiredConsumables: [{ id: "nails", amount: 12 }],
+      inputMaterials: [
+        // Six whole deck boards: slatted sides and a bottom
+        {
+          type: ["board"],
+          width: [4],
+          length: [3],
+          thickness: [1],
+          quantity: 6,
+        },
+      ],
+      output: (materials: ReadonlyArray<MaterialInstance>) => {
+        const boards = materials.filter(
+          (m: MaterialInstance): m is Board => m.type === "board",
+        );
+        if (boards.length !== 6) {
+          throw new Error("Need exactly 6 boards to build a crate");
+        }
+        return {
+          inputs: [],
+          outputs: [
+            makeMaterial<FinishedProduct>({
+              type: "crate",
+              species: boards[0].species,
+            }),
+          ],
+        };
+      },
+    },
   ],
 };

--- a/tests/fixtures/consumables-shop.ts
+++ b/tests/fixtures/consumables-shop.ts
@@ -98,6 +98,7 @@ export const consumablesShop: GameState = {
   },
   listings: [],
   jobBoard: [],
+  seenJobTemplateIds: [],
   acceptedJobs: [],
   categoryDemand: {},
   dust: {},

--- a/tests/fixtures/cutting-board-shop.ts
+++ b/tests/fixtures/cutting-board-shop.ts
@@ -92,6 +92,7 @@ export const cuttingBoardShop: GameState = {
   },
   listings: [],
   jobBoard: [],
+  seenJobTemplateIds: [],
   acceptedJobs: [],
   categoryDemand: {},
   dust: {},

--- a/tests/fixtures/end-grain-shop.ts
+++ b/tests/fixtures/end-grain-shop.ts
@@ -121,6 +121,7 @@ export const endGrainShop: GameState = {
   },
   listings: [],
   jobBoard: [],
+  seenJobTemplateIds: [],
   acceptedJobs: [],
   categoryDemand: {},
   dust: {},

--- a/tests/fixtures/hand-tools-shop.ts
+++ b/tests/fixtures/hand-tools-shop.ts
@@ -93,6 +93,7 @@ export const handToolsShop: GameState = {
   },
   listings: [],
   jobBoard: [],
+  seenJobTemplateIds: [],
   acceptedJobs: [],
   categoryDemand: {},
   dust: {},

--- a/tests/fixtures/layout-with-placed-machines.ts
+++ b/tests/fixtures/layout-with-placed-machines.ts
@@ -127,6 +127,7 @@ export const layoutWithPlacedMachines: GameState = {
   },
   listings: [],
   jobBoard: [],
+  seenJobTemplateIds: [],
   acceptedJobs: [],
   categoryDemand: {},
   dust: {},

--- a/tests/fixtures/marketplace-shop.ts
+++ b/tests/fixtures/marketplace-shop.ts
@@ -71,6 +71,7 @@ export const marketplaceShop: GameState = {
   },
   listings: [],
   jobBoard: [],
+  seenJobTemplateIds: [],
   acceptedJobs: [],
   categoryDemand: {},
   dust: {},

--- a/tests/fixtures/milling-shop.ts
+++ b/tests/fixtures/milling-shop.ts
@@ -108,6 +108,7 @@ export const millingShop: GameState = {
   },
   listings: [],
   jobBoard: [],
+  seenJobTemplateIds: [],
   acceptedJobs: [],
   categoryDemand: {},
   dust: {},

--- a/tests/fixtures/miter-frame-shop.ts
+++ b/tests/fixtures/miter-frame-shop.ts
@@ -119,6 +119,7 @@ export const miterFrameShop: GameState = {
   },
   listings: [],
   jobBoard: [],
+  seenJobTemplateIds: [],
   acceptedJobs: [],
   categoryDemand: {},
   dust: {},

--- a/tests/fixtures/miter-saw-crate-shop.ts
+++ b/tests/fixtures/miter-saw-crate-shop.ts
@@ -89,6 +89,7 @@ export const miterSawCrateShop: GameState = {
   },
   listings: [],
   jobBoard: [],
+  seenJobTemplateIds: [],
   acceptedJobs: [],
   categoryDemand: {},
   dust: {},

--- a/tests/fixtures/pattern-board-shop.ts
+++ b/tests/fixtures/pattern-board-shop.ts
@@ -127,6 +127,7 @@ export const patternBoardShop: GameState = {
   },
   listings: [],
   jobBoard: [],
+  seenJobTemplateIds: [],
   acceptedJobs: [],
   categoryDemand: {},
   dust: {},


### PR DESCRIPTION
Implements the content-expansion plan from the recipes/commissions audit: the authored commission sequence now runs through all existing (and new) content, the job board keeps pace with the player's capabilities, and eight new sellable products fill out the ladder.

## Commission sequence (8 new, 7 → 15)

| # | Name | Deliverable | Introduces |
|---|------|-------------|------------|
| 8 | Balcony Garden | 2 planter boxes | drill + screws |
| 9 | Oiled &amp; Ready | 2 oiled cutting boards | finishes, hands-free soak |
| 10 | Gallery Wall | 2 hardwood picture frames | 45° stops + first journal skill purchase |
| 11 | Shelving, But Nice | 2 hardwood shelves | fine shelving |
| 12 | Stripes | 1 walnut/maple striped board | two-species glue-ups, species-specific ask |
| 13 | Small Treasures | 2 jewelry boxes | thin planed stock |
| 14 | The Sunrise Board | 1 sunrise board | freeform lamination |
| 15 | The Butcher's Block | 1 oiled end-grain block | jig building; the finale |

Ordering respects every skill prerequisite chain. Skills are player-purchased with XP points, so from #10 on the descriptions point at the journal; commission XP alone (rewardMoney/5) funds ~7 of the ~9 points needed by the finale, with operation/job XP covering the rest.

## New products (8) and skills (4)

- **Hammer:** birdhouse, crate (pallet-tier variety)
- **Drill:** step stool, bookshelf (screwed assembly)
- **Bench:** hex frame (consumes the miter saw's previously unused 30° stop, via new `polygonJoinery`), serving tray (panel + mitered rails, `trayWork`), side table (wide glue-up top on 8/4 legs, `furnitureBasics`), checkerboard end-grain board (cashes in the strip pattern `EndGrainSlice` already carries, `checkerboards`)

Sprites reuse existing renderers (box/frame/cutting-board), with a real two-tone checker grid added to `CuttingBoardSprite`. The journal lays out new skills automatically; marketplace demand categories are automatic.

## Job board overhaul

- **14 new templates** covering tiers 5–9: oiled/striped/sunrise/end-grain/checkerboard boards, fine shelves, bookshelves, jewelry boxes, gallery frame batches, hex frames, serving trays, side tables, step stools, birdhouses, crates, and a raw table-top **panel blank** that sells lamination work directly.
- **Species-specific asks:** hardwood product requests sometimes name one specific buyable species (drawn from the unlocked lumber channels), paying its full value through the existing fair-value pricing and tipping +1 reputation.
- **Three refresh guarantees:** the existing zero-cost income floor; a **new-capability burst** (templates never before available each land a guaranteed offer, tracked via a new `seenJobTemplateIds` field — save v24 with migration); and a **top-tier guarantee** so the board always wants the player's best work.
- **Low-tier scaling:** pallet-errand batch sizes grow with reputation instead of going stale.

## Supporting changes

- Requirements can now constrain `finish` / `accentSpecies` declaratively (works with the existing key matcher) and panel width via a new serializable `minPanelWidth` — job offers persist through JSON save/load, so generated requirements must never carry `matches` predicates (regression-tested).
- `createMockMaterial` carries finish/accent through so oiled/two-tone asks price correctly; requirement descriptions render the new constraints; `generateSingleMockMaterial` also gained the previously-missing `endGrainCuttingBoard` case.

## Testing

- `npm run tsc` clean.
- Unit suite: 548 tests pass, including new suites for the 8 recipes (`expanded-products.test.ts`), the job board guarantees/serializability (`job-generation.test.ts`), and the extended commission invariants.
- E2E: 14/17 pass locally; the 3 failures (`basic`, `game-sounds`, `settings`) reproduce identically on `main` in this sandbox (sound-asset fetches reset by the environment proxy) and are unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1enyxFVJVfr9a7p4cQRyF