### PR TITLE
Stop agents from killing the dev server you have open

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "permissions": {
+    "ask": ["Bash(pkill:*)", "Bash(killall:*)"]
+  },
   "hooks": {
     "PostToolUse": [
       {

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -6,11 +6,29 @@ description: How to launch and drive this app to verify changes at the browser s
 # Verifying changes in Woodworking Tycoon
 
 The surface is a browser GUI (React + PIXI). Do NOT use the user's dev
-server (port 3001). Start a throwaway one:
+server (port 3001) or the E2E one (3002). Start a throwaway one, on a free
+port, with the `--verify-server` marker:
 
 ```sh
-ES_BUILD_DEV_PORT=3003 node esbuild-client.config.mjs --dev &   # kill when done
+PORT=3003   # any free port that isn't 3001 or 3002
+ES_BUILD_DEV_PORT=$PORT node esbuild-client.config.mjs --dev --verify-server &
+echo $! > "/tmp/wwt-verify-$PORT.pid"
 ```
+
+The marker does nothing to the build — the config only looks for `--dev` —
+but it puts a word in this process's command line that the user's server
+does not have. Stop it by PID when you're done:
+
+```sh
+kill "$(cat /tmp/wwt-verify-3003.pid)"
+```
+
+**Never `pkill -f esbuild`, `pkill -f "esbuild-client.config.mjs --dev"`, or
+anything else matching the bare config name.** The user keeps a dev server
+running all day whose command line is exactly `node esbuild-client.config.mjs
+--dev`, and those patterns SIGTERM it out from under them. If the pidfile is
+gone, `pkill -f -- "--verify-server"` is the widest pattern that is still
+safe (it can only hit verify servers, including other agents').
 
 Drive it with Playwright from a Node script (`@playwright/test` is a
 dependency; use `createRequire` pointed at this repo's package.json if the

--- a/esbuild-client.config.mjs
+++ b/esbuild-client.config.mjs
@@ -12,6 +12,12 @@ import tailwind from "tailwindcss";
 
 const isDev = process.argv.some((arg) => arg == "--dev");
 
+// Other argv is ignored on purpose. An agent's throwaway verify server passes
+// `--verify-server` (see .claude/skills/verify) purely so its command line
+// differs from yours: `pkill -f "esbuild-client.config.mjs --dev"` matches
+// every dev server on the machine, and the one it kills is usually the one
+// you've had open all day. Don't "clean up" the unrecognized flag.
+
 // Where the bundle lands and what the dev server serves. The E2E server
 // overrides this so a test run and a `npm run dev` you have open can't
 // overwrite each other's output — they build the same sources with


### PR DESCRIPTION
Every time an agent made a change, the dev server died with `[dev] SIGTERM received, shutting down.` The sender was the agent.

`.claude/skills/verify` told agents to start a throwaway server as:

```sh
ES_BUILD_DEV_PORT=3003 node esbuild-client.config.mjs --dev &   # kill when done
```

`ES_BUILD_DEV_PORT` is an env prefix, so it never reaches argv — that process's command line is `node esbuild-client.config.mjs --dev`, byte-for-byte the same as the one `npm run dev` gives you. The skill said "kill when done" without saying how, so cleanup fell back to pattern matching. Across the session transcripts that lands on `pkill -f "esbuild-client.config.mjs --dev"` (~15 times, plus variants), usually chained right before `npm run test`. `pkill` sends SIGTERM. The full path is irrelevant to `-f`, so an agent in a worktree still kills the server in your main checkout.

## Changes

- **`--verify-server` marker.** The verify server now passes an extra arg that the user's never has. The config only looks for `--dev`, so it changes nothing about the build — it just puts a distinguishing word in the command line.
- **Kill by pid.** The skill writes `$!` to a per-port pidfile and stops the server with `kill "$(cat ...)"`, and names the patterns that are off limits. `pkill -f -- "--verify-server"` is documented as the widest still-safe fallback.
- **`permissions.ask` on `pkill`/`killall`,** so a broad kill prompts instead of landing silently. (`ask`, not `deny` — sometimes it's the right tool.)
- **A note in `esbuild-client.config.mjs`** so nobody "cleans up" the unrecognized flag.

## Verified

Started a marked server on 3009 alongside the running dev server on 3001:

```
=== OLD pattern 'esbuild-client.config.mjs --dev' would hit: ===
5676 node esbuild-client.config.mjs --dev                    <- yours
9800 node esbuild-client.config.mjs --dev --verify-server

=== NEW pattern '--verify-server' hits: ===
9800 node esbuild-client.config.mjs --dev --verify-server
```

The marked server built and served (HTTP 200), and `kill "$(cat …pid)"` stopped it with PID 5676 still running.

Note: these are config/skill files — they take effect once this is on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)