### PR TITLE
Cut the floating hints down to verbs

### DIFF
--- a/src/components/shop-overlay/PlayerPrompt.tsx
+++ b/src/components/shop-overlay/PlayerPrompt.tsx
@@ -73,7 +73,8 @@ export const PlayerPrompt: React.FC = () => {
         key="put-down-machine"
         keys={<ShortcutKeys shortcut="carry-machine" />}
       >
-        put down {MACHINE_TYPES[carried.machineTypeId].name}
+        {/* No name: the machine is on your shoulders, drawn there. */}
+        put down
       </HintRow>,
       <HintRow key="rotate" keys={<ShortcutKeys shortcut="carry-rotate" />}>
         rotate
@@ -82,7 +83,7 @@ export const PlayerPrompt: React.FC = () => {
     if (!canPutDownCarriedMachine(gameState)) {
       rows.push(
         <HintRow key="no-room" className="text-store-orange/90">
-          no room to set it down here
+          no room here
         </HintRow>,
       );
     }
@@ -114,14 +115,15 @@ export const PlayerPrompt: React.FC = () => {
           <HintRow
             key="empty-pan"
             keys={<ShortcutKeys shortcut="operate-machine" />}
+            hold
           >
-            hold to empty
+            empty
           </HintRow>,
         );
       } else if (panFill >= 1) {
         rows.push(
           <HintRow key="pan-full" className="text-store-orange/90">
-            dustpan full — empty it at the garbage can
+            dustpan full — empty at the can
           </HintRow>,
         );
       } else if (canSweepAt(gameState)) {
@@ -129,8 +131,9 @@ export const PlayerPrompt: React.FC = () => {
           <HintRow
             key="sweep"
             keys={<ShortcutKeys shortcut="operate-machine" />}
+            hold
           >
-            hold to sweep
+            sweep
           </HintRow>,
         );
       }
@@ -143,14 +146,15 @@ export const PlayerPrompt: React.FC = () => {
           <HintRow
             key="empty-vac"
             keys={<ShortcutKeys shortcut="operate-machine" />}
+            hold
           >
-            hold to empty
+            empty
           </HintRow>,
         );
       } else if (fill >= 1) {
         rows.push(
           <HintRow key="vac-full" className="text-store-orange/90">
-            canister full — empty it at the garbage can
+            canister full — empty at the can
           </HintRow>,
         );
       } else if (canVacuumAt(gameState)) {
@@ -158,21 +162,22 @@ export const PlayerPrompt: React.FC = () => {
           <HintRow
             key="vacuum"
             keys={<ShortcutKeys shortcut="operate-machine" />}
+            hold
           >
-            hold to vacuum
+            vacuum
           </HintRow>,
         );
       }
       rows.push(
         <HintRow key="set-vac" keys={<ShortcutKeys shortcut="vac-toggle" />}>
-          set down vac · {Math.round(fill * 100)}%
+          set down · {Math.round(fill * 100)}%
         </HintRow>,
       );
     }
     if (standingOnVac && !draggingVac) {
       rows.push(
         <HintRow key="grab-vac" keys={<ShortcutKeys shortcut="vac-toggle" />}>
-          grab shop vac
+          grab vac
         </HintRow>,
       );
     }
@@ -187,8 +192,8 @@ export const PlayerPrompt: React.FC = () => {
       )
     ) {
       rows.push(
-        <HintRow key="wait" keys={<ShortcutKeys shortcut="wait" />}>
-          hold to pass time
+        <HintRow key="wait" keys={<ShortcutKeys shortcut="wait" />} hold>
+          pass time
         </HintRow>,
       );
     }
@@ -216,7 +221,7 @@ export const PlayerPrompt: React.FC = () => {
       )}
       {rows.length > 0 && (
         <CellAnchored cell={gameState.player.position}>
-          <HintList>{rows}</HintList>
+          <HintList testId="player-hints">{rows}</HintList>
         </CellAnchored>
       )}
     </>
