### PR TITLE
Render cut spray through a RenderLayer so the targeting outline can't rim it

### DIFF
--- a/src/components/machine-sprites/CutParticles.tsx
+++ b/src/components/machine-sprites/CutParticles.tsx
@@ -1,6 +1,6 @@
 import { useTick } from "@pixi/react";
 import { Graphics, Ticker } from "pixi.js";
-import React, { useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import { deriveMachineCutLoad } from "../../game/cut-load";
 import { Machine } from "../../game/Machine";
 import { DustSpecies } from "../../game/Materials";
@@ -9,6 +9,7 @@ import { mixColors } from "../../utils/colorUtils";
 import { lerp } from "../../utils/mathUtils";
 import { rBool, rUniform } from "../../utils/randUtils";
 import { dustColorBySpecies } from "../shop-view/colorBySpecies";
+import { useCutSprayLayer } from "../shop-view/cutSprayLayer";
 import { emitDustStamp } from "../shop-view/dustStampBus";
 
 /**
@@ -115,6 +116,21 @@ export const CutParticles: React.FC<{
   const graphicsRef = useRef<Graphics>(null);
   const particles = useRef<Particle[]>([]);
   const spawnDebt = useRef(0);
+
+  // The spray renders through ShopView's cut-spray RenderLayer instead of
+  // in place: this graphics sits inside the machine's sprite, whose
+  // subtree wears the white targeting OutlineFilter exactly while the
+  // machine is spraying, and the filter rims every airborne fleck — see
+  // cutSprayLayer.ts. The transform still comes from the machine.
+  const sprayLayer = useCutSprayLayer();
+  useEffect(() => {
+    const g = graphicsRef.current;
+    if (!sprayLayer || !g) return;
+    sprayLayer.attach(g);
+    return () => {
+      sprayLayer.detach(g);
+    };
+  }, [sprayLayer]);
 
   const dust = kind === "dust";
   const rate = (ambient ? 55 : dust ? 140 : 45) * intensity * density;

--- a/src/components/shop-view/ShopView.tsx
+++ b/src/components/shop-view/ShopView.tsx
@@ -1,5 +1,9 @@
 import { Application, useApplication } from "@pixi/react";
-import type { Application as PixiApplication, Container } from "pixi.js";
+import type {
+  Application as PixiApplication,
+  Container,
+  RenderLayer,
+} from "pixi.js";
 import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useCellMap } from "../useCellMap";
 import { MachineId, machineKey } from "../../game/Machine";
@@ -31,6 +35,7 @@ import {
   CollisionDebugLayer,
   collisionDebugRequested,
 } from "./CollisionDebugLayer";
+import { cutSprayLayerContext } from "./cutSprayLayer";
 import { DustLayer } from "./DustLayer";
 import { DustMotionLayer } from "./DustMotionLayer";
 import { FeedLaneLayer } from "./FeedLaneLayer";
@@ -249,6 +254,10 @@ export const ShopView: React.FC = () => {
   // renders through, swelled about the bench while a bench view is
   // mounted. Imperative for the same reason — see BenchDiveLayer.
   const benchDiveContainerRef = useRef<Container>(null);
+  // The layer the machines' cut spray renders through, held in state so
+  // the provider re-renders the consumers once the pixi element exists —
+  // see cutSprayLayer.ts for why the spray can't render in place.
+  const [cutSprayLayer, setCutSprayLayer] = useState<RenderLayer | null>(null);
   const [view, setView] = useState<{
     scale: number;
     width: number;
@@ -389,150 +398,157 @@ export const ShopView: React.FC = () => {
             viewHeight={view.height}
             scale={scale}
           />
-          <pixiContainer x={offsetX} y={offsetY} scale={scale}>
-            <pixiContainer ref={benchDiveContainerRef}>
-              <pixiContainer ref={cameraContainerRef}>
-                <EnvironmentLayer
-                  width={width}
-                  height={height}
-                  viewport={worldViewport}
-                  truckHighlight={truckHighlight}
-                  truckCargoHighlight={truckCargoHighlight}
-                  truckTutorialHighlight={coach.truck}
-                />
-                <pixiTilingSprite
-                  eventMode="static"
-                  texture={floorTexture}
-                  tilePosition={{ x: 0, y: 0 }}
-                  tileScale={{ x: 0.25, y: 0.25 }}
-                  width={width}
-                  height={height}
-                />
-                {cellMap.getCells().map((cell) => (
-                  <FloorTileSprite
-                    cell={cell}
-                    key={`cell-${vectorKey(cell.position)}`}
+          <cutSprayLayerContext.Provider value={cutSprayLayer}>
+            <pixiContainer x={offsetX} y={offsetY} scale={scale}>
+              <pixiContainer ref={benchDiveContainerRef}>
+                <pixiContainer ref={cameraContainerRef}>
+                  <EnvironmentLayer
+                    width={width}
+                    height={height}
+                    viewport={worldViewport}
+                    truckHighlight={truckHighlight}
+                    truckCargoHighlight={truckCargoHighlight}
+                    truckTutorialHighlight={coach.truck}
                   />
-                ))}
-                {/* Settled sawdust sits on the floor, under everything that moves */}
-                <DustLayer width={width} height={height} />
-                {/* Cords run along the slab from the electric machines to
+                  <pixiTilingSprite
+                    eventMode="static"
+                    texture={floorTexture}
+                    tilePosition={{ x: 0, y: 0 }}
+                    tileScale={{ x: 0.25, y: 0.25 }}
+                    width={width}
+                    height={height}
+                  />
+                  {cellMap.getCells().map((cell) => (
+                    <FloorTileSprite
+                      cell={cell}
+                      key={`cell-${vectorKey(cell.position)}`}
+                    />
+                  ))}
+                  {/* Settled sawdust sits on the floor, under everything that moves */}
+                  <DustLayer width={width} height={height} />
+                  {/* Cords run along the slab from the electric machines to
                   the wall outlets, under everything that sits on it */}
