### PR TITLE
Slide the miter saw's cut line by the inch, a foot with shift

### DIFF
--- a/src/components/current-cell-info/CutLineScale.tsx
+++ b/src/components/current-cell-info/CutLineScale.tsx
@@ -2,10 +2,11 @@ import React from "react";
 import { OperationParameter } from "../../game/Machine";
 import { Board } from "../../game/Materials";
 import { classNames } from "../../utils/classNames";
+import { formatLength } from "../../utils/formatNumber";
 import { Tooltip } from "../Tooltip";
 
-/** The longest board in the game — the widget's full width, in feet. */
-const FULL_LENGTH = 8;
+/** The longest board in the game — the widget's full width, in inches. */
+const FULL_LENGTH = 96;
 
 /**
  * The miter saw's cut input, drawn as the thing you'd actually do: the
@@ -28,9 +29,15 @@ export const CutLineScale: React.FC<{
   /** The station is working: the cut line reads out but won't slide. */
   locked?: boolean;
 }> = ({ param, value, onSelect, satisfiable, board, angle, locked }) => {
-  const pct = (feet: number) => `${(feet / FULL_LENGTH) * 100}%`;
+  const pct = (inches: number) => `${(inches / FULL_LENGTH) * 100}%`;
   const position = typeof value === "number" ? value : Number(value) || 0;
   const length = board?.length;
+  // How far apart the marks sit, so each one's hit target is exactly its
+  // own share of the rule and clicking anywhere lands on the nearest.
+  const markSpacing =
+    param.values.length > 1
+      ? Math.abs(Number(param.values[1]) - Number(param.values[0]))
+      : FULL_LENGTH;
 
   return (
     <div
@@ -51,13 +58,13 @@ export const CutLineScale: React.FC<{
       >
         {/* Foot marks scribed on the stock itself */}
         {Array.from(
-          { length: (length ?? FULL_LENGTH) - 1 },
-          (_, i) => i + 1,
-        ).map((foot) => (
+          { length: Math.ceil((length ?? FULL_LENGTH) / 12) - 1 },
+          (_, i) => (i + 1) * 12,
+        ).map((inches) => (
           <span
-            key={foot}
+            key={inches}
             className="absolute top-0 h-full w-px bg-ink-black/15"
-            style={{ left: `${(foot / (length ?? FULL_LENGTH)) * 100}%` }}
+            style={{ left: `${(inches / (length ?? FULL_LENGTH)) * 100}%` }}
           />
         ))}
       </div>
@@ -69,13 +76,13 @@ export const CutLineScale: React.FC<{
             className="absolute top-[0.7rem] flex h-4 -translate-x-1/2 items-center font-condensed text-[0.65rem] font-bold tabular-nums text-ink-black/80"
             style={{ left: pct(position / 2) }}
           >
-            {position}&#8242;
+            {formatLength(position)}
           </span>
           <span
             className="absolute top-[0.7rem] flex h-4 -translate-x-1/2 items-center font-condensed text-[0.65rem] font-bold tabular-nums text-ink-black/80"
             style={{ left: pct(position + (length - position) / 2) }}
           >
-            {length - position}&#8242;
+            {formatLength(length - position)}
           </span>
         </>
       )}
@@ -85,47 +92,54 @@ export const CutLineScale: React.FC<{
           className="absolute top-[0.7rem] flex h-4 -translate-x-1/2 items-center font-condensed text-[0.65rem] tabular-nums text-ink-fade"
           style={{ left: pct(length / 2) }}
         >
-          {length}&#8242;
+          {formatLength(length)}
         </span>
       )}
 
-      {/* Foot marks below the table, one per allowed cut line */}
+      {/* One hit target per allowed cut line, each as wide as the gap to
+          the next mark. On an inch rule that's a hair each, so only the
+          foot marks (and whichever line is set) print a number — the rest
+          are unlabeled ticks, the way a tape reads. */}
       {param.values.map((v) => {
         const selected = v === value;
         const reachable = satisfiable?.(v) ?? true;
-        const feet = typeof v === "number" ? v : Number(v);
+        const inches = typeof v === "number" ? v : Number(v);
+        const labeled = selected || inches % 12 === 0;
+        const mark = formatLength(inches);
         return (
           <Tooltip
             key={v}
             content={
               locked
-                ? `Cut line at ${feet}' — the station is working`
+                ? `Cut line at ${mark} — the station is working`
                 : reachable
-                  ? length !== undefined && feet < length
-                    ? `Cut at ${feet}': a ${feet}' and a ${length - feet}' piece`
-                    : `Cut line at ${feet}'`
-                  : `${feet}' — the carried board doesn't reach`
+                  ? length !== undefined && inches < length
+                    ? `Cut at ${mark}: a ${mark} and a ${formatLength(length - inches)} piece`
+                    : `Cut line at ${mark}`
+                  : `${mark} — the carried board doesn't reach`
             }
           >
             <button
               role="radio"
               aria-checked={selected}
-              aria-label={`${feet}'`}
+              aria-label={mark}
               disabled={locked}
               onClick={() => onSelect(v)}
               className={classNames(
-                "group absolute top-0 bottom-0 flex w-4 -translate-x-1/2 flex-col items-center justify-end outline-none",
+                "group absolute top-0 bottom-0 flex min-w-[3px] -translate-x-1/2 flex-col items-center justify-end outline-none",
                 !reachable && "opacity-35",
                 locked && "cursor-not-allowed",
               )}
-              style={{ left: pct(feet) }}
+              style={{ left: pct(inches), width: pct(markSpacing) }}
             >
               <span
                 className={classNames(
                   "w-px",
                   selected
                     ? "h-[0.5rem] w-0.5 bg-ink-blue"
-                    : "h-[0.35rem] bg-ink-black/50",
+                    : labeled
+                      ? "h-[0.35rem] bg-ink-black/50"
+                      : "h-[0.2rem] bg-ink-black/30",
                   !selected && !locked && "group-hover:bg-ink-black",
                 )}
               />
@@ -134,9 +148,10 @@ export const CutLineScale: React.FC<{
                   "font-condensed text-[0.65rem] leading-tight tabular-nums",
                   selected ? "font-bold text-ink-blue" : "text-ink-black/70",
                   !selected && !locked && "group-hover:text-ink-black",
+                  !labeled && "invisible",
                 )}
               >
-                {feet}
+                {mark}
               </span>
             </button>
           </Tooltip>

--- a/src/components/shop-view/ShopKeyboardShortcuts.tsx
+++ b/src/components/shop-view/ShopKeyboardShortcuts.tsx
@@ -386,7 +386,15 @@ export const ShopKeyboardShortcuts: React.FC = () => {
   // On direct-feed machines the setting can belong to any available
   // operation (what's in hand decides which one runs); on benches only the
   // selected operation's settings are live.
-  const stepSetting = (kind: "linear" | "rotate", step: 1 | -1) => {
+  //
+  // `coarse` is the shift modifier: it jumps the parameter's declared
+  // coarseStep detents at once (a foot along the miter saw's inch marks)
+  // instead of one, landing on the same marks a bare press walks through.
+  const stepSetting = (
+    kind: "linear" | "rotate",
+    step: 1 | -1,
+    coarse = false,
+  ) => {
     const machine = targeted.current;
     if (!machine) return;
 
@@ -406,7 +414,9 @@ export const ShopKeyboardShortcuts: React.FC = () => {
       machine.selectedParameters?.[param.id] ?? param.defaultValue;
     const currentIndex =
       current === undefined ? -1 : param.values.indexOf(current);
-    let next = param.values[mod(currentIndex + step, param.values.length)];
+    const detents = coarse ? (param.coarseStep ?? 1) : 1;
+    let next =
+      param.values[mod(currentIndex + step * detents, param.values.length)];
 
     // A slide param moves the stock itself, so the key steps between the
     // marks the stock can actually reach — a 4' board slides among its own
@@ -446,12 +456,12 @@ export const ShopKeyboardShortcuts: React.FC = () => {
 
   useShortcut(
     "setting-down",
-    () => stepSetting("linear", -1),
+    (event) => stepSetting("linear", -1, event.shiftKey),
     present && !stationWorking,
   );
   useShortcut(
     "setting-up",
-    () => stepSetting("linear", 1),
+    (event) => stepSetting("linear", 1, event.shiftKey),
     present && !stationWorking,
   );
   // R is claimed by whichever of its three bindings applies: the carried

--- a/src/game/Machine.ts
+++ b/src/game/Machine.ts
@@ -530,6 +530,13 @@ export interface OperationParameter<T = number | string> {
    * why a machine can usefully carry one of each.
    */
   readonly presentation?: "slide" | "rotate";
+  /**
+   * How many detents a shifted press jumps. Declare it on a scale whose
+   * marks are fine enough that walking them one at a time is a chore —
+   * the miter saw's inch marks, where shift moves a whole foot. Left off,
+   * shift steps one detent like a bare press.
+   */
+  readonly coarseStep?: number;
 }
 
 export type ParameterValues = Record<string, number | string>;

--- a/src/game/machines/miter-cuts.test.ts
+++ b/src/game/machines/miter-cuts.test.ts
@@ -31,6 +31,36 @@ const withEnds = (base: Board, ends: Board["ends"]): Board => ({
 const MITERED_45 = { kind: "mitered", angle: 45 } as const;
 const SQUARE = { kind: "square" } as const;
 
+describe("miter saw cut line", () => {
+  const cutLine = cutBoardOp.parameters?.find((p) => p.id === "cutPosition")!;
+
+  it("marks the stock every inch, stopping short of the longest board", () => {
+    assert.deepStrictEqual(
+      cutLine.values.slice(0, 3),
+      [1, 2, 3],
+      "the rule starts at the first inch",
+    );
+    assert.strictEqual(cutLine.values.at(-1), 95);
+    assert.strictEqual(cutLine.values.length, 95);
+  });
+
+  it("jumps a foot on a shifted press", () => {
+    // Z/X walk the marks one at a time; shift moves coarseStep of them
+    assert.strictEqual(cutLine.coarseStep, 12);
+  });
+
+  it("cuts at the inch the line is set to", () => {
+    const { outputs } = cutBoardOp.output([board("oak", 96, 4, 4)], {
+      angle: 0,
+      cutPosition: 25,
+    });
+    assert.deepStrictEqual(
+      outputs.map((piece) => (piece as Board).length),
+      [25, 71],
+    );
+  });
+});
+
 describe("miter saw angle stops", () => {
   it("a 45° cut at the 5' mark miters both fresh faces at the cut line", () => {
     const { outputs } = cutBoardOp.output([board("oak", 96, 4, 4)], {

--- a/src/game/machines/miterSaw.ts
+++ b/src/game/machines/miterSaw.ts
@@ -12,17 +12,28 @@ import { formatLength } from "../../utils/formatNumber";
 export const SAW_ANGLE_STOPS = [-45, -30, -22.5, 0, 22.5, 30, 45] as const;
 
 /**
- * Where along the stock the blade can land, in inches from the board's
- * left end — you slide the board under the blade to a mark, you don't
- * dial in "how long the kept piece is". The detents sit every half foot:
- * fine enough for short work (a birdhouse's 6" sides come off one 12"
- * crosscut, halved), coarse enough that the scale still reads at a
- * glance. A cut needs wood on both sides of the line, so the marks stop
- * short of the longest board.
+ * The half-foot marks of the miter box the hand saw stands in — coarse
+ * enough that a dragged pointer snaps to one cleanly (see
+ * bench-work/tool-work.ts). The powered saw reads a finer rule; see
+ * MITER_CUT_POSITIONS.
  */
 export const CUT_POSITIONS = Array.from(
   { length: 15 },
   (_, i) => (i + 1) * 6,
+) as ReadonlyArray<number>;
+
+/**
+ * Where along the stock the powered saw's blade can land, in inches from
+ * the board's left end — you slide the board under the blade to a mark,
+ * you don't dial in "how long the kept piece is". The marks are an inch
+ * apart, the way a tape reads: Z and X walk them one inch at a time, and
+ * shift jumps a whole foot (the parameter's coarseStep). A cut needs
+ * wood on both sides of the line, so the marks stop an inch short of the
+ * longest board.
+ */
+export const MITER_CUT_POSITIONS = Array.from(
+  { length: 95 },
+  (_, i) => i + 1,
 ) as ReadonlyArray<number>;
 
 export const miterSaw: MachineType = {
@@ -73,11 +84,14 @@ export const miterSaw: MachineType = {
         {
           id: "cutPosition",
           name: "Cut Line",
-          values: CUT_POSITIONS,
+          values: MITER_CUT_POSITIONS,
           // Fresh out of the crate the stock sits mid-table
           defaultValue: 48,
           unit: '"',
           presentation: "slide",
+          // Shift slides the board a foot at a time — 95 inch marks are
+          // too many to walk one press at a time.
+          coarseStep: 12,
         },
         {
           id: "angle",

--- a/src/game/shortcuts.ts
+++ b/src/game/shortcuts.ts
@@ -361,6 +361,9 @@ const defs = [
     description: "Machine setting down / in / left",
     scope: "home",
     group: "Machines",
+    // On a fine scale — the miter saw's inch marks — shift moves a foot
+    // at a time. Scales without a coarse step just move one mark.
+    shiftHint: "move a foot at a time",
   },
   {
     id: "setting-up",
@@ -369,6 +372,7 @@ const defs = [
     description: "Machine setting up / out / right",
     scope: "home",
     group: "Machines",
+    shiftHint: "move a foot at a time",
   },
   {
     id: "cycle-machine",

--- a/tests/milling.spec.ts
+++ b/tests/milling.spec.ts
@@ -95,12 +95,17 @@ async function setAngle(page: any, target: number) {
   throw new Error(`could not swing the head to ${target}`);
 }
 
-/** Z/X — slide the miter saw's cut line to a mark. */
+/**
+ * Z/X — slide the miter saw's cut line to a mark: the marks are an inch
+ * apart, so shift (a foot a press) covers the distance and bare presses
+ * close the last few inches.
+ */
 async function setCutLine(page: any, target: number) {
-  for (let i = 0; i < 16; i++) {
-    const current = await sawSetting(page, "cutPosition");
+  for (let i = 0; i < 32; i++) {
+    const current = Number(await sawSetting(page, "cutPosition"));
     if (current === target) return;
-    await pressKey(page, Number(current) > target ? "z" : "x");
+    const key = current > target ? "z" : "x";
+    await pressKey(page, Math.abs(current - target) >= 12 ? `Shift+${key}` : key);
   }
   throw new Error(`could not slide the cut line to ${target}`);
 }
@@ -470,10 +475,24 @@ test.describe("Milling", () => {
       await expect(sheet).toHaveCount(0);
     });
 
-    await test.step("first cut: 45° at the 5' mark makes a 5' and a 3' piece", async () => {
-      // Board on the table first — the settings move the board that's on
-      // the saw, not a ghost of one you're holding
+    await test.step("the cut line steps an inch, or a foot with shift", async () => {
+      // Board on the table first: the keys slide what's on the saw, and
+      // the marks they stop at are the ones that board can reach.
       await setStockDown(page);
+      await setCutLine(page, 24);
+      await pressKey(page, "x");
+      expect(Number(await sawSetting(page, "cutPosition"))).toBe(25);
+      await pressKey(page, "z");
+      expect(Number(await sawSetting(page, "cutPosition"))).toBe(24);
+      await pressKey(page, "Shift+x");
+      expect(Number(await sawSetting(page, "cutPosition"))).toBe(36);
+      await pressKey(page, "Shift+z");
+      expect(Number(await sawSetting(page, "cutPosition"))).toBe(24);
+    });
+
+    await test.step("first cut: 45° at the 5' mark makes a 5' and a 3' piece", async () => {
+      // The board is already on the table from the step above — the
+      // settings move what's on the saw, not a ghost of what's in hand
       await setAngle(page, 45);
       await setCutLine(page, 60);
       await runWhileHolding(


### PR DESCRIPTION
The miter saw's cut line stopped every half foot. Now it stops every inch, and shift makes the long moves quick.

- **`MITER_CUT_POSITIONS`** — the powered saw's own rule, 1″ through 95″. `CUT_POSITIONS` stays as it was (half-foot) for the hand saw and its miter box: those are the detents a dragged pointer snaps to in the bench view, where coarse is the point.
- **`OperationParameter.coarseStep`** — how many detents a shifted press jumps. The cut line declares `12`; scales that don't declare one step a single mark on shift, as before. Z/X read `event.shiftKey` the way R already does, and the `?` sheet picks the modifier up through `shiftHint`.
- **`CutLineScale`** — it was still measuring in feet against values that had become inches (a 48″ setting put the blade line at 600% width). Full width is now 96″, readouts and tooltips go through `formatLength`, every mark's hit target is its own share of the rule, and only the foot marks (plus whichever line is set) print a number.

### Testing

- `npm run test:unit` — 1119 pass, including new cases for the inch marks, the declared `coarseStep`, and a cut landing at 25″.
- `npm run test:e2e` — all 7 specs pass. `milling.spec.ts` gains a step that presses X, Z, Shift+X, Shift+Z at the saw and asserts 1″ / 1″ / 12″ / 12″; its `setCutLine` helper now uses shift to cover distance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
