### PR TITLE
Deal the client's card once, in the shop, and let it hold the screen

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -3,8 +3,9 @@ import { useModalScope, useShortcut } from "./shortcuts/ShortcutProvider";
 
 /**
  * The shared shell for centered dialogs (Settings, the phone, the journal,
- * the manual): a dimmed backdrop that closes on click, a panel that swallows
- * clicks so only the backdrop dismisses, and the modal keyboard scope so
+ * the manual): a dimmed backdrop that closes on click (unless the caller
+ * asks it not to), a panel that swallows clicks so only the backdrop
+ * dismisses, and the modal keyboard scope so
  * Escape closes this and nothing else — it used to also clear the player's
  * work queue on the page behind. The panel's look is entirely the caller's:
  * each modal is a different physical object (card, notebook, handset), so
@@ -23,8 +24,23 @@ export const Modal: React.FC<{
    */
   panelRef?: React.Ref<HTMLDivElement>;
   backdropRef?: React.Ref<HTMLDivElement>;
+  /**
+   * Whether clicking off the panel closes it. True for anything the player
+   * opened and can put down again; false for a modal that is telling them
+   * something they have to answer, where a click meant for the shop floor
+   * behind it would sweep the message away unread (see ClientCard).
+   */
+  backdropCloses?: boolean;
   children: React.ReactNode;
