### PR TITLE
Make benchtop machines pay for sitting on the floor

### DIFF
--- a/src/components/bench-view/BlueprintCorner.tsx
+++ b/src/components/bench-view/BlueprintCorner.tsx
@@ -5,6 +5,7 @@ import {
   Operation,
   operationParameters,
 } from "../../game/Machine";
+import { stationWorkSpeed } from "../../game/bench-mounting";
 import { machineDustMultiplier } from "../../game/Dust";
 import { MACHINE_ARTICLES } from "../../game/manual";
 import { setMachineOperationAction } from "../../game/game-actions/player-actions";
@@ -200,7 +201,7 @@ export const BlueprintCorner: React.FC<{ machine: Machine }> = ({
                           operation,
                           gameState.progression,
                           dustMultiplier,
-                          machine.workSpeed,
+                          stationWorkSpeed(machine, gameState),
                         ),
                       )}
                     </span>

--- a/src/components/manual/articles/ShopLayoutArticle.tsx
+++ b/src/components/manual/articles/ShopLayoutArticle.tsx
@@ -41,6 +41,21 @@ export const ShopLayoutArticle: React.FC = () => (
       other; keep the outfeed clear too.
     </P>
 
+    <H>Benchtop Machines</H>
+    <P>
+      Some machines are built to sit on a bench rather than on the ground: the
+      planer, the jointer, the jobsite table saw, and the miter saw. Set one on
+      a worktable and it runs at full speed. Left on the floor, its table sits
+      at your knees and every cut takes twice as long. Carry it up onto a
+      worktable as soon as you've built one.
+    </P>
+    <P>
+      The machine has to fit entirely on the table's top — a machine with one
+      foot still on the ground is a machine on the ground. The shelf below
+      doubles as its stand storage, and whatever top is left over is still yours
+      to work on.
+    </P>
+
     <Note>
       Give the table saw the middle of the long wall — long rips need room on
       both ends.

--- a/src/components/shop-view/useMachineActivity.tsx
+++ b/src/components/shop-view/useMachineActivity.tsx
@@ -1,3 +1,4 @@
+import { stationWorkSpeed } from "../../game/bench-mounting";
 import { machineDustMultiplier } from "../../game/Dust";
 import { Machine, machineKey } from "../../game/Machine";
 import { playerAttendsMachine } from "../../game/machine-helpers";
@@ -27,7 +28,7 @@ export function useMachineActivity(machine: Machine) {
         operation,
         gameState.progression,
         machineDustMultiplier(gameState.dust, machine, gameState.shopInfo.size),
-        machine.workSpeed,
+        stationWorkSpeed(machine, gameState),
       )
     : [];
   // Same rule the tick uses: standing there isn't enough, you have to be

--- a/src/components/station/BlueprintStack.tsx
+++ b/src/components/station/BlueprintStack.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from "react";
+import { stationWorkSpeed } from "../../game/bench-mounting";
 import { clampsFor, clampsFree } from "../../game/Clamp";
 import { consumableLabel } from "../../game/Consumable";
 import {
@@ -96,7 +97,7 @@ export const BlueprintSheet: React.FC<{
                     operation,
                     gameState.progression,
                     dustMultiplier,
-                    machine.workSpeed,
+                    stationWorkSpeed(machine, gameState),
                   ),
                 )}
               </span>

--- a/src/components/station/MachineChips.tsx
+++ b/src/components/station/MachineChips.tsx
@@ -11,6 +11,7 @@ import {
   OperationParameter,
   operationParameters,
 } from "../../game/Machine";