-                <PowerCordLayer />
-                <BroomSprite />
+                  <PowerCordLayer />
+                  <BroomSprite />
 
-                {gameState.machineCrates.map((crate, index) => (
-                  <MachineCrateSprite
-                    crate={crate}
-                    key={`crate-${index}-${vectorKey(crate.position)}`}
-                  />
-                ))}
+                  {gameState.machineCrates.map((crate, index) => (
+                    <MachineCrateSprite
+                      crate={crate}
+                      key={`crate-${index}-${vectorKey(crate.position)}`}
+                    />
+                  ))}
 
-                {/* The machines' hit shapes, under the loose stock on
+                  {/* The machines' hit shapes, under the loose stock on
                   purpose — a board lying across a machine is what you're
                   pointing at, not the machine under it */}
-                <MachineHitTargets
-                  machines={operableHere}
-                  onHover={setTarget}
-                  onClick={(machine) =>
-                    isTargeted(machine) ? toggleSheet() : setTarget(machine)
-                  }
-                  onRightClick={(machine) => {
-                    setTarget(machine);
-                    openSheet(machine);
-                  }}
-                />
+                  <MachineHitTargets
+                    machines={operableHere}
+                    onHover={setTarget}
+                    onClick={(machine) =>
+                      isTargeted(machine) ? toggleSheet() : setTarget(machine)
+                    }
+                    onRightClick={(machine) => {
+                      setTarget(machine);
+                      openSheet(machine);
+                    }}
+                  />
 
-                {/* Piles draw in drop order, so the last piece set down on a
+                  {/* Piles draw in drop order, so the last piece set down on a
                   spot is on top — matching the pickup order E offers */}
-                {gameState.materialPiles.map((pile) => {
-                  const live =
-                    reachablePiles.has(pile.material.id) && !benchDive;
-                  return (
-                    <MaterialPileSprite
-                      key={`pile-${pile.material.id}`}
-                      pile={pile}
-                      highlighted={pile === pickupTarget && !benchDive}
-                      tutorialTarget={
-                        coach.matchesPile?.(pile.material) ?? false
-                      }
-                      onHover={live ? () => setPileTarget(pile) : undefined}
-                      onRightClick={
-                        live
-                          ? () => {
-                              setPileTarget(pile);
-                              openFloorSheet();
-                            }
-                          : undefined
-                      }
-                    />
-                  );
-                })}
-                {/* Every worktable's cast shadow, in one pass beneath all
+                  {gameState.materialPiles.map((pile) => {
+                    const live =
+                      reachablePiles.has(pile.material.id) && !benchDive;
+                    return (
+                      <MaterialPileSprite
+                        key={`pile-${pile.material.id}`}
+                        pile={pile}
+                        highlighted={pile === pickupTarget && !benchDive}
+                        tutorialTarget={
+                          coach.matchesPile?.(pile.material) ?? false
+                        }
+                        onHover={live ? () => setPileTarget(pile) : undefined}
+                        onRightClick={
+                          live
+                            ? () => {
+                                setPileTarget(pile);
+                                openFloorSheet();
+                              }
+                            : undefined
+                        }
+                      />
+                    );
+                  })}
+                  {/* Every worktable's cast shadow, in one pass beneath all
                   of them: tables pushed together are one bench, and a
                   neighbour's shadow falling across the top butted against
                   it would draw a seam that isn't there. */}
