### PR TITLE
Fix the stale code comments the docs audit turned up

### DIFF
--- a/src/components/station/BlueprintStack.tsx
+++ b/src/components/station/BlueprintStack.tsx
@@ -77,7 +77,7 @@ export const BlueprintSheet: React.FC<{
         {/* Title block, the way real drawings carry one */}
         <div className="mt-2 border border-white/40 bg-black/10">
           <div className="flex items-baseline justify-between gap-2 border-b border-white/25 px-2 py-0.5">
-            <figcaption className="truncate font-stencil text-[0.8rem] uppercase tracking-wide text-white">
+            <figcaption className="truncate font-condensed text-[0.8rem] font-bold uppercase tracking-wide text-white">
               {operation.name}
             </figcaption>
             <span className="shrink-0 font-condensed text-[0.6rem] uppercase tracking-[0.15em] text-white/70">

--- a/src/components/station/MachineChips.tsx
+++ b/src/components/station/MachineChips.tsx
@@ -36,7 +36,7 @@ import { useMachineActivity } from "../shop-view/useMachineActivity";
  * state on one line, then a key chip per verb that applies right now —
  * the same weight as the player's own "[F] put down" hint, nothing
  * card-like. Buttons, scales, and racks live on the station sheet
- * (Enter); the in-world sprite already shows settings physically (the
+ * (Tab); the in-world sprite already shows settings physically (the
  * fence rides its rail, the miter head swings).
  */
 export const MachineChips: React.FC<{ machine: Machine }> = ({ machine }) => {

--- a/src/game/ShopVac.ts
+++ b/src/game/ShopVac.ts
@@ -19,7 +19,7 @@ export interface ShopVacState {
 }
 
 export const SHOP_VAC_COST = 350;
-/** ~5 full cells' worth before a trip to the garbage. */
+/** Dozens of cells filled to DUST_MAX_PER_CELL before a trip to the garbage. */
 export const SHOP_VAC_CANISTER_CAPACITY = 500;
 /** Dragging it over dust cleans a trickle underfoot, every tick. */
 export const SHOP_VAC_PASSIVE_RATE = 6;

--- a/src/game/game-actions/store-actions.ts
+++ b/src/game/game-actions/store-actions.ts
@@ -122,7 +122,8 @@ export function buyMachineAction(
       },
     };
 
-    // A first purchase can trip progression milestones (see UNLOCK_CONDITIONS)
+    // Buying gear can reveal manual articles that key on what the shop owns
+    // (see MANUAL_ARTICLES) — the milestone check is where that lands.
     return checkProgressionMilestonesAction()(updatedState);
   };
 }

--- a/src/game/machines/jobsiteTableSaw.ts
+++ b/src/game/machines/jobsiteTableSaw.ts
@@ -45,7 +45,8 @@ export const jobsiteTableSaw: MachineType = {
   outputPosition: [0, -2],
   cost: 300,
   materialStorage: 0,
-  // One jig at a time — the crosscut sled is the first
+  // Room for two of the shop-built jigs at once — there are more sleds and
+  // fences to build than the saw can wear, so which two are mounted matters
   toolSlots: 2,
   // One board on the table at a time. What's on it decides the cut — an
   // edge-jointed board rips against the fence, a rough one rides the


### PR DESCRIPTION
Closes #128.

Four of the eight sites the issue lists were already true on `main` — the docs-audit follow-up commits (`2e8812f` folding carrying-machines.md into machine-actions, `4fcb374` folding direct-feed-machines.md into `Machine.ts`) rewrote them along the way. I checked each and left them alone:

- `src/game/shortcuts.ts` — the carry-machine def no longer claims carrying is gated; it explains the contextual chip instead.
- `src/game/Machine.ts` — the `directFeed` doc now says the bay *is* the machine's table (`inputSpaces: 1`), which is what every direct-feed machine ships.
- `src/components/material-sprites/MaterialSprite.tsx` — the mangled comment is gone; it reads "Blueprint-assembled products draw from their bill of materials," matching the routing under it.
- `src/game/game-actions/store-actions.ts` — the "unlocks machine carrying" half was dropped, but the residual "(see `UNLOCK_CONDITIONS`)" pointer was still wrong, so that one is fixed below.

## What changed

- **`store-actions.ts`** — buying a machine trips no `UNLOCK_CONDITIONS` entry (they key on completed commissions, reputation, and dust). What a purchase *can* reveal is a manual article gated on `ownsMachine`, and `checkProgressionMilestonesAction` scans those too — so the comment now points at `MANUAL_ARTICLES`.
- **`ShopVac.ts`** — the canister comment predates the dust rescale: ~5 full cells at the old ceiling, dozens at today's `DUST_MAX_PER_CELL`. Rewritten to name the constant rather than a number that will rot the next time it moves.
- **`MachineChips.tsx`** — the station sheet opens on Tab, not Enter (`open-station-sheet` in `shortcuts.ts`).
- **`jobsiteTableSaw.ts`** — "One jig at a time" sat over `toolSlots: 2`. The saw wears two of the shop-built jigs at once, and there are more to build than it can hold, so the comment says that.

Plus the live design-system violation found the same way: **`BlueprintStack.tsx`** set the blueprint title block's `<figcaption>` in `font-stencil`, which `docs/design-system.md` reserves for painted retail signage (the Orange Box wordmark). It's bold `font-condensed` now, like every other heading — the sheet's other title-block line already was.

## Testing

- `npm run tsc` — clean
- `npm run test:unit` — 1101 pass
- `npx playwright test tests/stations.spec.ts tests/bench.spec.ts` — both pass (the two specs that render `BlueprintSheet`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017nwLtVV7LmQnonEVn3EbXd

---
_Generated by [Claude Code](https://claude.ai/code/session_017nwLtVV7LmQnonEVn3EbXd)_