### PR TITLE
Stand the milling fixture off the jointer's beds

### DIFF
--- a/tests/fixtures/milling-shop.ts
+++ b/tests/fixtures/milling-shop.ts
@@ -46,14 +46,19 @@ function roughWalnut(id: string): Board {
 }
 
 /**
- * The full milling chain, ready to run: jointer (op cell [2,10], where the
- * player starts), planer (op cell [4,10]), table saw with the straight-line
- * sled mounted (op cell [8,10]), and a workspace (op cell [10,4]). The
- * feed-through machines sit mid-shop in their own columns, each with the
- * 6–7' of lane an 8' board needs both sides (see feed-clearance.ts). Two
- * rough walnut boards in the player's pockets, 22 reputation so every
- * lumber channel is open in the store, and jigsAndFixtures unlocked so
- * the sled operates.
+ * The full milling chain, ready to run: jointer (op cell [2,10]), planer
+ * (op cell [4,10]), table saw with the straight-line sled mounted (op cell
+ * [8,10]), and a workspace (op cell [10,4]). The feed-through machines sit
+ * mid-shop in their own columns, each with the 6–7' of lane an 8' board
+ * needs both sides (see feed-clearance.ts). Two rough walnut boards in the
+ * player's pockets, 22 reputation so every lumber channel is open in the
+ * store, and jigsAndFixtures unlocked so the sled operates.
+ *
+ * The player starts a step back from the jointer's infeed, facing it,
+ * rather than on the operation cell itself: the jointer's beds overhang
+ * its footprint by a couple of inches (see the measured collision box),
+ * so a body dropped at that cell's *center* lands inside the outfeed
+ * table — deeper than it could ever walk. One cell back is clear floor.
  */
 export const millingShop: GameState = {
   tick: 0,
@@ -64,8 +69,8 @@ export const millingShop: GameState = {
   materialPiles: [],
   player: {
     name: "Player",
-    position: [2, 10], // the jointer's operation cell
-    direction: 0,
+    position: [2, 11], // one step down the jointer's infeed lane
+    direction: 1, // facing the jointer
     inventory: [roughWalnut("test-rough-1"), roughWalnut("test-rough-2")],
     busyTicks: 0,
     away: null,

--- a/tests/milling.spec.ts
+++ b/tests/milling.spec.ts
@@ -286,9 +286,10 @@ test.describe("Milling", () => {
     });
 
     await test.step("power switch: no cut until the jointer is switched on", async () => {
-      // Player starts on the jointer's operation cell, boards in hand.
-      // With two rough boards carried the machine would grab the first —
-      // park the spare on the floor so the jointer reads one board.
+      // Step up to the jointer's operation cell, boards in hand. With two
+      // rough boards carried the machine would grab the first — park the
+      // spare on the floor so the jointer reads one board.
+      await movePlayerTo(page, [2, 10]);
       await handSlot(page, "Walnut 4/4").first().click();
       await page.waitForTimeout(30);
       // The machine wears its state and its keys — there is no panel


### PR DESCRIPTION
The milling-shop fixture started the player at `[2,10]`, the jointer's operation cell. The jointer's measured collision box overhangs its footprint by ~0.19 cells at each end (the beds run longer than the 2×3-ft footprint), so the body — 0.8-cell half-width, snapped to the cell's *center* on fixture load — landed 0.49 cells inside the outfeed table. Deeper than a walking body could ever press in, hence the weirdness: the player is drawn standing in the machine and can't walk back to where they started.

Start them one cell back down the infeed lane at `[2,11]`, facing the jointer. `milling.spec.ts` steps up to `[2,10]` before throwing the power switch.

Verified: `npm run test:unit` (791 pass — the cleaning-chain sequence tests run off this fixture), `npx playwright test tests/milling.spec.ts` (pass), `npm run tsc`, prettier clean.

Note, not changed here: `resaw-shop` (player at `[2,9]`, 0.46 into the bandsaw) and `miter-saw-crate-shop` (player at `[0,0]`, 0.28 into a neighbouring box) have the same spawn overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)