-                {machines
-                  .filter((m) => m.type.worktable)
-                  .map((worktable) => (
-                    <pixiContainer
-                      key={`shadow-${machineKey(worktable.state)}`}
-                      x={cellToPixelCenter(worktable.position)[0]}
-                      y={cellToPixelCenter(worktable.position)[1]}
-                      angle={worktable.rotation * -90}
-                    >
-                      <WorktableShadowSprite machine={worktable} />
-                    </pixiContainer>
-                  ))}
-                {[...machines]
-                  // Worktables draw first so mounted benchtop machines sit on top
-                  .sort(
-                    (a, b) =>
-                      Number(b.type.worktable ?? false) -
-                      Number(a.type.worktable ?? false),
-                  )
-                  .map((machinePlacement) => (
-                    <MachineSprite
-                      key={machineKey(machinePlacement.state)}
-                      machine={machinePlacement}
-                      isSelected={
-                        !gameState.player.away &&
-                        gameState.player.carriedMachine == null &&
-                        // Diving into a bench, the giant outline rim
-                        // would only clutter the close-up
-                        !benchDive &&
-                        isTargeted(machinePlacement)
-                      }
-                      tutorialTarget={coach.machineTypeIds.has(
-                        machinePlacement.type.id as MachineId,
-                      )}
-                    />
-                  ))}
-                {/* Painted over the machines: a blocked lane cell is usually
-                 *under* the machine that's blocking it */}
-                <FeedLaneLayer />
-                {collisionDebugRequested() && <CollisionDebugLayer />}
-                <PlayerMotionLayer paused={paused} />
-                <FootstepSoundLayer />
-                <ShopVacSprite />
-                {!gameState.player.away && truckStage === "parked" && (
-                  <PersonSprite person={gameState.player} />
-                )}
-                {/* Dust in flight rides above the tools taking it */}
-                <DustMotionLayer />
-                <CarriedMachineLayer />
-                {/* The hour of the day, over the whole world — the sky
+                  {machines
+                    .filter((m) => m.type.worktable)
+                    .map((worktable) => (
+                      <pixiContainer
+                        key={`shadow-${machineKey(worktable.state)}`}
+                        x={cellToPixelCenter(worktable.position)[0]}
+                        y={cellToPixelCenter(worktable.position)[1]}
+                        angle={worktable.rotation * -90}
+                      >
+                        <WorktableShadowSprite machine={worktable} />
+                      </pixiContainer>
+                    ))}
+                  {[...machines]
+                    // Worktables draw first so mounted benchtop machines sit on top
+                    .sort(
+                      (a, b) =>
+                        Number(b.type.worktable ?? false) -
+                        Number(a.type.worktable ?? false),
+                    )
+                    .map((machinePlacement) => (
+                      <MachineSprite
+                        key={machineKey(machinePlacement.state)}
+                        machine={machinePlacement}
+                        isSelected={
+                          !gameState.player.away &&
+                          gameState.player.carriedMachine == null &&
+                          // Diving into a bench, the giant outline rim
+                          // would only clutter the close-up
+                          !benchDive &&
+                          isTargeted(machinePlacement)
+                        }
+                        tutorialTarget={coach.machineTypeIds.has(
+                          machinePlacement.type.id as MachineId,
+                        )}
+                      />
+                    ))}
+                  {/* Where the machines' cut spray renders: over them all,
+                  outside any one machine's outline filter — see
+                  cutSprayLayer.ts. Childless on purpose; particles are
+                  attach()ed, and RenderLayer's addChild throws. */}
+                  <pixiRenderLayer ref={setCutSprayLayer} />
+                  {/* Painted over the machines: a blocked lane cell is usually
+                   *under* the machine that's blocking it */}
+                  <FeedLaneLayer />
+                  {collisionDebugRequested() && <CollisionDebugLayer />}
+                  <PlayerMotionLayer paused={paused} />
+                  <FootstepSoundLayer />
+                  <ShopVacSprite />
+                  {!gameState.player.away && truckStage === "parked" && (
+                    <PersonSprite person={gameState.player} />
+                  )}
+                  {/* Dust in flight rides above the tools taking it */}
+                  <DustMotionLayer />
+                  <CarriedMachineLayer />
+                  {/* The hour of the day, over the whole world — the sky
                     outdoors, the bulbs on the slab. Last, so it lights
                     everything the camera holds rather than sitting under
                     half of it. */}