-}> = ({ onClose, label, panelClassName, panelRef, backdropRef, children }) => {
+}> = ({
+  onClose,
+  label,
+  panelClassName,
+  panelRef,
+  backdropRef,
+  backdropCloses = true,
+  children,
+}) => {
   useModalScope();
   useShortcut("close-modal", onClose);
 
@@ -32,7 +48,7 @@ export const Modal: React.FC<{
     <div
       ref={backdropRef}
       className="fixed inset-0 z-50 flex items-center justify-center bg-ink-black/60 p-4"
-      onClick={onClose}
+      onClick={backdropCloses ? onClose : undefined}
       role="presentation"
     >
       <div

--- a/src/components/payout/ClientCard.tsx
+++ b/src/components/payout/ClientCard.tsx
@@ -15,6 +15,10 @@ import { Modal } from "../Modal";
  * Dismissing it is what releases the reward flight (see
  * `RewardFlightLayer`), so the payout reads as a consequence of the handoff
  * rather than a number that moved while the player was looking elsewhere.
+ *
+ * It holds the screen until the player takes the money (or presses Escape):
+ * a click aimed at the shop floor behind it used to sweep the card away
+ * before it had been read, which is the one dismissal nobody meant.
  */
 export const ClientCard: React.FC<{
   payout: PayoutEvent;
@@ -22,6 +26,7 @@ export const ClientCard: React.FC<{
 }> = ({ payout, onDismiss }) => (
   <Modal
     onClose={onDismiss}
+    backdropCloses={false}
     label={`${payout.title} — delivered`}
     panelClassName="payout-card-in relative w-[30rem] max-w-full bg-paper-legal text-ink-black p-6 rounded-sm shadow-2xl"
   >

--- a/src/components/payout/RewardFlightLayer.tsx
+++ b/src/components/payout/RewardFlightLayer.tsx
@@ -3,6 +3,7 @@ import { clearPendingPayoutsAction } from "../../game/game-actions/payout-action
 import { PayoutEvent } from "../../game/PayoutEvent";
 import { playSound } from "../../utils/sfx";
 import { SparkIcon, StarIcon } from "../StarIcon";
+import { useTruckStage } from "../shop-view/truckStageStore";
 import { useApplyGameAction, useGameState } from "../useGameState";
 import { ClientCard } from "./ClientCard";
 import { REWARD_TARGET_ATTRIBUTE, RewardTarget } from "./rewardTargets";
@@ -24,6 +25,13 @@ import { REWARD_TARGET_ATTRIBUTE, RewardTarget } from "./rewardTargets";
  *
  * The underlying numbers changed the instant the action ran — the flight is
  * decoration over an already-settled state, so nothing here can desync it.
+ *
+ * Both steps wait for the truck to be parked. A delivery settles on the
+ * drive in (delivery-actions.ts), which is a couple of seconds of arrival
+ * before the shop is back: staged the moment it was queued, the card dealt
+ * itself over the trip's backdrop and the chips flew at readouts that
+ * weren't on screen yet. Nothing is dropped by waiting — the queue simply
+ * keeps until the shop is there to celebrate in.
  */
 
 /** How many coins one payout throws. Bigger paydays throw more. */
@@ -108,10 +116,20 @@ export const RewardFlightLayer: React.FC = () => {
   const gameState = useGameState();
   const applyAction = useApplyGameAction();
   const pending = gameState.pendingPayouts;
+  // Home and interactive: the shop is on screen, the truck is in the
+  // driveway, and the readouts the chips aim at are where they'll land.
+  const home = useTruckStage() === "parked" && !gameState.player.away;
 
   /** Commission cards waiting to be dismissed, oldest first. */
   const [cards, setCards] = useState<ReadonlyArray<PayoutEvent>>([]);
   const [flights, setFlights] = useState<ReadonlyArray<Flight>>([]);
+  /**
+   * Every payout this session has already been staged from. A handoff can
+   * reach the queue twice — actions run as updaters React is free to
+   * re-invoke — and the second copy is the same announcement, not a second
+   * payday, so it must not deal a second card (#159).
+   */
+  const staged = useRef(new Set<string>());
 
   const launch = useCallback((payout: PayoutEvent) => {
     const chips = chipsFor(payout);
@@ -129,20 +147,24 @@ export const RewardFlightLayer: React.FC = () => {
     ]);
   }, []);
 
-  // Drain the queue: commissions become a card to dismiss, jobs fly at once.
+  // Drain the queue once the truck is home: commissions become a card to
+  // dismiss, jobs fly at once. Announcements already staged are dropped
+  // rather than celebrated again.
   useEffect(() => {
-    if (!pending || pending.length === 0) return;
-    const commissions = pending.filter(
-      (payout) => payout.kind === "commission",
-    );
+    if (!pending || pending.length === 0 || !home) return;
+    const fresh = pending.filter((payout) => !staged.current.has(payout.id));
+    for (const payout of fresh) {
+      staged.current.add(payout.id);
+    }
+    const commissions = fresh.filter((payout) => payout.kind === "commission");
     if (commissions.length > 0) {
       setCards((current) => [...current, ...commissions]);
     }
-    for (const payout of pending) {
+    for (const payout of fresh) {
       if (payout.kind !== "commission") launch(payout);
     }
     applyAction(clearPendingPayoutsAction);
-  }, [pending, applyAction, launch]);
+  }, [pending, home, applyAction, launch]);
 
   // No next-order reveal here: the next commission arrives later, by
   // phone, once reputation reaches its threshold (see CommissionCallLayer)

--- a/src/game/game-actions/payout-actions.test.ts
+++ b/src/game/game-actions/payout-actions.test.ts
@@ -112,6 +112,21 @@ describe("payout announcements", () => {
     assert.strictEqual(result.money, state.money);
   });
 
+  it("gives one handoff one id however often the action is re-run", () => {
+    // Actions run as `setGameState` updaters, and React may invoke an
+    // updater more than once against the same base state. Both invocations
+    // have to describe the same payday, or the flight layer stages it twice
+    // and the client's card is dealt twice (#159).
+    const state = atCab([shelf()]);
+    const first = deliver(state);
+    const again = deliver(state);
+
+    assert.strictEqual(
+      (first.pendingPayouts ?? [])[0].id,
+      (again.pendingPayouts ?? [])[0].id,
+    );
+  });
+
   it("clears the queue once the flight layer has picked it up", () => {
     const delivered = deliver(atCab([shelf()]));
     const drained = clearPendingPayoutsAction(delivered);

--- a/src/game/game-actions/payout-actions.ts
+++ b/src/game/game-actions/payout-actions.ts
@@ -8,18 +8,30 @@ import { PayoutEvent } from "../PayoutEvent";
  */
 export const NO_PAYOUTS: ReadonlyArray<PayoutEvent> = [];
 
-let nextPayoutId = 0;
-
-/** Append a payout announcement to the queue (pure apart from the id counter). */
+/**
+ * Append a payout announcement to the queue.
+ *
+ * The id is derived from the state the announcement is made in — the tick,
+ * what's already queued, and what was handed over — rather than minted from
+ * a counter. Actions run as `setGameState` updaters, and React may invoke an
+ * updater more than once against the same base state; a counter handed each
+ * invocation a *different* id, so the same handoff could reach the flight
+ * layer as two distinct payouts and deal the client's card twice (#159). A
+ * derived id makes the repeat identical, which the layer's dedup collapses.
+ */
 export function emitPayout(
   gameState: GameState,
   event: Omit<PayoutEvent, "id">,
 ): GameState {
+  const queued = gameState.pendingPayouts ?? NO_PAYOUTS;
   return {
     ...gameState,
     pendingPayouts: [
-      ...(gameState.pendingPayouts ?? NO_PAYOUTS),
-      { ...event, id: `payout-${nextPayoutId++}` },
+      ...queued,
+      {
+        ...event,
+        id: `payout-${gameState.tick}-${queued.length}-${event.kind}-${event.title}`,
+      },
     ],
   };
 }

--- a/tests/floor.spec.ts
+++ b/tests/floor.spec.ts
@@ -600,6 +600,16 @@ test.describe("Shop floor", () => {
       await expect(card).toContainText("Marguerite");
       // The payout is itemized on the card: money, reputation, craft XP
       await expect(card).toContainText("$20.00");
+      // One handoff deals one card, not a stack of them
+      await expect(card).toHaveCount(1);
+    });
+
+    await test.step("the card holds the screen until the money is taken", async () => {
+      // A click aimed at the floor behind it is not a dismissal — the card
+      // waits for "Take the money" (or Escape)
+      await page.mouse.click(40, 760);
+      await page.waitForTimeout(100);
+      await expect(page.getByTestId("client-card")).toBeVisible();
     });
 
     await test.step("the payout has already landed behind the card", async () => {


### PR DESCRIPTION
The commission-complete card could be dealt twice for one delivery (#159), and the first showing landed over the trip's backdrop instead of the shop.

## What changed

**Payout ids come from the state, not a counter.** `emitPayout` minted ids from a module-level `nextPayoutId++`. Game actions run as `setGameState` updaters, and React is free to invoke an updater more than once against the same base state — each invocation took a fresh id, so one handoff could reach the flight layer as two distinct paydays that no id-based dedup could collapse. The id is now derived from the tick, the queue, and what was handed over, so a repeat is identical.

**The flight layer dedups, and waits for the shop.** `RewardFlightLayer` remembers which announcements it has staged and drops repeats. It also holds the whole queue until the truck is parked: a delivery settles on the drive *in* (`delivery-actions.ts`), a couple of seconds before the shop is back on screen, so staging it the moment it was queued dealt the card over the trip's brown backdrop and flew the reward chips at readouts that weren't rendered yet. Nothing is dropped by waiting — the payoff now lands at the same moment control does.

**The card holds the screen.** It no longer closes on a backdrop click. It's the one modal the player didn't open, so a click aimed at the shop floor behind it swept the client's line away unread; it now waits for "Take the money" or Escape. `Modal` grew a `backdropCloses` opt-out for this case.

## Checks

- `npm run tsc` clean
- `npm run test:unit` — 1148 pass, including a new case asserting one handoff keeps one id however often the action is re-run
- `npm run test:e2e` — all 7 specs pass; `floor.spec` now also asserts one card per handoff and that a stray click doesn't dismiss it
- Verified by hand in a real (non-E2E) build with the trip transitions on: the payout is queued mid-arrival, held, and the card is dealt once the truck parks — over the shop, surviving a stray click, dismissed by the button

The E2E build disables the trip transitions, which is why the suite never saw the over-the-backdrop showing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
