### PR TITLE
Clip the end-grain rings to the board's cut face

### DIFF
--- a/src/components/material-sprites/BoardOnEndSprite.tsx
+++ b/src/components/material-sprites/BoardOnEndSprite.tsx
@@ -1,6 +1,7 @@
 import { Graphics } from "pixi.js";
 import React, { useCallback } from "react";
 import { Board } from "../../game/Materials";
+import { clipArcToRect } from "../../utils/arcClipping";
 import { colorToNumber, mixColors } from "../../utils/colorUtils";
 import { omitUndefined } from "../../utils/objectUtils";
 import { seededRandom } from "../../utils/randUtils";
@@ -13,6 +14,10 @@ import { PIXELS_PER_INCH } from "../shop-view/shop-scale";
  * waits under a face-down top. Drawn darker than the face (end grain
  * drinks light) with a few growth arcs seeded off the piece's id, so
  * standing a board up doesn't reroll its character.
+ *
+ * The arcs are rings around a pith sitting off the face, the way a flatsawn
+ * board's end reads, and they are clipped to the cut face — a ring only
+ * exists where the saw exposed it.
  */
 export const BoardOnEndSprite: React.FC<
   {
@@ -32,6 +37,7 @@ export const BoardOnEndSprite: React.FC<
       const face = colorBySpecies[species].primary;
       const endGrain = colorToNumber(mixColors(face, 0x000000, 0.25));
       const ring = colorToNumber(mixColors(face, 0x000000, 0.45));
+      const cut = { x: -w / 2, y: -h / 2, width: w, height: h };
 
       // shadow: the standing piece throws a slightly wider foot
       for (const spread of [1, 2]) {
@@ -47,13 +53,31 @@ export const BoardOnEndSprite: React.FC<
       g.rect(-w / 2, -h / 2, w, h);
       g.fill(endGrain);
 
-      // growth arcs sweeping in from one corner, like a real end cut
-      const cx = -w / 2 + rand() * w;
-      const cy = h / 2 + rand() * h * 0.5;
-      for (let i = 1; i <= 3; i++) {
-        const radius = (Math.max(w, h) * i) / 3 + rand() * 2;
-        g.arc(cx, cy, radius, Math.PI, Math.PI * 2);
-        g.stroke({ color: ring, width: 1, alpha: 0.5 });
+      // Growth rings around a pith below the face, spaced so each one actually
+      // crosses the cut, then trimmed to the piece.
+      const pithX = (rand() - 0.5) * w * 2;
+      const pithY = h / 2 + w * (0.6 + rand() * 1.0);
+      const ringCount = Math.max(2, Math.min(5, Math.round(w / 6)));
+      for (let i = 0; i < ringCount; i++) {
+        const t = (i + 0.5 + (rand() - 0.5) * 0.5) / ringCount;
+        const crossingX = -w / 2 + t * w;
+        const radius = Math.hypot(crossingX - pithX, pithY);
+        const spans = clipArcToRect(
+          pithX,
+          pithY,
+          radius,
+          Math.PI,
+          Math.PI * 2,
+          cut,
+        );
+        for (const [from, to] of spans) {
+          g.moveTo(
+            pithX + radius * Math.cos(from),
+            pithY + radius * Math.sin(from),
+          );
+          g.arc(pithX, pithY, radius, from, to);
+          g.stroke({ color: ring, width: 1, alpha: 0.5 });
+        }
       }
 
       // a hairline rim so the block reads as a cut face, not a fill

--- a/src/utils/arcClipping.test.ts
+++ b/src/utils/arcClipping.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { clipArcToRect, ClipRect } from "./arcClipping";
+
+const UNIT_SQUARE: ClipRect = { x: -1, y: -1, width: 2, height: 2 };
+
+function pointsInside(
+  spans: [number, number][],
+  cx: number,
+  cy: number,
+  r: number,
+  rect: ClipRect,
+): boolean {
+  return spans.every(([from, to]) =>
+    [from + 1e-6, (from + to) / 2, to - 1e-6].every((a) => {
+      const x = cx + r * Math.cos(a);
+      const y = cy + r * Math.sin(a);
+      return (
+        x >= rect.x - 1e-6 &&
+        x <= rect.x + rect.width + 1e-6 &&
+        y >= rect.y - 1e-6 &&
+        y <= rect.y + rect.height + 1e-6
+      );
+    }),
+  );
+}
+
+describe("clipArcToRect", () => {
+  it("keeps a whole arc that never leaves the rect", () => {
+    const spans = clipArcToRect(0, 0, 0.5, 0, Math.PI * 2, UNIT_SQUARE);
+    assert.deepStrictEqual(spans, [[0, Math.PI * 2]]);
+  });
+
+  it("drops an arc that never enters the rect", () => {
+    const spans = clipArcToRect(10, 10, 1, 0, Math.PI * 2, UNIT_SQUARE);
+    assert.deepStrictEqual(spans, []);
+  });
+
+  it("drops an arc that encircles the rect without touching it", () => {
+    const spans = clipArcToRect(0, 0, 5, 0, Math.PI * 2, UNIT_SQUARE);
+    assert.deepStrictEqual(spans, []);
+  });
+
+  it("cuts a circle that straddles one edge into a single span", () => {
+    // Centered on the right edge, so only the left half of the circle is in.
+    const spans = clipArcToRect(1, 0, 0.5, 0, Math.PI * 2, UNIT_SQUARE);
+    assert.strictEqual(spans.length, 1);
+    const [[from, to]] = spans;
+    assert.ok(to - from > 0);
+    assert.ok(
+      Math.abs(to - from - Math.PI) < 1e-6,
+      `expected half the sweep, got ${to - from}`,
+    );
+    assert.ok(pointsInside(spans, 1, 0, 0.5, UNIT_SQUARE));
+  });
+
+  it("returns several spans when a big circle crosses a thin strip twice", () => {
+    // A strip much wider than it is tall, with a ring sweeping through it.
+    const strip: ClipRect = { x: -10, y: -1, width: 20, height: 2 };
+    const spans = clipArcToRect(0, 4, 6, 0, Math.PI * 2, strip);
+    assert.strictEqual(spans.length, 2);
+    assert.ok(pointsInside(spans, 0, 4, 6, strip));
+  });
+
+  it("only reports spans within the requested sweep", () => {
+    const spans = clipArcToRect(0, 0, 0.5, Math.PI, Math.PI * 2, UNIT_SQUARE);
+    assert.deepStrictEqual(spans, [[Math.PI, Math.PI * 2]]);
+  });
+
+  it("clips a sweep that starts outside the rect", () => {
+    const strip: ClipRect = { x: -10, y: -1, width: 20, height: 2 };
+    const spans = clipArcToRect(0, 4, 6, Math.PI, Math.PI * 2, strip);
+    assert.ok(spans.length >= 1);
+    assert.ok(
+      spans.every(([from, to]) => from >= Math.PI && to <= Math.PI * 2),
+    );
+    assert.ok(pointsInside(spans, 0, 4, 6, strip));
+  });
+
+  it("ignores a degenerate radius or a backwards sweep", () => {
+    assert.deepStrictEqual(clipArcToRect(0, 0, 0, 0, Math.PI, UNIT_SQUARE), []);
+    assert.deepStrictEqual(clipArcToRect(0, 0, 1, Math.PI, 0, UNIT_SQUARE), []);
+  });
+});

--- a/src/utils/arcClipping.ts
+++ b/src/utils/arcClipping.ts
@@ -1,0 +1,88 @@
+/**
+ * Clipping an arc to a rectangle, in angles rather than pixels.
+ *
+ * PIXI's Graphics has no clip path, and drawing a circle "inside" a shape by
+ * masking costs an extra display object per sprite. When the shape is an
+ * axis-aligned rectangle — a board's end-grain face, say — the honest answer
+ * is cheaper: work out which stretches of the sweep are inside the rectangle
+ * and only draw those.
+ */
+
+export interface ClipRect {
+  /** Left edge, in the same space as the circle's center. */
+  x: number;
+  /** Top edge. */
+  y: number;
+  width: number;
+  height: number;
+}
+
+const TAU = Math.PI * 2;
+/** Angular slop when testing a span's midpoint, so tangents don't flicker. */
+const EPSILON = 1e-9;
+
+/**
+ * The stretches of the arc `[start, end]` on the circle at (cx, cy) that fall
+ * inside `rect`, as `[from, to]` angle pairs in the arc's own direction.
+ * Returns `[]` when the arc never enters the rectangle, and `[[start, end]]`
+ * when it never leaves. `end` must be at or after `start`.
+ */
+export function clipArcToRect(
+  cx: number,
+  cy: number,
+  radius: number,
+  start: number,
+  end: number,
+  rect: ClipRect,
+): [number, number][] {
+  if (!(radius > 0) || end <= start) return [];
+
+  const left = rect.x;
+  const right = rect.x + rect.width;
+  const top = rect.y;
+  const bottom = rect.y + rect.height;
+
+  // Every angle at which the circle crosses one of the four edge *lines*.
+  // Crossings outside the edge's extent are harmless: they only split a span
+  // that the midpoint test then classifies as a whole.
+  const crossings: number[] = [];
+  for (const x of [left, right]) {
+    const cos = (x - cx) / radius;
+    if (cos >= -1 && cos <= 1) {
+      const a = Math.acos(cos);
+      crossings.push(a, -a);
+    }
+  }
+  for (const y of [top, bottom]) {
+    const sin = (y - cy) / radius;
+    if (sin >= -1 && sin <= 1) {
+      const a = Math.asin(sin);
+      crossings.push(a, Math.PI - a);
+    }
+  }
+
+  // Lift each crossing into every turn the sweep actually covers.
+  const cuts = [start, end];
+  for (const crossing of crossings) {
+    const base = crossing - TAU * Math.floor((crossing - start) / TAU);
+    for (let a = base; a < end; a += TAU) {
+      if (a > start) cuts.push(a);
+    }
+  }
+  cuts.sort((a, b) => a - b);
+
+  const spans: [number, number][] = [];
+  for (let i = 0; i < cuts.length - 1; i++) {
+    const from = cuts[i];
+    const to = cuts[i + 1];
+    if (to - from <= EPSILON) continue;
+    const mid = (from + to) / 2;
+    const x = cx + radius * Math.cos(mid);
+    const y = cy + radius * Math.sin(mid);
+    if (x < left || x > right || y < top || y > bottom) continue;
+    const previous = spans[spans.length - 1];
+    if (previous && from - previous[1] <= EPSILON) previous[1] = to;
+    else spans.push([from, to]);
+  }
+  return spans;
+}


### PR DESCRIPTION
Fixes #138.

A board stood on end (`BoardOnEndSprite`) drew three growth arcs seeded off the piece id and never clipped them, so at the bench view's zoom the rings swept across the bench far outside the width × thickness face.

- Rings now radiate from a pith sitting off the face, with radii chosen so each ring actually crosses the cut instead of missing it or dwarfing it.
- Each arc is trimmed to the face by a new `clipArcToRect` (`src/utils/arcClipping.ts`) — angle-space clipping, since PIXI's Graphics has no clip path and a display mask would cost an extra object per sprite. It has unit tests of its own.

Checked: `npm run tsc` clean, `npm run test:unit` 1124/1124 pass, and an offline SVG render of the exact draw math across six board sections (thin planks, square legs, chunks) shows every ring inside its face.

🤖 Generated with [Claude Code](https://claude.com/claude-code)