@@ -227,9 +232,10 @@ export const PlayerPrompt: React.FC = () => {
  * The pickup chip sits on the pile it would grab — the same piece wearing
  * the targeting outline on the canvas, wherever it lies (long stock is
  * grabbable along its whole length; the piece underfoot may rest well off
- * to the side). It names the piece, and with more of them within reach
- * offers R to rummage — unless a machine's rotate setting claims the key
- * (the binding steps aside the same way).
+ * to the side). The piece's name titles the chip the way a machine's name
+ * titles its own (see MachineChips), leaving the key rows to be verbs; with
+ * more pieces within reach it offers R to rummage — unless a machine's
+ * rotate setting claims the key (the binding steps aside the same way).
  */
 const PickupChip: React.FC<{
   piles: ReadonlyArray<MaterialPile>;
@@ -250,10 +256,11 @@ const PickupChip: React.FC<{
       testId="pickup-chip"
     >
       <HintList>
-        <HintRow keys={<ShortcutKeys shortcut="pick-up" />}>
-          pick up · {getMaterialFullName(target.material)}
+        <HintRow className="text-paper-manila/60">
+          {getMaterialFullName(target.material)}
           {place}
         </HintRow>
+        <HintRow keys={<ShortcutKeys shortcut="pick-up" />}>pick up</HintRow>
         {sourceCount > 1 && !rotateSettingLive && (
           <HintRow keys={<ShortcutKeys shortcut="cycle-pile" />}>
             next piece

--- a/src/components/shop-overlay/TruckPrompt.tsx
+++ b/src/components/shop-overlay/TruckPrompt.tsx
@@ -27,7 +27,6 @@ import {
 } from "../../game/lot";
 import { MACHINE_TYPES } from "../../game/Machine";
 import { jobPayout } from "../../game/marketplace";
-import { getMaterialName } from "../../game/material-helpers";
 import { formatMoney } from "../../utils/formatNumber";
 import { interactLabel, resolveInteract } from "../../game/interact";
 import { ShortcutId } from "../../game/shortcuts";
@@ -103,14 +102,16 @@ export const TruckBedPrompt: React.FC<{ canvasWidth: number }> = ({
       // in the bed always agree about what E lifts out.
       <HintRow key="take" keys={<ShortcutKeys shortcut="pick-up" />}>
         {interactLabel(interact)}
-        {interact.count > 1 && ` · ${interact.count} in bed`}
+        {interact.count > 1 && ` (${interact.count})`}
       </HintRow>,
     );
   }
   if (holding) {
     rows.push(
+      // Just the verb: the hands strip already names what's in hand, and
+      // the chip's own title says where it's going.
       <HintRow key="place" keys={<ShortcutKeys shortcut="put-down" />}>
-        place {getMaterialName(gameState.player.inventory[0])}
+        load
       </HintRow>,
     );
   }
@@ -137,7 +138,7 @@ export const TruckBedPrompt: React.FC<{ canvasWidth: number }> = ({
         transform: "translate(-50%, -100%)",
       }}
     >
-      <HintList>
+      <HintList testId="truck-bed-chips">
         <HintRow className="text-paper-manila/60">Truck Bed</HintRow>
         {rows}
       </HintList>
@@ -375,10 +376,10 @@ export const TruckPrompt: React.FC<{
           transform: "translate(-50%, -100%)",
         }}
       >
-        <HintList>
+        <HintList testId="truck-cab-chips">
           <HintRow className="text-paper-manila/60">The truck</HintRow>
           <HintRow keys={<ShortcutKeys shortcut="pick-up" />}>
-            {handoffCount > 0 ? "deliver work" : "head out"}
+            {handoffCount > 0 ? "deliver" : "head out"}
           </HintRow>
         </HintList>
       </div>

--- a/src/components/shortcuts/HintList.tsx
+++ b/src/components/shortcuts/HintList.tsx
@@ -12,11 +12,17 @@ import { HintSurfaceContext } from "./Kbd";
  * surface so key caps and muted text stay readable on the dark background
  * (see Kbd.tsx).
  */
-export const HintList: React.FC<{ children: React.ReactNode }> = ({
-  children,
-}) => (
+export const HintList: React.FC<{
+  children: React.ReactNode;
+  /** Names the cluster for the specs — the labels inside are single verbs
+   * now, too generic to locate a chip by. */
+  testId?: string;
+}> = ({ children, testId }) => (
   <HintSurfaceContext.Provider value="chrome">
-    <ul className="grid grid-cols-[auto_1fr] items-baseline gap-x-1.5 gap-y-0.5 rounded bg-ink-black/70 px-2 py-1 text-left font-condensed text-[0.65rem] uppercase tracking-[0.1em] text-paper-manila/90 whitespace-nowrap">
+    <ul
+      data-testid={testId}
+      className="grid grid-cols-[auto_1fr] items-baseline gap-x-1.5 gap-y-0.5 rounded bg-ink-black/70 px-2 py-1 text-left font-condensed text-[0.65rem] uppercase tracking-[0.1em] text-paper-manila/90 whitespace-nowrap"
+    >
       {children}
     </ul>
   </HintSurfaceContext.Provider>
@@ -27,17 +33,28 @@ export const HintList: React.FC<{ children: React.ReactNode }> = ({
  * in the right. The `<li>` is `display: contents` so both cells sit
  * directly in the list's grid and line up with every other row's;
  * `className` still styles both, since colour inherits through it.
+ *
+ * `hold` marks a key that has to be held down rather than tapped. It rides
+ * the key column, not the label — "hold" describes the press, so the label
+ * column stays a plain list of verbs ("sweep", "rip") instead of every
+ * held key spending three words on "hold to ..." before saying anything.
  */
 export const HintRow: React.FC<{
   keys?: React.ReactNode;
+  hold?: boolean;
   className?: string;
   children: React.ReactNode;
-}> = ({ keys, className, children }) =>
+}> = ({ keys, hold, className, children }) =>
   keys == null ? (
     <li className={classNames("col-span-2", className)}>{children}</li>
   ) : (
     <li className={classNames("contents", className)}>
-      <span className="justify-self-end">{keys}</span>
+      <span className="justify-self-end whitespace-nowrap">
+        {hold && (
+          <span className="mr-1 text-[0.6rem] text-paper-manila/50">hold</span>
+        )}
+        {keys}
+      </span>
       <span>{children}</span>
     </li>
   );

--- a/src/components/station/MachineChips.tsx
+++ b/src/components/station/MachineChips.tsx
@@ -150,7 +150,7 @@ export const MachineChips: React.FC<{ machine: Machine }> = ({ machine }) => {
   ) : null;
 
   return (
-    <HintList>
+    <HintList testId="machine-chips">
       <HintRow className="text-paper-manila/60">
         {machine.type.name}
         {status && <> · {status}</>}
@@ -173,17 +173,20 @@ export const MachineChips: React.FC<{ machine: Machine }> = ({ machine }) => {
           next piece
         </HintRow>
       )}
+      {/* Just the verb: what's in hand is already drawn in the hands
+          strip, so naming it here would say it twice. With an armful the
+          verb can't say *which* piece goes on, so that one names it. */}
       {stageable.length > 0 && (
         <HintRow keys={<ShortcutKeys shortcut="put-down" />}>
-          {machine.type.stageVerb ?? "place"} {getMaterialName(stageable[0])}
+          {machine.type.stageVerb ?? "place"}
+          {stageable.length > 1 && ` ${getMaterialName(stageable[0])}`}
         </HintRow>
       )}
       {/* Hand work has no chip of its own: the bench view owns it
-          (docs/bench-work.md), and the single "use workbench" chip
-          below is the door to all of it — prying, plans, arranging. */}
+          (docs/bench-work.md), and the single "[Tab] use" chip below is
+          the door to all of it — prying, plans, arranging. */}
       {canOperate && !runOperation?.interaction && (
-        <HintRow keys={<ShortcutKeys shortcut="operate-machine" />}>
-          hold to{" "}
+        <HintRow keys={<ShortcutKeys shortcut="operate-machine" />} hold>
           {(runOperation?.name ?? machine.type.feedVerb ?? "run").toLowerCase()}
         </HintRow>
       )}
@@ -235,7 +238,7 @@ export const MachineChips: React.FC<{ machine: Machine }> = ({ machine }) => {
             ? "accessories"
             : machine.type.container
               ? "contents"
-              : "use workbench"}
+              : "use"}
         </HintRow>
       )}
       {machines.length > 1 && (
@@ -243,15 +246,17 @@ export const MachineChips: React.FC<{ machine: Machine }> = ({ machine }) => {
           className="text-paper-manila/70"
           keys={<ShortcutKeys shortcut="cycle-machine" />}
         >
-          next machine ({machines.length} here)
+          next machine · {machines.length}
         </HintRow>
       )}
+      {/* "carry", not "pick up": E on the same cluster is already the
+          pick-up key, and the title has said which machine this is. */}
       {liftable && (
         <HintRow
           className="text-paper-manila/70"
           keys={<ShortcutKeys shortcut="carry-machine" />}
         >
-          pick up {machine.type.name}
+          carry
         </HintRow>
       )}
     </HintList>

--- a/src/game/interact.test.ts
+++ b/src/game/interact.test.ts
@@ -167,7 +167,7 @@ describe("interactLabel", () => {
     const pallet = { type: "pallet" } as never;
     assert.strictEqual(
       interactLabel({ kind: "truck-bed", count: 3, material: pallet }),
-      "pick up Pallet",
+      "take Pallet",
     );
     assert.strictEqual(
       interactLabel({
@@ -177,7 +177,7 @@ describe("interactLabel", () => {
           inputMaterials: [pallet],
         } as never,
       }),
-      "pick up Pallet",
+      "take Pallet",
     );
   });
 });

--- a/src/game/interact.ts
+++ b/src/game/interact.ts
@@ -256,17 +256,20 @@ export function resolveInteract(
 }
 
 /**
- * The short verb the hint chip shows for an interact action. A chip names
- * the *thing* the key moves, not the furniture it comes off: "pick up
- * pallet", never "take from makeshift workbench" — you can already see
- * which bench you're standing at.
+ * The short verb the hint chip shows for an interact action — a verb and
+ * nothing more wherever the chip's own title already names what the key
+ * acts on (the machine's chips are headed by the machine, the bed's by
+ * the bed). It never names the furniture something comes off: "take", not
+ * "take from makeshift workbench" — you can see which bench you're at. The
+ * piece a loaded machine or the bed would hand back does get named, since
+ * that's the one thing the title can't say.
  */
 export function interactLabel(action: InteractAction): string {
   switch (action.kind) {
     case "take-outputs":
       return `take (${action.machine.outputMaterials.length})`;
     case "take-inputs":
-      return `pick up ${getMaterialName(action.machine.inputMaterials[0])}`;
+      return `take ${getMaterialName(action.machine.inputMaterials[0])}`;
     case "switch-on":
       return "switch on";
     case "switch-off":
@@ -276,8 +279,8 @@ export function interactLabel(action: InteractAction): string {
     case "pick-up-broom":
       return "pick up broom";
     case "truck-bed":
-      return `pick up ${getMaterialName(action.material)}`;
+      return `take ${getMaterialName(action.material)}`;
     case "truck-cab":
-      return action.handoffCount > 0 ? "deliver work" : "head out";
+      return action.handoffCount > 0 ? "deliver" : "head out";
   }
 }

--- a/tests/bench.spec.ts
+++ b/tests/bench.spec.ts
@@ -106,10 +106,10 @@ test.describe("Bench view", () => {
       page.evaluate(() => (document.activeElement as HTMLElement)?.blur?.());
 
     await test.step("Space won't run hand work — the chips send it to the bench", async () => {
-      // The chip row offers exactly one door — "use workbench" at the
-      // sheet key — and the operate key does nothing: the bench view is
-      // the only player path to hand work.
-      await expect(page.getByText("use workbench")).toBeVisible();
+      // The chip row offers exactly one door — "[Tab] use" at the sheet
+      // key — and the operate key does nothing: the bench view is the
+      // only player path to hand work.
+      await expect(page.getByTestId("machine-chips")).toContainText("use");
       await blur();
       await page.keyboard.down("Space");
       await page.waitForTimeout(400);

--- a/tests/floor.spec.ts
+++ b/tests/floor.spec.ts
@@ -250,8 +250,8 @@ test.describe("Shop floor", () => {
       const state = await page.evaluate(() => window.__GET_GAME_STATE__());
       expect(state.machineCrates).toHaveLength(0);
       expect(state.player.carriedMachine.machineTypeId).toBe("miterSaw");
-      await expect(page.getByText("Put down Miter Saw")).toBeVisible();
-      await expect(page.getByText("Rotate")).toBeVisible();
+      await expect(page.getByTestId("player-hints")).toContainText("put down");
+      await expect(page.getByTestId("player-hints")).toContainText("rotate");
     });
 
     await test.step("rotate the carried machine", async () => {
@@ -280,7 +280,9 @@ test.describe("Shop floor", () => {
     });
 
     await test.step("lift the placed machine back up from the same spot", async () => {
-      await expect(page.getByText("Pick up Miter Saw")).toBeVisible();
+      // The chip is headed by the machine's name, so the key row is
+      // just the verb
+      await expect(page.getByTestId("machine-chips")).toContainText("carry");
       await page.keyboard.press("b");
       await page.waitForTimeout(30);
       expect((await carried(page)).machineTypeId).toBe("miterSaw");
@@ -295,7 +297,7 @@ test.describe("Shop floor", () => {
       // The fixture's miter saw at [6,3] holds a board; stand at its
       // operator cell and try
       await teleportPlayer(page, [6, 5]);
-      await expect(page.getByText("Pick up Miter Saw")).toHaveCount(0);
+      await expect(page.getByTestId("machine-chips")).not.toContainText("carry");
       await page.keyboard.press("b");
       await page.waitForTimeout(30);
       expect(await carried(page)).toBeNull();
@@ -304,8 +306,8 @@ test.describe("Shop floor", () => {
     await test.step("carry a worktable to a new spot", async () => {
       // The fixture's small worktable at [9,2] operates from [9,4]
       await teleportPlayer(page, [9, 4]);
-      const machineHint = page.getByText(/use workbench/i);
-      await expect(machineHint.first()).toBeVisible();
+      const machineHint = page.getByTestId("machine-chips");
+      await expect(machineHint.first()).toContainText(/use/i);
       await page.keyboard.press("b");
       await page.waitForTimeout(30);
       expect((await carried(page)).machineTypeId).toBe("worktable1x1");
@@ -322,7 +324,9 @@ test.describe("Shop floor", () => {
       );
       expect(table.position).toEqual([5, 8]);
       // Standing at the freshly placed table's operator cell brings it back
-      await expect(page.getByText(/use workbench/i).first()).toBeVisible();
+      await expect(page.getByTestId("machine-chips").first()).toContainText(
+        /use/i,
+      );
     });
 
     await test.step("buying a machine crates it into the truck's bed", async () => {
@@ -361,7 +365,7 @@ test.describe("Shop floor", () => {
       const state = await page.evaluate(() => window.__GET_GAME_STATE__());
       expect(state.truck.crates).toHaveLength(0);
       // The lot is walkable, not usable: no setting a machine down out here
-      await expect(page.getByText("no room to set it down here")).toBeVisible();
+      await expect(page.getByText("no room here")).toBeVisible();
       // Carry it in and stand it on open floor
       await teleportPlayer(page, [2, 10]);
       await page.keyboard.press("b");
@@ -419,8 +423,8 @@ test.describe("Shop floor", () => {
       });
       await teleportPlayer(page, [10, 6]);
       // The chip names the piece it would grab
-      const chip = page.getByText(/^pick up · Pine/i).first();
-      await expect(chip).toBeVisible();
+      const chip = page.getByTestId("pickup-chip").first();
+      await expect(chip).toContainText(/Pine/i);
       // The camera may still be easing back indoors from the tailgate a
       // few steps ago — the overlay rides it, so wait for the chip to
       // hold still before treating its position as meaningful.
@@ -565,7 +569,7 @@ test.describe("Shop floor", () => {
       ).toBe(true);
       // Standing at the rail, the chip names the piece E would lift back
       // out rather than the furniture it's lying in
-      await expect(page.getByText("pick up Rustic Shelf")).toBeVisible();
+      await expect(page.getByText("take Rustic Shelf")).toBeVisible();
       await movePlayerToCab(page);
       await openTruckMenu(page);
 

--- a/tests/keyboard.spec.ts
+++ b/tests/keyboard.spec.ts
@@ -499,7 +499,7 @@ test.describe("Keyboard", () => {
       );
 
       // Pine went down last, so it's on top and the chip offers it first
-      const chip = page.getByText(/pick up · /);
+      const chip = page.getByTestId("pickup-chip");
       await expect(chip).toContainText(/Pine/);
       await expect(chip).toContainText("1 of 2");
 
@@ -699,7 +699,7 @@ test.describe("Keyboard", () => {
       // With a cure running and nobody working, the player's cluster
       // offers the wait key — and holding it spins the clock much
       // faster than the idle creep ever would
-      await expect(page.getByText("hold to pass time")).toBeVisible();
+      await expect(page.getByTestId("player-hints")).toContainText("pass time");
       const tickBefore = await page.evaluate(
         () => (window as any).__GET_GAME_STATE__().tick,
       );

--- a/tests/milling.spec.ts
+++ b/tests/milling.spec.ts
@@ -306,11 +306,12 @@ test.describe("Milling", () => {
         page.getByText(/On the floor: work here takes twice as long/),
       ).toBeVisible();
       // Switched off it takes nothing: no chip offering to place the board
-      await expect(page.getByText(/place Walnut 4\/4/)).toHaveCount(0);
+      await expect(page.getByTestId("machine-chips")).not.toContainText("place");
       await switchOn(page);
       await expect(page.getByText("Jointer · on")).toBeVisible();
-      // On, the chip names the very board it would take out of our hands
-      await expect(page.getByText(/place Walnut 4\/4/)).toBeVisible();
+      // On, it offers to take the board out of our hands — the hands
+      // strip has already named it, so the chip is just the verb
+      await expect(page.getByTestId("machine-chips")).toContainText("place");
     });
 
     await test.step("jointer: the stock decides — face pass, then edge pass", async () => {


### PR DESCRIPTION
An audit of every floating hint chip on the shop floor. Each cluster is already headed by the name of the thing it belongs to, so key rows that repeated that name were saying it twice on a chip with no room to spare.

**Now just the verb** (the title already says the noun):

| Before | After |
| --- | --- |
| `[B] pick up Miter Saw` | `[B] carry` |
| `[B] put down Miter Saw` | `[B] put down` |
| `[Tab] use workbench` | `[Tab] use` |
| `[F] place Walnut 4/4` | `[F] place` |
| `[F] place Walnut 4/4` (truck bed) | `[F] load` |
| `[E] deliver work` | `[E] deliver` |
| `[E] pick up Pallet` (bed / loaded machine) | `[E] take Pallet` |
| `[G] next machine (3 here)` | `[G] next machine · 3` |
| `[V] set down vac · 45%` | `[V] set down · 45%` |
| `no room to set it down here` | `no room here` |

**"hold to ..." moved off the label and onto the key cap**, where it belongs — it describes the press, not the work. `hold to sweep` becomes `hold [Space] sweep`, and every held row (sweep, vacuum, empty, run/rip/joint, pass time) reads as a bare verb like the rest.

**The floor's pickup chip** had no title at all and carried the piece's name inline (`[E] pick up · Pine 4/4 (rough) · 1 of 2`). It's headed by the piece's name now, the same shape as the machine chips, leaving `[E] pick up` and `[R] next piece`.

Names stay wherever the title genuinely can't supply them: the piece a loaded machine or the bed would hand back, the machine inside an unopened crate, and — when the hands are full — which piece goes onto the machine first.

The specs located these clusters by their label text, which is too generic now, so the four clusters (`machine-chips`, `player-hints`, `truck-bed-chips`, `truck-cab-chips`) carry test ids and the assertions scope to them.

Unit tests (1127) and all seven E2E specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