-                <DaylightLayer
-                  width={width}
-                  height={height}
-                  viewport={worldViewport}
-                />
+                  <DaylightLayer
+                    width={width}
+                    height={height}
+                    viewport={worldViewport}
+                  />
+                </pixiContainer>
               </pixiContainer>
             </pixiContainer>
-          </pixiContainer>
+          </cutSprayLayerContext.Provider>
           {/* The bench scene, published by BenchWorkSurface, drawn in
               screen space above the world — outside the camera so the
               daylight pass can't darken the top under your hands. The

--- a/src/components/shop-view/cutSprayLayer.ts
+++ b/src/components/shop-view/cutSprayLayer.ts
@@ -1,0 +1,21 @@
+import { RenderLayer } from "pixi.js";
+import { createContext, useContext } from "react";
+
+/**
+ * Where the machines' cut spray actually renders. The particle emitters
+ * live inside each machine's sprite (aimed at its blade and chip port),
+ * but that subtree wears the targeting OutlineFilter whenever the player
+ * stands at the machine — which is exactly when it sprays — so the
+ * filter rimmed every airborne fleck in white. Children attached to a
+ * RenderLayer skip their ancestors' filter pass while keeping their
+ * logical parent's transform, so CutParticles attaches its graphics
+ * here: the chips still fly with the machine's position and rotation,
+ * just outside its outline. ShopView mounts the layer over the machines,
+ * so a spray also clears a neighbouring machine instead of vanishing
+ * under it.
+ */
+export const cutSprayLayerContext = createContext<RenderLayer | null>(null);
+
+export function useCutSprayLayer(): RenderLayer | null {
+  return useContext(cutSprayLayerContext);
+}

--- a/src/pixi-react.d.ts
+++ b/src/pixi-react.d.ts
@@ -2,6 +2,7 @@
 import type {
   Container,
   Graphics,
+  RenderLayer,
   Sprite,
   Text,
   TextStyle,
@@ -45,6 +46,8 @@ declare global {
       pixiGraphics: PixiProps<Graphics> & {
         draw?: DrawCallback;
       };
+      // No children: RenderLayer takes objects via attach(), not addChild
+      pixiRenderLayer: PixiProps<RenderLayer>;
       pixiSprite: PixiProps<Sprite> & {
         texture?: string | Texture;
         image?: string;

--- a/src/pixi-setup.ts
+++ b/src/pixi-setup.ts
@@ -1,12 +1,22 @@
 // This file sets up and extends PIXI components for use with @pixi/react v8
 import { extend } from "@pixi/react";
-import { Container, Graphics, Sprite, Text, TilingSprite } from "pixi.js";
+import {
+  Container,
+  Graphics,
+  RenderLayer,
+  Sprite,
+  Text,
+  TilingSprite,
+} from "pixi.js";
 
 // Register PIXI components to be used in React
 // Note: Stage is built-in to @pixi/react and doesn't need to be extended
+// Note: a pixiRenderLayer must stay childless in JSX — RenderLayer takes
+// objects via attach(), and its addChild throws
 extend({
   Container,
   Graphics,
+  RenderLayer,
   Sprite,
   Text,
   TilingSprite,


### PR DESCRIPTION
Fixes #162 — sawdust rendered with a weird white outline.

## Root cause

The issue body's EDIT had it right: it *is* the machine focus outline. The `CutParticles` emitters render inside each machine's sprite, and that whole subtree wears the white targeting `OutlineFilter` (`MachineSprite.tsx`) exactly while the player stands at the machine — which is the only time it sprays. The filter outlines the alpha silhouette of everything in the container, so every airborne shaving and fleck got its own white rim. (The settled-dust eraser pass in `DustLayer.tsx` was innocent: an erase blend only removes alpha and can't deposit white, and the settled-dust sprite sits outside any filtered container.)

## Fix

PIXI v8's `RenderLayer`: children attached to a render layer are skipped by their ancestors' filter pass (documented behavior) while keeping their logical parent's transform. `ShopView` now mounts a childless `pixiRenderLayer` over the machines and provides it via context; each `CutParticles` graphics `attach()`es itself to it. The chips still fly with the machine's position and rotation — just outside its outline. This also fixes the same fringe under the orange tutorial outline, and a spray now clears a neighbouring machine instead of vanishing under it.

## Verification

- Before/after screenshots of the jointer face-jointing walnut while targeted: before, every shaving wears a fat white ring; after, clean brown curls while the machine and board keep their intended white targeting rim.
- `npm run tsc` clean, unit suite 1147 passing, all 7 E2E specs passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)