+import { isBenchtopOnFloor } from "../../game/bench-mounting";
 import { canPickUpMachine } from "../../game/game-actions/machine-actions";
 import { heldTool } from "../../game/HeldTool";
 import {
@@ -126,6 +127,11 @@ export const MachineChips: React.FC<{ machine: Machine }> = ({ machine }) => {
     gameState.player.carriedMachine == null &&
     canPickUpMachine(gameState, machine.state);
 
+  // A benchtop machine sitting on the ground works, badly — say why the
+  // cut is slow right where the player is standing to make it (see
+  // bench-mounting.ts).
+  const onFloor = isBenchtopOnFloor(machine, gameState);
+
   // What the station says it's doing: its own word for the job when it has
   // one ("emptying" at the garbage can), the generic motor otherwise.
   const workingWord =
@@ -149,6 +155,11 @@ export const MachineChips: React.FC<{ machine: Machine }> = ({ machine }) => {
         {machine.type.name}
         {status && <> · {status}</>}
       </HintRow>
+      {onFloor && (
+        <HintRow className="max-w-56 whitespace-normal normal-case italic tracking-normal text-store-orange/90">
+          On the floor: work here takes twice as long. Set it on a worktable.
+        </HintRow>
+      )}
       {interactHere && (
         <HintRow keys={<ShortcutKeys shortcut="pick-up" />}>
           {interactLabel(interactHere)}

--- a/src/components/station/useOperationProgress.ts
+++ b/src/components/station/useOperationProgress.ts
@@ -1,3 +1,4 @@
+import { stationWorkSpeed } from "../../game/bench-mounting";
 import { machineDustMultiplier } from "../../game/Dust";
 import { Machine } from "../../game/Machine";
 import { getOperationPhases } from "../../game/skill-helpers";
@@ -33,7 +34,7 @@ export function useOperationProgress(machine: Machine): OperationProgressView {
         operation,
         gameState.progression,
         machineDustMultiplier(gameState.dust, machine, gameState.shopInfo.size),
-        machine.workSpeed,
+        stationWorkSpeed(machine, gameState),
       )
     : [];
 

--- a/src/game/bench-mounting.test.ts
+++ b/src/game/bench-mounting.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import {
+  FLOOR_WORK_PENALTY,
+  isBenchtopOnFloor,
+  isMountedOnWorktable,
+  stationWorkSpeed,
+} from "./bench-mounting";
+import { GameState } from "./GameState";
+import { getMachines, Machine, MachineState } from "./Machine";
+import { initialGameState } from "./initialGameState";
+
+function machineAt(
+  machineTypeId: MachineState["machineTypeId"],
+  position: [number, number],
+  overrides: Partial<MachineState> = {},
+): MachineState {
+  return {
+    machineTypeId,
+    position,
+    rotation: 0,
+    inputMaterials: [],
+    processingMaterials: [],
+    outputMaterials: [],
+    selectedOperationId: "none",
+    selectedParameters: undefined,
+    operationProgress: {
+      status: "notStarted",
+      phaseIndex: 0,
+      ticksRemaining: 0,
+    },
+    tools: [],
+    storedMaterials: [],
+    ...overrides,
+  };
+}
+
+/** The state plus a lookup of the placed machine view by type id. */
+function shopWith(machines: ReadonlyArray<MachineState>): {
+  gameState: GameState;
+  machine: (typeId: string) => Machine;
+} {
+  const gameState: GameState = { ...initialGameState, machines };
+  const views = getMachines(machines);
+  return {
+    gameState,
+    machine: (typeId) => views.find((m) => m.type.id === typeId)!,
+  };
+}
+
+describe("benchtop mounting", () => {
+  // A 6'×2' table at the origin; the miter saw's 3×2 footprint fits
+  // entirely on its top when anchored at [1,1] (see worktables.test.ts).
+  const table = machineAt("worktable1x3", [0, 0]);
+
+  it("counts a benchtop machine wholly on a table as mounted", () => {
+    const { gameState, machine } = shopWith([
+      table,
+      machineAt("miterSaw", [1, 1]),
+    ]);
+    assert.ok(isMountedOnWorktable(machine("miterSaw"), gameState));
+    assert.ok(!isBenchtopOnFloor(machine("miterSaw"), gameState));
+  });
+
+  it("counts a benchtop machine on bare floor as not mounted", () => {
+    const { gameState, machine } = shopWith([machineAt("miterSaw", [6, 6])]);
+    assert.ok(!isMountedOnWorktable(machine("miterSaw"), gameState));
+    assert.ok(isBenchtopOnFloor(machine("miterSaw"), gameState));
+  });
+
+  it("does not count a machine half off the table as mounted", () => {
+    // Anchored at [5,1], the saw's footprint runs past the table's right
+    // edge — one foot on the top, one on the ground.
+    const { gameState, machine } = shopWith([
+      table,
+      machineAt("miterSaw", [5, 1]),
+    ]);
+    assert.ok(!isMountedOnWorktable(machine("miterSaw"), gameState));
+    assert.ok(isBenchtopOnFloor(machine("miterSaw"), gameState));
+  });
+
+  it("leaves floor-standing machines alone", () => {
+    // The band saw belongs on the floor: no penalty, and it is never
+    // "mounted" however it's placed.
+    const { gameState, machine } = shopWith([machineAt("bandSaw", [6, 6])]);
+    assert.ok(!isMountedOnWorktable(machine("bandSaw"), gameState));
+    assert.ok(!isBenchtopOnFloor(machine("bandSaw"), gameState));
+    assert.strictEqual(
+      stationWorkSpeed(machine("bandSaw"), gameState),
+      machine("bandSaw").workSpeed,
+    );
+  });
+});
+
+describe("the floor penalty", () => {
+  const table = machineAt("worktable1x3", [0, 0]);
+
+  it("halves work speed for a benchtop machine on the floor", () => {
+    const onFloor = shopWith([machineAt("miterSaw", [6, 6])]);
+    const mounted = shopWith([table, machineAt("miterSaw", [1, 1])]);
+    assert.strictEqual(
+      stationWorkSpeed(mounted.machine("miterSaw"), mounted.gameState) /
+        stationWorkSpeed(onFloor.machine("miterSaw"), onFloor.gameState),
+      FLOOR_WORK_PENALTY,
+    );
+  });
+
+  it("runs a mounted machine at its own undiminished speed", () => {
+    const { gameState, machine } = shopWith([
+      table,
+      machineAt("miterSaw", [1, 1]),
+    ]);
+    assert.strictEqual(
+      stationWorkSpeed(machine("miterSaw"), gameState),
+      machine("miterSaw").workSpeed,
+    );
+  });
+
+  it("ignores the hosting table's own speed and upgrades", () => {
+    // The penalty is binary: a vise on the bench has no business making
+    // the saw cut faster.
+    const bare = shopWith([table, machineAt("miterSaw", [1, 1])]);
+    const upgraded = shopWith([
+      machineAt("worktable1x3", [0, 0], { upgrades: ["vise"] }),
+      machineAt("miterSaw", [1, 1]),
+    ]);
+    assert.strictEqual(
+      stationWorkSpeed(upgraded.machine("miterSaw"), upgraded.gameState),
+      stationWorkSpeed(bare.machine("miterSaw"), bare.gameState),
+    );
+  });
+});

--- a/src/game/bench-mounting.ts
+++ b/src/game/bench-mounting.ts
@@ -1,0 +1,79 @@
+import { CellMap } from "./CellMap";
+import { GameState } from "./GameState";
+import { Machine } from "./Machine";
+import { rotateVec, translateVec, Vector } from "./Vectors";
+
+/**
+ * Where a benchtop machine sits, and what it costs to leave it on the
+ * floor.
+ *
+ * A benchtop machine (MachineType.benchtop — the lunchbox planer, jointer,
+ * jobsite table saw, miter saw) is built to live on a bench: its table is
+ * knee-high on the ground, so you feed it stooped over and fight the stock
+ * the whole way. It still works, it just works badly. Mounted on a
+ * worktable it runs at the duration its operations declare; on the floor
+ * every attended phase takes FLOOR_WORK_PENALTY times as long.
+ *
+ * The penalty is binary — a machine is either up on a table or it isn't.
+ * The table's own workSpeed and its upgrades stay out of it: a vise and a
+ * drawer of chisels have no business speeding up a planer, and they
+ * already pay for themselves in the hand work the table does host.
+ *
+ * "Mounted" means every cell the machine occupies has a worktable under
+ * it. Placement (canPlaceMachine) checks table-vs-floor per cell, so a
+ * wide machine can technically straddle a table's edge; a machine with one
+ * foot on the ground is not mounted.
+ */
+export const FLOOR_WORK_PENALTY = 2;
+
+/**
+ * Whether this placed machine is sitting on a worktable. False for
+ * anything that isn't a benchtop machine — a floor-standing band saw is
+ * exactly where it belongs.
+ */
+export function isMountedOnWorktable(
+  machine: Machine,
+  gameState: GameState,
+): boolean {
+  if (!machine.type.benchtop) {
+    return false;
+  }
+  const cellMap = CellMap.fromGameState(gameState);
+  return machine.type.cellsOccupied.every((relativeCell) => {
+    const position: Vector = translateVec(
+      rotateVec(relativeCell, machine.rotation),
+      machine.position,
+    );
+    return cellMap.at(position)?.tableMachine !== undefined;
+  });
+}
+
+/**
+ * Whether this machine is a benchtop machine left on the shop floor —
+ * the state the penalty applies to, and the one the UI calls out.
+ */
+export function isBenchtopOnFloor(
+  machine: Machine,
+  gameState: GameState,
+): boolean {
+  return (
+    Boolean(machine.type.benchtop) && !isMountedOnWorktable(machine, gameState)
+  );
+}
+
+/**
+ * The work speed to run this station's attended phases at: the machine's
+ * own effective speed (type base × installed upgrades), halved when it's a
+ * benchtop machine still on the floor. Everything that turns an operation
+ * into ticks should read speed through here rather than off
+ * `Machine.workSpeed`, the way dust slowdown comes through
+ * machineDustMultiplier.
+ */
+export function stationWorkSpeed(
+  machine: Machine,
+  gameState: GameState,
+): number {
+  return isBenchtopOnFloor(machine, gameState)
+    ? machine.workSpeed / FLOOR_WORK_PENALTY
+    : machine.workSpeed;
+}

--- a/src/game/game-actions/operation-actions.ts
+++ b/src/game/game-actions/operation-actions.ts
@@ -1,3 +1,4 @@
+import { stationWorkSpeed } from "../bench-mounting";
 import { addConsumables, ConsumableAmount } from "../Consumable";
 import { machineDustMultiplier } from "../Dust";
 import { GameAction, GameState } from "../GameState";
@@ -347,7 +348,7 @@ export function finishAttendedWorkAction(machine: Machine): GameAction {
       operation,
       gameState.progression,
       machineDustMultiplier(gameState.dust, live, gameState.shopInfo.size),
-      live.workSpeed,
+      stationWorkSpeed(live, gameState),
     );
     const { phaseIndex } = machineState.operationProgress;
     if (phases[Math.min(phaseIndex, phases.length - 1)].attended === false) {
@@ -630,7 +631,7 @@ export function startGlueUpAction(
       operation,
       gameState.progression,
       machineDustMultiplier(gameState.dust, live, gameState.shopInfo.size),
-      live.workSpeed,
+      stationWorkSpeed(live, gameState),
     );
     return {
       ...gameState,

--- a/src/game/game-actions/player-actions.ts
+++ b/src/game/game-actions/player-actions.ts
@@ -1,4 +1,5 @@
 import { materialMeetsInput } from "../material-helpers";
+import { stationWorkSpeed } from "../bench-mounting";
 import { seatedAssemblyPieces } from "../bench-work/assembly";
 import { productBlueprintFor } from "../bench-work/blueprint";
 import { CellMap } from "../CellMap";
@@ -579,7 +580,7 @@ export function operateMachineAction(
         operation,
         gameState.progression,
         machineDustMultiplier(gameState.dust, machine, gameState.shopInfo.size),
-        machine.workSpeed,
+        stationWorkSpeed(machine, gameState),
       );
       return {
         ...gameState,
@@ -653,7 +654,7 @@ export function operateMachineAction(
         match.operation,
         gameState.progression,
         machineDustMultiplier(gameState.dust, machine, gameState.shopInfo.size),
-        machine.workSpeed,
+        stationWorkSpeed(machine, gameState),
       );
       return {
         ...gameState,
@@ -768,7 +769,7 @@ export function operateMachineAction(
       selectedOperation,
       gameState.progression,
       machineDustMultiplier(gameState.dust, machine, gameState.shopInfo.size),
-      machine.workSpeed,
+      stationWorkSpeed(machine, gameState),
     );
     return {
       ...gameState,

--- a/src/game/game-actions/tickAction.ts
+++ b/src/game/game-actions/tickAction.ts
@@ -1,3 +1,4 @@
+import { stationWorkSpeed } from "../bench-mounting";
 import { deriveMachineCutLoad } from "../cut-load";
 import { emitMachineDust, machineDustMultiplier } from "../Dust";
 import { DUST_BAG_CAPTURE } from "../tools/dustBag";
@@ -161,7 +162,7 @@ export function machineTickPass(): GameAction {
         selectedOperation,
         gameState.progression,
         dustMultiplier,
-        machine.workSpeed,
+        stationWorkSpeed(machine, gameState),
       );
       // What "attended" takes — presence, grip, power — lives in
       // operationAttendanceSatisfied, shared with the time-flow model so

--- a/src/game/skill-helpers.ts
+++ b/src/game/skill-helpers.ts
@@ -64,9 +64,10 @@ const GLUE_OPERATION_IDS = [
 /**
  * The operation's phase list with passive skills applied per phase, then
  * the dust slowdown (see Dust.ts machineDustMultiplier) and the station's
- * work speed (MachineType.workSpeed — a solid worktable beats the wobbly
- * makeshift bench) applied to the attended phases — a buried machine or a
- * bad bench slows your handwork, not the glue's cure. Ops that declare no
+ * work speed (bench-mounting.ts stationWorkSpeed — a solid worktable beats
+ * the wobbly makeshift bench, and a benchtop machine left on the floor is
+ * worse than either) applied to the attended phases — a buried machine or
+ * a bad bench slows your handwork, not the glue's cure. Ops that declare no
  * phases are one attended stretch of hand work. Phase durations are read
  * as each phase is entered, so a skill bought (or a floor swept)
  * mid-operation affects the remaining phases but not the current one.

--- a/src/game/time-flow.ts
+++ b/src/game/time-flow.ts
@@ -1,3 +1,4 @@
+import { stationWorkSpeed } from "./bench-mounting";
 import { machineDustMultiplier } from "./Dust";
 import { GameState } from "./GameState";
 import { heldTool } from "./HeldTool";
@@ -109,7 +110,7 @@ function machineSpendsTime(gameState: GameState, machine: Machine): boolean {
     operation,
     gameState.progression,
     machineDustMultiplier(gameState.dust, machine, gameState.shopInfo.size),
-    machine.workSpeed,
+    stationWorkSpeed(machine, gameState),
   );
   const { phaseIndex, ticksRemaining } = machineState.operationProgress;
   const phase =

--- a/tests/milling.spec.ts
+++ b/tests/milling.spec.ts
@@ -296,6 +296,10 @@ test.describe("Milling", () => {
       await page.waitForTimeout(30);
       // The machine wears its state and its keys — there is no panel
       await expect(page.getByText("Jointer · off")).toBeVisible();
+      // A benchtop machine on the shop floor says why its cuts are slow
+      await expect(
+        page.getByText(/On the floor: work here takes twice as long/),
+      ).toBeVisible();
       // Switched off it takes nothing: no chip offering to place the board
       await expect(page.getByText(/place Walnut 4\/4/)).toHaveCount(0);
       await switchOn(page);


### PR DESCRIPTION
Closes #118.

The planer, jointer, jobsite table saw, and miter saw (`MachineType.benchtop`) are built to live on a bench. Until now they worked exactly as well sitting on the ground as mounted on a worktable. Now, left on the floor, every attended phase takes **twice as long**; up on a worktable they run at the duration their operations declare.

## The design decisions

- **Floor is a penalty, not mounting a bonus.** Today's declared durations stay the *mounted* speed, so floor placement inflates them rather than mounting deflating them.
- **2× gap** between floor and mounted.
- **Binary.** The hosting table's own `workSpeed` and its installed upgrades stay out of it — a vise has no business speeding up a planer, and it already pays for itself in the hand work the table hosts.
- **"Mounted" means fully mounted.** Every occupied cell needs a table under it. `canPlaceMachine` checks table-vs-floor per cell, so a wide machine can technically straddle a table's edge; a machine with one foot on the ground is a machine on the ground.

## What changed

New module `src/game/bench-mounting.ts` owns the rule, with the explanation in its header rather than a new doc file (one owning module → no doc).

Everything that turns an operation into ticks now reads speed through `stationWorkSpeed(machine, gameState)` instead of off `Machine.workSpeed` — the same shape dust slowdown already has via `machineDustMultiplier`. That's all 11 call sites: the tick, the time-flow clock, the start-operation actions, and every UI duration readout, so they can't drift. The two blueprint pickers are no-ops today (worktables aren't benchtop machines) but route consistently rather than becoming a future drift point.

Player-facing readout:

- The targeted machine's hint cluster gains a keyless row — *"On the floor: work here takes twice as long. Set it on a worktable."*
- A **Benchtop Machines** section in the shop manual's layout article.

## Testing

- `npm run tsc` clean.
- 7 new unit tests in `bench-mounting.test.ts`: mounted, on bare floor, half off the table, floor-standing band saw unaffected, the 2× ratio, and upgrades not passing through.
- Full unit suite: 1108 pass. The first run showed 2 failures, so I re-ran five more times — all clean, consistent with the known-flaky progression tests rather than this change.
- Full E2E: 7/7, including a new assertion in `milling.spec.ts` that the floor-sitting jointer really renders the warning chip.

## One balance caveat

The progression ledger survives the 2× penalty, but it asserts *reachability* — can you afford the next machine, does the grind clear the next reputation gate — not elapsed time. So it shows the penalty doesn't make the game unwinnable; it does not show the opening still *feels* right.

All four benchtop machines are floor-bound until the first shop-built worktable, since the makeshift workspace isn't a `worktable`. That whole stretch is now twice as slow. Whether that's the intended pressure or a slog is a play-test question, not a test-suite one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
