### PR TITLE
Board flipping: tumble the flat → on-edge → on-end cycle

### DIFF
--- a/docs/bench-work.md
+++ b/docs/bench-work.md
@@ -220,7 +220,16 @@ exactly over the shop's copy.
 
 The bench's contents lie on it exactly where `MachineState.benchLayout`
 says (`BenchScene`; a board flipped up on edge narrows to its thickness,
-`BoardOnEdgeSprite`). Stroke and saw work runs on those very pieces in
+`BoardOnEdgeSprite`). F is one verb with three stops on a board — flat,
+up on its long edge, up on its end — and the scene tumbles it between
+them rather than swapping sprites: `bench-work/flip-cycle.ts` owns the
+cycle and interpolates the very footprints `placedPieceSize` declares,
+so the outgoing and incoming sprites cross-fade at a shared apparent
+size. Its header covers the one wrinkle worth knowing (the three stops
+can't be reached by three honest single-axis tips, and why the leftover
+quarter turn is spent inside the leg instead of on `angleDeg`). The key
+hint names the stop F reaches next, so the cycle isn't something a
+player has to discover by surprise. Stroke and saw work runs on those very pieces in
 place (`StrokeSurface` / `SawSurface` mount over the scene at the
 piece's placement — no takeover surface exists). The chrome floats:
 nameplate top-left, instruction + key hints bottom-center, the plan

--- a/src/components/bench-view/BenchScene.tsx
+++ b/src/components/bench-view/BenchScene.tsx
@@ -24,6 +24,15 @@ import {
   ProductBlueprint,
   slotFootprintIn,
 } from "../../game/bench-work/blueprint";
+import {
+  advanceFlipPhase,
+  FLIP_LEG_SECONDS,
+  FLIP_STOPS,
+  flipStopOf,
+  flipStopSize,
+  tumbleFrame,
+  tumbles,
+} from "../../game/bench-work/flip-cycle";
 import { placedPieceSize } from "../../game/bench-work/workpiece";
 import { MaterialInstance, Pallet, PalletNail } from "../../game/Materials";
 import { drawFastenerHead } from "../material-sprites/fastenerHead";
@@ -148,8 +157,30 @@ const TweenedTransform: React.FC<{
   );
 };
 
-/** The white attention ring, drawn in sprite pixels inside the tweened
- * container so it hugs the piece through the turn. */
+/** The white attention ring around a piece of a given footprint, drawn
+ * in sprite pixels inside the tweened container so it hugs the piece
+ * through the turn. */
+function drawPieceRing(
+  g: Graphics,
+  sizeIn: { widthIn: number; heightIn: number },
+  fit: StageFit,
+  hovered: boolean,
+  dragging: boolean,
+): void {
+  g.clear();
+  if (!hovered && !dragging) return;
+  const w = (sizeIn.widthIn * fit.pxPerIn) / fit.spriteScale;
+  const h = (sizeIn.heightIn * fit.pxPerIn) / fit.spriteScale;
+  const pad = 4 / fit.spriteScale;
+  g.roundRect(-w / 2 - pad, -h / 2 - pad, w + pad * 2, h + pad * 2, pad).stroke(
+    {
+      width: 2 / fit.spriteScale,
+      color: 0xf5efe3,
+      alpha: dragging ? 0.9 : 0.55,
+    },
+  );
+}
+
 const PieceRing: React.FC<{
   material: MaterialInstance;
   placement: BenchPlacement;
@@ -159,27 +190,132 @@ const PieceRing: React.FC<{
 }> = ({ material, placement, fit, hovered, dragging }) => {
   const drawRing = useCallback(
     (g: Graphics) => {
-      g.clear();
-      if (!hovered && !dragging) return;
-      const size = placedPieceSize(material, placement);
-      const w = (size.widthIn * fit.pxPerIn) / fit.spriteScale;
-      const h = (size.heightIn * fit.pxPerIn) / fit.spriteScale;
-      const pad = 4 / fit.spriteScale;
-      g.roundRect(
-        -w / 2 - pad,
-        -h / 2 - pad,
-        w + pad * 2,
-        h + pad * 2,
-        pad,
-      ).stroke({
-        width: 2 / fit.spriteScale,
-        color: 0xf5efe3,
-        alpha: dragging ? 0.9 : 0.55,
-      });
+      drawPieceRing(
+        g,
+        placedPieceSize(material, placement),
+        fit,
+        hovered,
+        dragging,
+      );
     },
     [hovered, dragging, material, placement, fit],
   );
   return <pixiGraphics draw={drawRing} />;
+};
+
+/** Read once: the tumble snaps straight to its end states under
+ * `prefers-reduced-motion`, the way the rest of the view's motion does
+ * — which is also how the E2E suite runs. */
+let reducedMotion: boolean | null = null;
+function prefersReducedMotion(): boolean {
+  if (reducedMotion === null) {
+    reducedMotion =
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+  }
+  return reducedMotion;
+}
+
+/**
+ * A board going over: the stop it is leaving and the stop it is arriving
+ * at, both drawn at the footprint the tumble is passing through and
+ * cross-fading as one turns into the other, so F reads as the piece
+ * being tipped by hand instead of swapping sprites. The cycle, the
+ * footprints, and the easing all come from `bench-work/flip-cycle`; this
+ * only ticks it and pushes the result at PIXI.
+ *
+ * All three stops are mounted at once and hidden by the tick rather than
+ * by a prop: React must not get a say in which sprite shows, or the
+ * re-render that lands the new placement would pop the destination up at
+ * full size a frame before the tumble starts.
+ */
+const FlipTumble: React.FC<{
+  piece: LoosePiece;
+  fit: StageFit;
+  hovered: boolean;
+  dragging: boolean;
+}> = ({ piece, fit, hovered, dragging }) => {
+  const { material, placement } = piece;
+  const stop = flipStopOf(placement);
+  const groupRef = useRef<Container | null>(null);
+  const ringRef = useRef<Graphics | null>(null);
+  const targetPhase = useRef(stop);
+  const phase = useRef(stop);
+  // The stop the containers were mounted showing — a constant prop, so
+  // React applies it once and never touches `visible` again.
+  const mountedStop = useRef(stop).current;
+  // Advancing onto a stop already reached is a no-op, so re-rendering
+  // never double-steps the cycle.
+  targetPhase.current = advanceFlipPhase(targetPhase.current, stop);
+  if (prefersReducedMotion()) {
+    phase.current = targetPhase.current;
+  }
+  // Redrawing the ring is only worth it when something moved — and only
+  // the piece under the hand draws one at all.
+  const lastRing = useRef("");
+  // The ring is the tick's to draw (it has to follow the tumble); this
+  // only hands the Graphics over empty, and never re-runs.
+  const initRing = useCallback((g: Graphics) => {
+    g.clear();
+  }, []);
+
+  useTick((ticker) => {
+    if (phase.current !== targetPhase.current) {
+      const dt = Math.min(ticker.deltaMS, 50) / 1000;
+      phase.current = Math.min(
+        targetPhase.current,
+        phase.current + dt / FLIP_LEG_SECONDS,
+      );
+    }
+    const frame = tumbleFrame(material, phase.current);
+    const children = groupRef.current?.children ?? [];
+    for (let i = 0; i < children.length; i++) {
+      const node = children[i];
+      if (!node) continue;
+      const showing =
+        i === frame.fromStop
+          ? 1 - frame.fade
+          : i === frame.toStop
+            ? frame.fade
+            : 0;
+      node.visible = showing > 0.001;
+      if (!node.visible) continue;
+      node.alpha = showing;
+      // Each stop's sprite draws its own footprint, so matching the
+      // apparent one is a plain ratio of inches.
+      const own = flipStopSize(material, i);
+      node.scale.set(
+        (frame.widthIn / own.widthIn) * frame.lift,
+        (frame.heightIn / own.heightIn) * frame.lift,
+      );
+    }
+    const ring = ringRef.current;
+    if (!ring) return;
+    const sizeIn = {
+      widthIn: frame.widthIn * frame.lift,
+      heightIn: frame.heightIn * frame.lift,
+    };
+    const key = `${hovered}|${dragging}|${sizeIn.widthIn.toFixed(3)}|${sizeIn.heightIn.toFixed(3)}|${fit.pxPerIn}|${fit.spriteScale}`;
+    if (key === lastRing.current) return;
+    lastRing.current = key;
+    drawPieceRing(ring, sizeIn, fit, hovered, dragging);
+  });
+
+  return (
+    <>
+      <pixiContainer ref={groupRef}>
+        {FLIP_STOPS.map((flipStop, i) => (
+          <pixiContainer key={i} visible={i === mountedStop}>
+            <MaterialSprite
+              material={material}
+              onEdge={flipStop.onEdge}
+              onEnd={flipStop.onEnd}
+            />
+          </pixiContainer>
+        ))}
+      </pixiContainer>
+      <pixiGraphics ref={ringRef} draw={initRing} />
+    </>
+  );
 };
 
 const TweenedPiece: React.FC<{
@@ -193,18 +329,29 @@ const TweenedPiece: React.FC<{
     fit={fit}
     alpha={dragging ? 0.9 : 1}
   >
-    <MaterialSprite
-      material={piece.material}
-      onEdge={piece.placement.onEdge}
-      onEnd={piece.placement.onEnd}
-    />
-    <PieceRing
-      material={piece.material}
-      placement={piece.placement}
-      fit={fit}
-      hovered={hovered}
-      dragging={dragging}
-    />
+    {tumbles(piece.material) ? (
+      <FlipTumble
+        piece={piece}
+        fit={fit}
+        hovered={hovered}
+        dragging={dragging}
+      />
+    ) : (
+      <>
+        <MaterialSprite
+          material={piece.material}
+          onEdge={piece.placement.onEdge}
+          onEnd={piece.placement.onEnd}
+        />
+        <PieceRing
+          material={piece.material}
+          placement={piece.placement}
+          fit={fit}
+          hovered={hovered}
+          dragging={dragging}
+        />
+      </>
+    )}
   </TweenedTransform>
 );
 

--- a/src/components/bench-view/BenchWorkSurface.tsx
+++ b/src/components/bench-view/BenchWorkSurface.tsx
@@ -37,6 +37,13 @@ import {
   palletPointOnBench,
 } from "../../game/bench-work/bench-layout";
 import {
+  atFlipStop,
+  FLIP_STOP_HINTS,
+  flipStopOf,
+  nextFlipStop,
+  tumbles,
+} from "../../game/bench-work/flip-cycle";
+import {
   faceNails,
   PALLET_HEIGHT_IN,
   PALLET_WIDTH_IN,
@@ -1467,18 +1474,20 @@ export const BenchWorkSurface: React.FC<{
           ? dragPlacement.current
           : piece.placement;
       // One flip verb: a board cycles flat → up on its long edge → up
-      // on its end → flat again; anything else — the pallet — turns
-      // over. Mirroring a board face-for-face never showed anyway.
+      // on its end → flat again (bench-work/flip-cycle, which the scene
+      // also tumbles the piece through); anything else — the pallet —
+      // turns over. Mirroring a board face-for-face never showed anyway.
       const turned: BenchPlacement =
         event.code === "KeyR"
           ? { ...current, angleDeg: current.angleDeg + 90 }
-          : material.type === "board"
-            ? current.onEnd
-              ? { ...current, onEdge: false, onEnd: false }
-              : current.onEdge
-                ? { ...current, onEdge: false, onEnd: true }
-                : { ...current, onEdge: true, onEnd: false }
+          : tumbles(material)
+            ? atFlipStop(current, nextFlipStop(flipStopOf(current)))
             : { ...current, flipped: !current.flipped };
+      if (event.code === "KeyF" && tumbles(material)) {
+        // The knock of the piece coming down on its new face: three
+        // stops are easier to count by ear than by eye
+        playSound("material-drop", 0.3);
+      }
       // Turning and flipping pivot a piece about its middle, which is
       // the only thing the bench top holds it to — nothing to re-seat
       if (draggingId === id) {
@@ -1912,6 +1921,18 @@ export const BenchWorkSurface: React.FC<{
     return null;
   }
 
+  // What F would do to the piece in hand or under the pointer — the same
+  // one the key handler acts on.
+  const flipPiece = (() => {
+    const id = draggingId ?? hoveredId;
+    return id ? scenePieces.find((p) => p.material.id === id) : undefined;
+  })();
+  const flipHint =
+    flipPiece && tumbles(flipPiece.material)
+      ? (FLIP_STOP_HINTS[nextFlipStop(flipStopOf(flipPiece.placement))] ??
+        "flip")
+      : "flip";
+
   const keyHints: Array<[string, string]> = holdingClamp
     ? [
         ["Click", "lay the clamp down"],
@@ -1960,8 +1981,10 @@ export const BenchWorkSurface: React.FC<{
                   ["Drag", "move a piece"],
                   ["R", "turn"],
                   // The one flip verb: boards tip up on edge, the pallet
-                  // turns over
-                  ["F", "flip"],
+                  // turns over. With a board in reach the chip names the
+                  // stop F is about to reach, so the three-stop cycle
+                  // stops being a thing you discover by surprise.
+                  ["F", flipHint],
                 ] as Array<[string, string]>)
               : []),
             ["E", "take back"],
@@ -2218,7 +2241,7 @@ export const BenchWorkSurface: React.FC<{
             )}
           </div>
           {sceneActive && (
-            <div className="flex gap-2">
+            <div className="flex gap-2" data-testid="bench-key-hints">
               {keyHints.map(([key, label]) => (
                 <span
                   key={`${key}-${label}`}

--- a/src/game/bench-work/flip-cycle.test.ts
+++ b/src/game/bench-work/flip-cycle.test.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { board } from "../board-helpers";
+import { BenchPlacement } from "./bench-layout";
+import {
+  advanceFlipPhase,
+  atFlipStop,
+  FLIP_STOP_HINTS,
+  FLIP_STOPS,
+  flipStopOf,
+  flipStopSize,
+  nextFlipStop,
+  stopAtPhase,
+  tumbleFrame,
+  tumbles,
+} from "./flip-cycle";
+import { placedPieceSize } from "./workpiece";
+
+const flat: BenchPlacement = {
+  xIn: 10,
+  yIn: 10,
+  angleDeg: 0,
+  flipped: false,
+};
+
+// 24" long, 2" wide, 6/4 (1.5") thick — so the three stops each cover a
+// different footprint and none of them can be confused for another.
+const plank = board("oak", 24, 2, 6);
+
+describe("the flip cycle", () => {
+  it("runs flat → on edge → on end → flat", () => {
+    assert.strictEqual(flipStopOf({}), 0);
+    assert.strictEqual(flipStopOf({ onEdge: true }), 1);
+    assert.strictEqual(flipStopOf({ onEnd: true }), 2);
+    assert.strictEqual(nextFlipStop(0), 1);
+    assert.strictEqual(nextFlipStop(1), 2);
+    assert.strictEqual(nextFlipStop(2), 0);
+  });
+
+  it("clears the stop it leaves", () => {
+    const onEdge = atFlipStop(flat, 1);
+    assert.deepStrictEqual(
+      { onEdge: onEdge.onEdge, onEnd: onEdge.onEnd },
+      { onEdge: true, onEnd: false },
+    );
+    const onEnd = atFlipStop(onEdge, 2);
+    assert.deepStrictEqual(
+      { onEdge: onEnd.onEdge, onEnd: onEnd.onEnd },
+      { onEdge: false, onEnd: true },
+    );
+    const backFlat = atFlipStop(onEnd, 0);
+    assert.deepStrictEqual(
+      { onEdge: backFlat.onEdge, onEnd: backFlat.onEnd },
+      { onEdge: false, onEnd: false },
+    );
+  });
+
+  it("keeps everything else about the placement, so three presses land where they started", () => {
+    const turned: BenchPlacement = { ...flat, angleDeg: 96, xIn: 3, yIn: 4 };
+    let placement = turned;
+    for (let i = 0; i < 3; i++) {
+      placement = atFlipStop(placement, nextFlipStop(flipStopOf(placement)));
+    }
+    assert.deepStrictEqual(placement, {
+      ...turned,
+      onEdge: false,
+      onEnd: false,
+    });
+  });
+
+  it("only boards tumble", () => {
+    assert.strictEqual(tumbles(plank), true);
+    assert.strictEqual(tumbles({ ...plank, type: "panel" } as never), false);
+  });
+
+  it("names the stop F is about to reach", () => {
+    assert.strictEqual(FLIP_STOP_HINTS.length, FLIP_STOPS.length);
+    assert.strictEqual(FLIP_STOP_HINTS[nextFlipStop(0)], "stand on edge");
+    assert.strictEqual(FLIP_STOP_HINTS[nextFlipStop(1)], "stand on end");
+    assert.strictEqual(FLIP_STOP_HINTS[nextFlipStop(2)], "lay flat");
+  });
+});
+
+describe("the tumble phase", () => {
+  it("accumulates forward one leg at a time", () => {
+    assert.strictEqual(advanceFlipPhase(0, 1), 1);
+    assert.strictEqual(advanceFlipPhase(1, 2), 2);
+    // Round the cycle: the phase keeps climbing rather than unwinding
+    assert.strictEqual(advanceFlipPhase(2, 0), 3);
+    assert.strictEqual(advanceFlipPhase(3, 1), 4);
+  });
+
+  it("holds still when the piece is already at that stop", () => {
+    assert.strictEqual(advanceFlipPhase(4, 1), 4);
+  });
+
+  it("tumbles through the stop between when a piece jumps two", () => {
+    // An assembly snap seats a leg straight onto its end
+    assert.strictEqual(advanceFlipPhase(0, 2), 2);
+    assert.strictEqual(advanceFlipPhase(1, 0), 3);
+  });
+
+  it("reads its stop off the accumulated phase", () => {
+    assert.strictEqual(stopAtPhase(0), 0);
+    assert.strictEqual(stopAtPhase(2), 2);
+    assert.strictEqual(stopAtPhase(3), 0);
+    assert.strictEqual(stopAtPhase(4.5), 1);
+  });
+});
+
+describe("the tumble frame", () => {
+  it("draws exactly placedPieceSize at every stop", () => {
+    for (let stop = 0; stop < FLIP_STOPS.length; stop++) {
+      const size = flipStopSize(plank, stop);
+      assert.deepStrictEqual(size, placedPieceSize(plank, FLIP_STOPS[stop]!));
+      const frame = tumbleFrame(plank, stop);
+      assert.strictEqual(frame.widthIn, size.widthIn);
+      assert.strictEqual(frame.heightIn, size.heightIn);
+      assert.strictEqual(frame.fade, 0);
+      assert.strictEqual(frame.lift, 1);
+    }
+  });
+
+  it("arrives at the next stop's footprint by the end of the leg", () => {
+    const nearlyThere = tumbleFrame(plank, 0.999999);
+    const arrived = flipStopSize(plank, 1);
+    assert.ok(Math.abs(nearlyThere.widthIn - arrived.widthIn) < 0.001);
+    assert.ok(Math.abs(nearlyThere.heightIn - arrived.heightIn) < 0.001);
+  });
+
+  it("narrows the face into the edge without touching the length", () => {
+    // Flat → on edge is a pure roll about the long axis: only the width
+    // across the bench moves.
+    const mid = tumbleFrame(plank, 0.5);
+    assert.strictEqual(mid.fromStop, 0);
+    assert.strictEqual(mid.toStop, 1);
+    assert.strictEqual(mid.heightIn, plank.length);
+    assert.ok(mid.widthIn < plank.width);
+    assert.ok(mid.widthIn > plank.thickness / 4);
+  });
+
+  it("tips the piece over before it settles across", () => {
+    // Edge → on end: the length foreshortens away first (the tip), and
+    // the width only spreads once the piece is most of the way over.
+    const early = tumbleFrame(plank, 1.2);
+    assert.ok(early.heightIn < plank.length, "the tip has started");
+    assert.strictEqual(
+      early.widthIn,
+      plank.thickness / 4,
+      "the settle has not",
+    );
+    const late = tumbleFrame(plank, 1.9);
+    assert.ok(late.widthIn > plank.thickness / 4, "the settle has started");
+  });
+
+  it("lifts off the bench at the top of the tumble and lands flat again", () => {
+    assert.ok(tumbleFrame(plank, 0.5).lift > 1);
+    assert.ok(Math.abs(tumbleFrame(plank, 0.999999).lift - 1) < 0.001);
+  });
+});

--- a/src/game/bench-work/flip-cycle.ts
+++ b/src/game/bench-work/flip-cycle.ts
@@ -1,0 +1,193 @@
+import { MaterialInstance } from "../Materials";
+import { BenchPlacement } from "./bench-layout";
+import { placedPieceSize } from "./workpiece";
+
+/**
+ * The one flip verb, and the tumble that makes it legible.
+ *
+ * F on a board cycles three stops — flat → up on its long edge → up on
+ * its end → flat — and each stop is nothing but a footprint, the one
+ * `placedPieceSize` already declares. That makes the whole animation a
+ * matter of interpolating between two rows of that table and
+ * cross-fading the two sprites that draw them: this module owns the
+ * cycle (which stop follows which, what to call it) and the frame math
+ * (how big the piece looks partway through), and the bench scene owns
+ * only the ticking.
+ *
+ * Two things are deliberate here.
+ *
+ * The cycle's stops can't be linked by three honest single-axis tips.
+ * Take the board's dimensions as (X, Y, Z): flat is (width, length,
+ * thickness), on edge is (thickness, length, width), on end is (width,
+ * thickness, length). Flat → edge is a pure roll about the length, and
+ * end → flat is a pure tip about the width, but edge → end needs a tip
+ * AND a quarter turn to land on the modeled footprint. No reordering of
+ * the three fixes that — the yaw is inherent. Animating it honestly
+ * would leave a board turned 90° after a full cycle, which is exactly
+ * the unpredictability the tumble exists to cure, so the turn is spent
+ * inside the leg instead: the shrinking axis leads and the growing one
+ * follows (`axisProgress`), which reads as the piece going over and
+ * then settling onto its new face. `angleDeg` is never touched, so
+ * three presses of F always land a board back where it started.
+ *
+ * The phase is accumulated, not normalized — the same reasoning
+ * `BenchPlacement.angleDeg` gives for accumulating turns. The cycle only
+ * ever runs forward, so a stop two steps along (an assembly snap seating
+ * a leg straight onto its end) tumbles through the stop between rather
+ * than springing backwards through it.
+ */
+
+/** One stop in the cycle: the placement flags that put a board there. */
+export interface FlipStop {
+  readonly onEdge?: boolean;
+  readonly onEnd?: boolean;
+}
+
+/** The three stops F cycles through, in cycle order. */
+export const FLIP_STOPS: ReadonlyArray<FlipStop> = [
+  {}, // lying flat
+  { onEdge: true }, // up on its long edge
+  { onEnd: true }, // up on its end
+];
+
+/** What F does next, named for the key hint that offers it. */
+export const FLIP_STOP_HINTS: ReadonlyArray<string> = [
+  "lay flat",
+  "stand on edge",
+  "stand on end",
+];
+
+/** Which stop this placement is at. */
+export function flipStopOf(placement: FlipStop): number {
+  if (placement.onEnd) return 2;
+  if (placement.onEdge) return 1;
+  return 0;
+}
+
+/** The stop F moves to from here. */
+export function nextFlipStop(stop: number): number {
+  return (stop + 1) % FLIP_STOPS.length;
+}
+
+/**
+ * The placement standing at a given stop. Both flags are written
+ * explicitly rather than spread, so leaving a stop clears it — an
+ * on-edge board sent to its end must stop being on edge.
+ */
+export function atFlipStop(
+  placement: BenchPlacement,
+  stop: number,
+): BenchPlacement {
+  const target = FLIP_STOPS[stop] ?? FLIP_STOPS[0]!;
+  return {
+    ...placement,
+    onEdge: target.onEdge ?? false,
+    onEnd: target.onEnd ?? false,
+  };
+}
+
+/**
+ * Whether F cycles this piece through the three stops at all. Only
+ * boards tumble; the pallet's F turns it over instead — a different
+ * verb, tweened as a mirror by the scene's transform — and everything
+ * else has nothing but a face to show.
+ */
+export function tumbles(material: MaterialInstance): boolean {
+  return material.type === "board";
+}
+
+/** The next accumulated phase for a piece that has arrived at `stop`. */
+export function advanceFlipPhase(phase: number, stop: number): number {
+  const count = FLIP_STOPS.length;
+  const current = ((Math.round(phase) % count) + count) % count;
+  const delta = (((stop - current) % count) + count) % count;
+  return phase + delta;
+}
+
+/** Which stop an accumulated phase sits at. */
+export function stopAtPhase(phase: number): number {
+  const count = FLIP_STOPS.length;
+  return ((Math.floor(phase) % count) + count) % count;
+}
+
+/** How long one leg of the cycle takes, in seconds. */
+export const FLIP_LEG_SECONDS = 0.18;
+
+/** How much the piece swells at the top of its tumble, selling the lift
+ * off the bench that a real hand gives it. */
+const LIFT = 0.1;
+
+/** How late in the leg the growing axis starts moving. */
+const FOLLOW_DELAY = 0.35;
+
+function easeInOut(t: number): number {
+  return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+}
+
+/**
+ * How far along its own move one axis is. The axis that shrinks leads
+ * on the leg's own clock; the axis that grows waits, so a board going
+ * from edge to end tips over before it settles across — see the header.
+ */
+function axisProgress(from: number, to: number, t: number): number {
+  if (to > from) {
+    return easeInOut(Math.max(0, (t - FOLLOW_DELAY) / (1 - FOLLOW_DELAY)));
+  }
+  return easeInOut(t);
+}
+
+/** One frame of a tumble: what to draw, how big, and how faded. */
+export interface TumbleFrame {
+  /** The stop being left, and the one being arrived at. */
+  readonly fromStop: number;
+  readonly toStop: number;
+  /** Raw progress through the leg, 0 at the stop being left. */
+  readonly t: number;
+  /** The footprint the piece appears to cover right now, in inches. */
+  readonly widthIn: number;
+  readonly heightIn: number;
+  /** Uniform swell, 1 at rest. */
+  readonly lift: number;
+  /** Cross-fade: the outgoing sprite carries `1 - fade`. */
+  readonly fade: number;
+}
+
+/**
+ * The piece's apparent footprint partway through the cycle. At an
+ * integer phase this is exactly `placedPieceSize` of that stop with the
+ * outgoing sprite alone on screen, so a piece at rest draws precisely
+ * as it always has.
+ */
+export function tumbleFrame(
+  material: MaterialInstance,
+  phase: number,
+): TumbleFrame {
+  const fromStop = stopAtPhase(phase);
+  const toStop = nextFlipStop(fromStop);
+  const t = phase - Math.floor(phase);
+  const from = flipStopSize(material, fromStop);
+  const to = flipStopSize(material, toStop);
+  const widthIn =
+    from.widthIn +
+    (to.widthIn - from.widthIn) * axisProgress(from.widthIn, to.widthIn, t);
+  const heightIn =
+    from.heightIn +
+    (to.heightIn - from.heightIn) * axisProgress(from.heightIn, to.heightIn, t);
+  return {
+    fromStop,
+    toStop,
+    t,
+    widthIn,
+    heightIn,
+    lift: 1 + LIFT * Math.sin(Math.PI * t),
+    fade: easeInOut(t),
+  };
+}
+
+/** The footprint a piece covers standing at one stop. */
+export function flipStopSize(
+  material: MaterialInstance,
+  stop: number,
+): { widthIn: number; heightIn: number } {
+  return placedPieceSize(material, FLIP_STOPS[stop] ?? FLIP_STOPS[0]!);
+}

--- a/tests/bench.spec.ts
+++ b/tests/bench.spec.ts
@@ -728,6 +728,46 @@ test.describe("Bench view", () => {
       // reads the hovered piece, and a busy renderer commits it a beat
       // after the pointer arrives
       await expect(stage).toHaveAttribute("data-hovered", "bp-r1");
+      // The chip names the stop F reaches next, so the three-stop cycle
+      // is readable before it's pressed rather than after
+      const hints = page.getByTestId("bench-key-hints");
+      await expect(hints).toContainText("stand on edge");
+      await page.keyboard.press("KeyF");
+      await expect
+        .poll(async () =>
+          page.evaluate(
+            () =>
+              window.__GET_GAME_STATE__().machines[0].benchLayout["bp-r1"]
+                .onEdge ?? false,
+          ),
+        )
+        .toBe(true);
+      await expect(hints).toContainText("stand on end");
+
+      // Round the cycle: on end, then back to lying flat where it started
+      await page.keyboard.press("KeyF");
+      await expect
+        .poll(async () =>
+          page.evaluate(
+            () =>
+              window.__GET_GAME_STATE__().machines[0].benchLayout["bp-r1"]
+                .onEnd ?? false,
+          ),
+        )
+        .toBe(true);
+      await expect(hints).toContainText("lay flat");
+      await page.keyboard.press("KeyF");
+      await expect
+        .poll(async () =>
+          page.evaluate(() => {
+            const at =
+              window.__GET_GAME_STATE__().machines[0].benchLayout["bp-r1"];
+            return [at.onEdge ?? false, at.onEnd ?? false];
+          }),
+        )
+        .toEqual([false, false]);
+
+      // Back on edge for the snap-drag below
       await page.keyboard.press("KeyF");
       await expect
         .poll(async () =>


### PR DESCRIPTION
Closes #156.

F on a board cycles three stops, and both halves of that surprised the playtester: the state change was an instantaneous sprite swap, and a second press put the board *on end* rather than back flat. This animates the change and makes the cycle legible before it's pressed.

## How it works

Each stop is nothing but a footprint — the one `placedPieceSize` already declares:

| stop | footprint (X, Y) |
|---|---|
| flat | width × length |
| on edge | thickness/4 × length |
| on end | width × thickness/4 |

So the tumble is a lerp between two rows of that table, with the outgoing and incoming sprites cross-fading at the shared apparent size. No sprite changed; `placedPieceSize` stays the single source of truth for how big a piece looks at each stop.

New `src/game/bench-work/flip-cycle.ts` owns the cycle and the frame math — including the key handler's own three-way ternary, which now routes through it. `BenchScene` only ticks it and pushes the result at PIXI.

## The one design call worth reviewing

The three stops **can't** be linked by three honest single-axis tips. In (X, Y, Z): flat is (width, length, thickness), on edge is (thickness, length, width), on end is (width, thickness, length). Flat→edge is a pure roll and end→flat is a pure tip, but **edge→end needs a quarter turn on top of the tip**, and no reordering of the three fixes that.

Animating that turn honestly would leave a board rotated 90° after a full cycle — exactly the unpredictability the issue asks to cure. So the turn is spent *inside* the leg instead: the shrinking axis leads and the growing one follows, which reads as the piece going over and then settling onto its new face. `angleDeg` is never touched, so three presses of F always land a board where it started.

## Predictability

Animation alone doesn't teach that there are three stops, so the key hint now names the stop F reaches next — `stand on edge` → `stand on end` → `lay flat` — instead of a static `flip`. A soft `material-drop` knock fires on each landing; three stops are easier to count by ear than by eye.

## Details

- Accumulated phase, forward-only (same reasoning `angleDeg` gives). A stop two steps along — an assembly snap seating a leg straight onto its end — tumbles through the stop between rather than springing backwards.
- A fixed-duration ease, deliberately **not** the existing `stepSpring`: that spring is underdamped, and overshoot on a phase that selects a sprite would swap twice.
- All three stops are mounted at once and hidden by the tick rather than by a prop, so the re-render that lands the new placement can't pop the destination up at full size a frame early.
- `prefers-reduced-motion` snaps straight to the end states, per the convention in `docs/bench-work.md` — which is also how the E2E suite runs.
- Hit-testing still reads live state, so the grab box flips instantly while the sprite catches up. Input shouldn't lag state; commented so nobody "fixes" it.

## Testing

- **Unit** (`flip-cycle.test.ts`, 14 new): cycle order, forward-only accumulation, a two-step jump resolving forward, frames matching `placedPieceSize` exactly at every stop, the tip-before-settle ordering on leg 2, and three presses returning the placement untouched.
- **E2E** (`bench.spec.ts`): the existing flip step now rounds the whole cycle — flat → edge → end → flat — asserting the hint label at each stop.
- Full suite green: 1139 unit, 7/7 E2E.
- **Verified at the browser surface**: the three settled stops render pixel-identical to `main` (no regression at rest), and a temporarily-slowed leg shows the face narrowing and cross-fading into the edge with the hover ring tracking the apparent footprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)