### PR TITLE
Fill a cart in the aisles, and pay for it on the way out

### DIFF
--- a/docs/trips.md
+++ b/docs/trips.md
@@ -32,6 +32,16 @@ Standing at the cab lists numbered rows in two groups:
   permitting.
 - **Work to deliver** — out of the bed.
 
+## A shopping trip ends at a register
+
+Shelves fill a cart rather than transacting a tile at a time: the cart
+hangs off the `shopping` trip itself (`ShoppingTrip.cart`), so driving
+away is what empties it, and the one press that pays for it also drives
+home. The line shapes are in `src/game/cart.ts` and the fold through
+the ordinary buy actions is in
+`src/game/game-actions/cart-actions.ts` — those buy actions still own
+where a purchase lands, and the cart only decides when.
+
 ## Delivery is a trip like any other
 
 Finished work — commissions and job-board jobs alike — only leaves the

--- a/src/components/CartIcon.tsx
+++ b/src/components/CartIcon.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+
+/**
+ * The shopping cart, drawn rather than borrowed: a basket on the slant,
+ * a push handle, and two wheels. Like the reputation star (see
+ * StarIcon.tsx) it sizes itself to the text it sits in (`1em`) and takes
+ * its color from it, so the store header's red-when-overdrawn total
+ * carries the cart along with the figure.
+ *
+ * Stroked, not filled — a solid cart at this size turns into a blob, and
+ * the store's chrome is line work everywhere else too.
+ */
+export const CartIcon: React.FC<{
+  readonly className?: string;
+  /** Screen-reader text; omitted where the label beside it already says "cart". */
+  readonly label?: string;
+}> = ({ className = "", label }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={`inline-block size-[1.15em] -translate-y-[0.05em] align-middle ${className}`}
+    role={label ? "img" : undefined}
+    aria-label={label}
+    aria-hidden={label ? undefined : true}
+  >
+    {/* Handle, up over the basket's back corner */}
+    <path d="M1.5 3 H4.5 L7.2 14.5" />
+    {/* The basket: the front rail runs level, the back leans on the handle */}
+    <path d="M6.2 6 H21.5 L19.6 13.2 A1.6 1.6 0 0 1 18 14.5 H7.2" />
+    <circle cx="9.5" cy="19.5" r="1.6" />
+    <circle cx="17.5" cy="19.5" r="1.6" />
+  </svg>
+);

--- a/src/components/lumberyard-page/LumberyardTripOverlay.tsx
+++ b/src/components/lumberyard-page/LumberyardTripOverlay.tsx
@@ -1,11 +1,11 @@
 import React from "react";
-import { returnFromStoreAction } from "../../game/game-actions/door-actions";
 import { BoardSelector } from "../store-page/BoardSelector";
+import { StoreCartReadout, StoreCheckoutButton } from "../store-page/StoreCart";
+import { useStoreTrip } from "../store-page/useStoreTrip";
 import { SawyerAndSonsLogo } from "./SawyerAndSonsLogo";
 import { TripHeader } from "../trip/TripHeader";
 import { TripOverlay } from "../trip/TripOverlay";
-import { useHeadHome } from "../trip/TripTransitionLayer";
-import { useApplyGameAction, useGameState } from "../useGameState";
+import { useGameState } from "../useGameState";
 
 /**
  * A trip to Sawyer & Sons, the hardwood lumberyard across town. Reached by
@@ -19,10 +19,15 @@ import { useApplyGameAction, useGameState } from "../useGameState";
  */
 export const LumberyardTripOverlay: React.FC = () => {
   const gameState = useGameState();
-  const applyAction = useApplyGameAction();
-  const beginReturn = useHeadHome();
-  const headHome = () =>
-    beginReturn(() => applyAction(returnFromStoreAction()));
+  const {
+    cart,
+    total,
+    overdrawn,
+    canCheckOut,
+    confirmingLeave,
+    requestLeave,
+    checkOutAndLeave,
+  } = useStoreTrip();
 
   if (
     gameState.player.away?.kind !== "shopping" ||
@@ -32,7 +37,7 @@ export const LumberyardTripOverlay: React.FC = () => {
   }
 
   return (
-    <TripOverlay label="Sawyer & Sons" onHeadHome={headHome}>
+    <TripOverlay label="Sawyer & Sons" onHeadHome={requestLeave}>
       <div className="rounded-md overflow-hidden shadow-2xl border border-mill-green-dark grow min-h-0 flex flex-col">
         <TripHeader
           brand={<SawyerAndSonsLogo className="h-12 w-auto shrink-0" />}
@@ -41,7 +46,28 @@ export const LumberyardTripOverlay: React.FC = () => {
           brandRowClassName="items-baseline"
           mutedClassName="text-paper-cream/80"
           homeButtonClassName="border-paper-cream/80 hover:bg-paper-cream/15"
-          onHeadHome={headHome}
+          onHeadHome={requestLeave}
+          confirmingLeave={confirmingLeave}
+          cart={
+            <StoreCartReadout
+              cart={cart}
+              total={total}
+              overdrawn={overdrawn}
+              mutedClassName="text-paper-cream/80"
+              // Ink red vanishes into the yard's green bar — the tag on
+              // the total has to shout from across the lot
+              overdrawnClassName="text-red-300"
+            />
+          }
+          checkout={
+            cart.length > 0 && (
+              <StoreCheckoutButton
+                canCheckOut={canCheckOut}
+                onCheckOut={checkOutAndLeave}
+                className="border-paper-cream bg-paper-cream text-mill-green-dark hover:bg-white hover:border-white"
+              />
+            )
+          }
         />
         <div className="bg-mill-timber text-ink-black p-6 grow min-h-0 overflow-y-auto">
           <div className="max-w-6xl mx-auto pt-2">

--- a/src/components/manual/articles/WelcomeArticle.tsx
+++ b/src/components/manual/articles/WelcomeArticle.tsx
@@ -93,8 +93,10 @@ export const WelcomeArticle: React.FC = () => (
       hardware store (a trip from the same cab) and the phone in the top bar,
       where work gets listed for sale and one-off jobs get taken. Jobs and sales
       are how the shop earns between commissions; new commissions arrive by
-      phone as your reputation grows. What you buy rides home in the bed; unload
-      it at the tailgate with <ShortcutKeys shortcut="pick-up" />.
+      phone as your reputation grows. Taking something off a shelf puts it in
+      your cart; nothing is paid for until you check out, and checking out is
+      the same press that drives you home. What you bought rides home in the bed
+      — unload it at the tailgate with <ShortcutKeys shortcut="pick-up" />.
     </P>
 
     <Note>

--- a/src/components/store-page/BoardSelector.tsx
+++ b/src/components/store-page/BoardSelector.tsx
@@ -1,7 +1,8 @@
 import React, { useMemo } from "react";
 import { Species } from "../../game/Materials";
 import { board } from "../../game/board-helpers";
-import { buyMaterialAction } from "../../game/game-actions/store-actions";
+import { CartLine } from "../../game/cart";
+import { addToCartAction } from "../../game/game-actions/cart-actions";
 import { getBoardBuyPrice } from "../../game/material-values";
 import { formatLength, formatMoney } from "../../utils/formatNumber";
 import {
@@ -19,8 +20,10 @@ import {
   unlockedLumberChannels,
 } from "../../game/lumberStock";
 import { BoardFaceSvg } from "./BoardFaceSvg";
+import { CartIcon } from "../CartIcon";
 import { Tooltip } from "../Tooltip";
 import { useApplyGameAction, useGameState } from "../useGameState";
+import { useCartCount } from "./useStoreTrip";
 
 /**
  * Every rack in town shares one pixels-per-foot, so lengths compare at a
@@ -49,7 +52,8 @@ const CHAIN_BG = `url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg
  * The racks mimic a real hardwood aisle: one bay per species, boards
  * standing on end and packed shoulder to shoulder, wooden posts between
  * bays, a safety chain across the front, and a paper tag stapled to each
- * board with its dims and price. The board itself is the buy button.
+ * board with its dims and price. The board itself is what you pick up —
+ * clicking one puts it in the cart, and its tag counts what's in there.
  * Everything reads right to left. The milled state and the channel's
  * flavor line wait in the channel-name tooltip; the surrounding overlay
  * owns the section heading, so each store keeps its own signage.
@@ -182,6 +186,8 @@ const BoardForSale: React.FC<{
   );
   const price = getBoardBuyPrice(material, channel.priceMultiplier);
   const fullName = getMaterialFullName(material);
+  const line: CartLine = { kind: "material", material, price };
+  const inCart = useCartCount(line);
 
   // The tag distinguishes the boards of a bay — species is on the floor
   const nominal = nominalSizeLabel(material);
@@ -210,13 +216,8 @@ const BoardForSale: React.FC<{
         className="relative block shrink-0 transition-[filter] enabled:cursor-pointer enabled:hover:brightness-110 disabled:opacity-60"
         style={{ height: (sku.length / 12) * PX_PER_FOOT }}
         disabled={gameState.money < price}
-        data-sfx="ui-purchase"
-        aria-label={`Buy ${fullName}`}
-        onClick={() =>
-          applyAction(
-            buyMaterialAction(channelBoard(channel, sku, species), price),
-          )
-        }
+        aria-label={`Add ${fullName} to cart`}
+        onClick={() => applyAction(addToCartAction(line))}
       >
         <BoardFaceSvg
           vertical
@@ -243,6 +244,14 @@ const BoardForSale: React.FC<{
               }`}
             >
               ×{numberOwned}
+            </span>
+          )}
+          {/* What's on the cart already, on the tag beside the count of
+              what the shop owns — the two numbers a shopper compares */}
+          {inCart > 0 && (
+            <span className="flex items-center gap-0.5 text-[10px] font-semibold tabular-nums text-ink-blue">
+              <CartIcon />
+              {inCart}
             </span>
           )}
         </span>

--- a/src/components/store-page/ProductTile.tsx
+++ b/src/components/store-page/ProductTile.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { formatCount, formatMoney } from "../../utils/formatNumber";
+import { CartIcon } from "../CartIcon";
 import { Tooltip } from "../Tooltip";
 import { BuyButton } from "./BuyButton";
 
@@ -20,13 +21,14 @@ export const ProductTile: React.FC<{
   /** One short line under the name — what the shop already has of this. */
   owned?: React.ReactNode;
   canAfford: boolean;
-  onBuy: () => void;
-  /** Routed to the delegated click-sound listener (e.g. "ui-purchase"). */
-  sfx?: string;
+  /** Put one in the cart. Nothing is paid for until the register. */
+  onAdd: () => void;
+  /** How many of this are already in the cart, called out under the name. */
+  inCart?: number;
   /**
    * Marks the whole tile for the guided opening to ring (see
    * TutorialSpotlightLayer) — the shelf tag is what you look for in an
-   * aisle, not the Buy button on it.
+   * aisle, not the Add to Cart button on it.
    */
   tutorialTarget?: string;
 }> = ({
@@ -36,8 +38,8 @@ export const ProductTile: React.FC<{
   info,
   owned,
   canAfford,
-  onBuy,
-  sfx,
+  onAdd,
+  inCart = 0,
   tutorialTarget,
 }) => (
   // The picture centers over the tile, the words hang off its left edge
@@ -62,15 +64,28 @@ export const ProductTile: React.FC<{
         {owned}
       </span>
     )}
-    <span className="mt-auto flex w-full items-center justify-between gap-1 pt-0.5">
+    {inCart > 0 && (
+      <span className="flex items-center gap-1 text-[0.7rem] font-semibold leading-tight text-ink-blue tabular-nums">
+        <CartIcon />
+        {formatCount(inCart)} in cart
+      </span>
+    )}
+    {/* wrap: "Add to Cart" is wide next to a four-figure price, and a
+        narrow aisle can't seat both on one line. Rather than let the
+        button overhang the tile — where it would sit under the next
+        tile's price tag and swallow clicks — it drops to its own row and
+        fills it. */}
+    <span className="mt-auto flex w-full flex-wrap items-center justify-between gap-1 pt-0.5">
       <PriceTag price={price} />
       <BuyButton
         size="compact"
         disabled={!canAfford}
-        data-sfx={sfx}
-        onClick={onBuy}
+        onClick={onAdd}
+        aria-label={`Add ${name} to cart`}
+        className="flex grow items-center justify-center gap-1 whitespace-nowrap"
       >
-        Buy
+        <CartIcon />
+        Add to Cart
       </BuyButton>
     </span>
   </li>
@@ -80,7 +95,8 @@ export const ProductTile: React.FC<{
  * The ⓘ in the tile's top corner: the one thing on the tile that opens
  * the hover copy. The whole tile used to be the trigger, which meant the
  * description ambushed you every time the pointer crossed an aisle on
- * its way to the Buy button. Reading it is now something you ask for —
+ * its way to the Add to Cart button. Reading it is now something you ask
+ * for —
  * point at the badge, or click it and it stays up until you click away.
  */
 const InfoButton: React.FC<{ name: string; info: React.ReactNode }> = ({

--- a/src/components/store-page/StoreCart.tsx
+++ b/src/components/store-page/StoreCart.tsx
@@ -1,0 +1,358 @@
+import {
+  autoUpdate,
+  flip,
+  FloatingPortal,
+  offset,
+  safePolygon,
+  shift,
+  useDismiss,
+  useFloating,
+  useFocus,
+  useHover,
+  useInteractions,
+  useRole,
+} from "@floating-ui/react";
+import React, { useState } from "react";
+import { CLAMP_NAME } from "../../game/Clamp";
+import { CartGroup, CartLine, groupCartLines } from "../../game/cart";
+import { CONSUMABLE_TYPES } from "../../game/Consumable";
+import {
+  addToCartAction,
+  clearCartAction,
+  removeFromCartAction,
+} from "../../game/game-actions/cart-actions";
+import { BROOM_NAME } from "../../game/HeldTool";
+import { MACHINE_TYPES, MachineId } from "../../game/Machine";
+import { getMaterialFullName } from "../../game/material-helpers";
+import { SHOP_VAC_NAME } from "../../game/ShopVac";
+import { ToolId } from "../../game/Tool";
+import { UPGRADE_TYPES, UpgradeId } from "../../game/Upgrade";
+import { classNames } from "../../utils/classNames";
+import { formatMoney } from "../../utils/formatNumber";
+import { CartIcon } from "../CartIcon";
+import {
+  BroomIcon,
+  ClampIcon,
+  ConsumableIcon,
+  MachineIcon,
+  ShopVacIcon,
+  ToolIcon,
+  UpgradeIcon,
+} from "../ItemIcon";
+import { useApplyGameAction } from "../useGameState";
+import { BoardFaceSvg } from "./BoardFaceSvg";
+import { SheetFaceSvg } from "./SheetFaceSvg";
+
+/**
+ * The cart, as the store's chrome shows it: a running total in the top
+ * bar between the wallet and the way out, and — on hover or focus — the
+ * itemized list hanging under it, where quantities are changed and
+ * things go back on the shelf.
+ *
+ * The total goes red the moment the cart outruns the wallet. Nothing
+ * stops you filling it past what you can pay (a store doesn't), so the
+ * red figure and the greyed-out Check Out are the whole of the warning.
+ *
+ * The panel is a real popover rather than a Tooltip: tooltips here are
+ * `pointer-events-none` by design, and this one is full of buttons. It
+ * stays open across the gap between the total and the panel
+ * (`safePolygon`), which is what makes "point at it, then reach for the
+ * minus" work.
+ */
+export const StoreCartReadout: React.FC<{
+  cart: ReadonlyArray<CartLine>;
+  total: number;
+  overdrawn: boolean;
+  /** The muted ink of the bar this sits in, matching the wallet's label. */
+  mutedClassName: string;
+  /**
+   * The red the total turns when it outruns the wallet. Each venue paints
+   * its own: ink red reads on the store's white bar and would disappear
+   * into the lumberyard's green one.
+   */
+  overdrawnClassName: string;
+}> = ({ cart, total, overdrawn, mutedClassName, overdrawnClassName }) => {
+  const [open, setOpen] = useState(false);
+
+  const { refs, floatingStyles, context } = useFloating({
+    open,
+    onOpenChange: setOpen,
+    placement: "bottom-end",
+    whileElementsMounted: autoUpdate,
+    middleware: [offset(8), flip({ padding: 8 }), shift({ padding: 8 })],
+  });
+  const hover = useHover(context, {
+    delay: { open: 80, close: 120 },
+    // The pointer has to cross open air to reach the panel's buttons
+    handleClose: safePolygon({ blockPointerEvents: false }),
+  });
+  const focus = useFocus(context);
+  const dismiss = useDismiss(context);
+  const role = useRole(context, { role: "dialog" });
+  const { getReferenceProps, getFloatingProps } = useInteractions([
+    hover,
+    focus,
+    dismiss,
+    role,
+  ]);
+
+  const count = cart.length;
+
+  return (
+    <>
+      <div
+        ref={refs.setReference}
+        {...getReferenceProps()}
+        // A div, not a button: the total isn't a control — the panel it
+        // opens holds the controls. tabIndex keeps it reachable anyway.
+        tabIndex={0}
+        data-testid="store-cart-total"
+        className="flex cursor-default flex-col items-end leading-tight outline-none"
+      >
+        <span
+          className={classNames(
+            "font-condensed uppercase tracking-[0.2em] text-[0.65rem]",
+            mutedClassName,
+          )}
+        >
+          {count === 0
+            ? "Cart"
+            : `Cart · ${count} ${count === 1 ? "item" : "items"}`}
+        </span>
+        <span
+          className={classNames(
+            "flex items-center gap-1.5 text-xl font-bold tabular-nums",
+            overdrawn && overdrawnClassName,
+          )}
+        >
+          <CartIcon label="Cart total" />
+          {formatMoney(total)}
+        </span>
+      </div>
+      {open && (
+        <FloatingPortal>
+          <div
+            ref={refs.setFloating}
+            style={floatingStyles}
+            {...getFloatingProps()}
+            data-testid="store-cart-panel"
+            className="z-50 w-[24rem] max-w-[calc(100vw-2rem)] rounded-sm border border-paper-manila-edge bg-paper-ivory text-ink-black shadow-2xl"
+          >
+            <CartPanel cart={cart} total={total} overdrawn={overdrawn} />
+          </div>
+        </FloatingPortal>
+      )}
+    </>
+  );
+};
+
+/**
+ * The register. One press pays for the cart and drives home — there is
+ * no ringing up and carrying on shopping, because what you buy goes in
+ * the truck's bed and the bed goes home. Absent entirely while the cart
+ * is empty (Head Home is the only way out then), and disabled while the
+ * cart outruns the wallet.
+ */
+export const StoreCheckoutButton: React.FC<{
+  canCheckOut: boolean;
+  onCheckOut: () => void;
+  /** The venue's paint for the button itself. */
+  className: string;
+}> = ({ canCheckOut, onCheckOut, className }) => (
+  <button
+    className={classNames(
+      "flex items-center gap-2 rounded-sm border-2 px-3 py-1.5 font-condensed font-bold uppercase tracking-[0.2em] text-sm disabled:cursor-not-allowed disabled:opacity-50",
+      className,
+    )}
+    onClick={onCheckOut}
+    disabled={!canCheckOut}
+    data-sfx="ui-purchase"
+    data-testid="store-check-out"
+  >
+    <CartIcon />
+    Check Out &amp; Head Home
+  </button>
+);
+
+const CartPanel: React.FC<{
+  cart: ReadonlyArray<CartLine>;
+  total: number;
+  overdrawn: boolean;
+}> = ({ cart, total, overdrawn }) => {
+  const applyAction = useApplyGameAction();
+  const groups = groupCartLines(cart);
+
+  if (groups.length === 0) {
+    return (
+      <p className="px-4 py-5 text-center font-condensed uppercase tracking-wider text-sm text-ink-fade">
+        Your cart is empty
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex max-h-[60vh] flex-col">
+      <ul className="min-h-0 grow divide-y divide-paper-manila-edge/60 overflow-y-auto">
+        {groups.map((group) => (
+          <CartRow key={group.key} group={group} />
+        ))}
+      </ul>
+      <div className="flex items-center justify-between gap-3 border-t border-paper-manila-edge bg-paper-manila/60 px-3 py-2">
+        <button
+          className="font-condensed uppercase tracking-wider text-xs text-ink-fade hover:text-ink-black"
+          onClick={() => applyAction(clearCartAction())}
+          data-sfx="ui-back"
+        >
+          Empty cart
+        </button>
+        <span className="flex items-baseline gap-2">
+          <span className="font-condensed uppercase tracking-[0.2em] text-[0.65rem] text-ink-fade">
+            Total
+          </span>
+          <span
+            className={classNames(
+              "text-lg font-bold tabular-nums",
+              overdrawn && "text-ink-red",
+            )}
+          >
+            {formatMoney(total)}
+          </span>
+        </span>
+      </div>
+      {overdrawn && (
+        <p className="border-t border-paper-manila-edge px-3 py-1.5 text-center text-xs text-ink-red">
+          More than your wallet — put something back.
+        </p>
+      )}
+    </div>
+  );
+};
+
+/** One product in the cart: what it is, how many, and what they cost. */
+const CartRow: React.FC<{ group: CartGroup }> = ({ group }) => {
+  const applyAction = useApplyGameAction();
+  const name = cartLineName(group.line);
+  // Always the last of the group, so removing one never disturbs the
+  // indices of the lines still ahead of it.
+  const lastIndex = group.indices[group.indices.length - 1];
+
+  return (
+    <li className="flex items-center gap-2.5 px-3 py-2">
+      {/* Clipped, not fitted: a board drawn to true aspect is a 2px
+          sliver at this height, so the box shows a window onto its face
+          — the grain and color that identify it — instead. */}
+      <span className="grid size-8 shrink-0 place-items-center overflow-hidden rounded-[1px]">
+        <CartLineIcon line={group.line} />
+      </span>
+      <span className="min-w-0 grow leading-tight">
+        <span className="block truncate text-sm" title={name}>
+          {name}
+        </span>
+        <span className="block text-xs tabular-nums text-ink-fade">
+          {formatMoney(group.line.price)} each
+        </span>
+      </span>
+      <span className="flex shrink-0 items-center gap-1">
+        <StepperButton
+          label={`Remove one ${name}`}
+          onClick={() => applyAction(removeFromCartAction(lastIndex))}
+        >
+          −
+        </StepperButton>
+        <span className="w-5 text-center text-sm font-bold tabular-nums">
+          {group.count}
+        </span>
+        <StepperButton
+          label={`Add another ${name}`}
+          onClick={() => applyAction(addToCartAction(group.line))}
+        >
+          +
+        </StepperButton>
+      </span>
+      <span className="w-16 shrink-0 text-right text-sm font-bold tabular-nums">
+        {formatMoney(group.price)}
+      </span>
+    </li>
+  );
+};
+
+const StepperButton: React.FC<{
+  label: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}> = ({ label, onClick, children }) => (
+  <button
+    aria-label={label}
+    onClick={onClick}
+    className="size-6 rounded-sm border border-paper-manila-edge bg-paper-manila text-base leading-none text-ink-black hover:bg-store-orange hover:text-white"
+  >
+    {children}
+  </button>
+);
+
+/** What a line is called on the receipt. */
+export function cartLineName(line: CartLine): string {
+  switch (line.kind) {
+    case "material":
+      return getMaterialFullName(line.material);
+    case "machine":
+      return MACHINE_TYPES[line.machineTypeId].name;
+    case "consumablePack":
+      return CONSUMABLE_TYPES[line.consumableId].packName;
+    case "upgrade":
+      return UPGRADE_TYPES[line.upgradeId].name;
+    case "clamp":
+      return CLAMP_NAME;
+    case "broom":
+      return BROOM_NAME;
+    case "shopVac":
+      return SHOP_VAC_NAME;
+  }
+}
+
+/** The same picture the shelf tag showed, shrunk to a receipt line. */
+const CartLineIcon: React.FC<{ line: CartLine }> = ({ line }) => {
+  switch (line.kind) {
+    case "material": {
+      const material = line.material;
+      if (material.type === "board") {
+        return (
+          <BoardFaceSvg board={material} className="h-8 w-auto max-w-none" />
+        );
+      }
+      if (material.type === "plywood") {
+        return <SheetFaceSvg kind={material.kind} className="size-7" />;
+      }
+      if (material.type === "tool") {
+        return (
+          <ToolIcon toolId={material.toolId as ToolId} className="size-7" />
+        );
+      }
+      return null;
+    }
+    case "machine":
+      return (
+        <MachineIcon
+          machineId={line.machineTypeId as MachineId}
+          className="max-h-8 w-auto"
+        />
+      );
+    case "consumablePack":
+      return (
+        <ConsumableIcon consumableId={line.consumableId} className="size-7" />
+      );
+    case "upgrade":
+      return (
+        <UpgradeIcon
+          upgradeId={line.upgradeId as UpgradeId}
+          className="size-7"
+        />
+      );
+    case "clamp":
+      return <ClampIcon className="size-7" />;
+    case "broom":
+      return <BroomIcon className="size-7" />;
+    case "shopVac":
+      return <ShopVacIcon className="size-7" />;
+  }
+};

--- a/src/components/store-page/StoreMachinesSection.tsx
+++ b/src/components/store-page/StoreMachinesSection.tsx
@@ -1,10 +1,12 @@
 import React from "react";
+import { CartLine } from "../../game/cart";
 import { MACHINE_TYPES, MachineId, MachineType } from "../../game/Machine";
-import { buyMachineAction } from "../../game/game-actions/store-actions";
+import { addToCartAction } from "../../game/game-actions/cart-actions";
 import { MachineIcon } from "../ItemIcon";
 import { useApplyGameAction, useGameState, useMachines } from "../useGameState";
 import { AisleSection } from "./AisleSection";
 import { ProductTile } from "./ProductTile";
+import { useCartCount } from "./useStoreTrip";
 
 export const StoreMachinesSection: React.FC<{ className?: string }> = ({
   className,
@@ -58,6 +60,12 @@ const MachineProductTile: React.FC<{ machine: MachineType }> = ({
       (crate) => crate.machine.machineTypeId === machine.id,
     ).length +
     (gameState.player.carriedMachine?.machineTypeId === machine.id ? 1 : 0);
+  const line: CartLine = {
+    kind: "machine",
+    machineTypeId: machine.id as MachineId,
+    price,
+  };
+  const inCart = useCartCount(line);
 
   return (
     <ProductTile
@@ -73,11 +81,9 @@ const MachineProductTile: React.FC<{ machine: MachineType }> = ({
       price={price}
       info={`${machine.description} Rides home crated in the truck's bed.`}
       owned={numberOwned > 0 ? `${numberOwned} owned` : undefined}
+      inCart={inCart}
       canAfford={gameState.money >= price}
-      sfx="ui-purchase"
-      onBuy={() =>
-        applyAction(buyMachineAction(machine.id as MachineId, price))
-      }
+      onAdd={() => applyAction(addToCartAction(line))}
     />
   );
 };

--- a/src/components/store-page/StoreSheetGoodsSection.tsx
+++ b/src/components/store-page/StoreSheetGoodsSection.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from "react";
-import { buyMaterialAction } from "../../game/game-actions/store-actions";
+import { CartLine } from "../../game/cart";
+import { addToCartAction } from "../../game/game-actions/cart-actions";
 import {
   describeStockDimensionsPlain,
   makeMaterial,
@@ -18,6 +19,7 @@ import { useApplyGameAction, useGameState } from "../useGameState";
 import { AisleSection } from "./AisleSection";
 import { ProductTile } from "./ProductTile";
 import { SheetFaceSvg } from "./SheetFaceSvg";
+import { useCartCount } from "./useStoreTrip";
 
 /**
  * The sheet-good rack (see sheetStock.ts). One tile per SKU, cheapest
@@ -65,6 +67,8 @@ const SheetSkuTile: React.FC<{ sku: SheetSku; size: SheetSize }> = ({
 
   const material = useMemo(makeSheet, [sku, size]);
   const price = getSheetBuyPrice(material);
+  const line: CartLine = { kind: "material", material, price };
+  const inCart = useCartCount(line);
 
   const numberOwned = gameState.player.inventory.filter((m) =>
     materialMeetsInput(m, {
@@ -88,9 +92,9 @@ const SheetSkuTile: React.FC<{ sku: SheetSku; size: SheetSize }> = ({
       owned={
         numberOwned > 0 ? `${size.label} · ${numberOwned} owned` : size.label
       }
+      inCart={inCart}
       canAfford={gameState.money >= price}
-      sfx="ui-purchase"
-      onBuy={() => applyAction(buyMaterialAction(makeSheet(), price))}
+      onAdd={() => applyAction(addToCartAction(line))}
     />
   );
 };

--- a/src/components/store-page/StoreSuppliesSection.tsx
+++ b/src/components/store-page/StoreSuppliesSection.tsx
@@ -5,15 +5,14 @@ import {
   CLAMP_NAME,
   clampsInUse,
 } from "../../game/Clamp";
+import { CartLine } from "../../game/cart";
 import { CONSUMABLE_TYPES, ConsumableId } from "../../game/Consumable";
-import {
-  buyClampAction,
-  buyConsumablePackAction,
-} from "../../game/game-actions/store-actions";
+import { addToCartAction } from "../../game/game-actions/cart-actions";
 import { ClampIcon, ConsumableIcon } from "../ItemIcon";
 import { useApplyGameAction, useGameState } from "../useGameState";
 import { AisleSection } from "./AisleSection";
 import { ProductTile } from "./ProductTile";
+import { useCartCount } from "./useStoreTrip";
 
 export const StoreSuppliesSection: React.FC<{ className?: string }> = ({
   className,
@@ -35,6 +34,8 @@ const ClampTile: React.FC = () => {
   const applyAction = useApplyGameAction();
   const gameState = useGameState();
   const inUse = clampsInUse(gameState.machines);
+  const line: CartLine = { kind: "clamp", price: CLAMP_COST };
+  const inCart = useCartCount(line);
 
   return (
     <ProductTile
@@ -47,8 +48,9 @@ const ClampTile: React.FC = () => {
           ? `${gameState.clamps} owned${inUse > 0 ? ` (${inUse} in use)` : ""}`
           : undefined
       }
+      inCart={inCart}
       canAfford={gameState.money >= CLAMP_COST}
-      onBuy={() => applyAction(buyClampAction())}
+      onAdd={() => applyAction(addToCartAction(line))}
     />
   );
 };
@@ -64,6 +66,12 @@ const ConsumablePackTile: React.FC<{ consumableId: ConsumableId }> = ({
   const gameState = useGameState();
   const type = CONSUMABLE_TYPES[consumableId];
   const owned = gameState.consumables[consumableId] ?? 0;
+  const line: CartLine = {
+    kind: "consumablePack",
+    consumableId,
+    price: type.packPrice,
+  };
+  const inCart = useCartCount(line);
 
   return (
     <ProductTile
@@ -72,8 +80,9 @@ const ConsumablePackTile: React.FC<{ consumableId: ConsumableId }> = ({
       price={type.packPrice}
       info={`${type.description} ${type.packSize} ${type.unit} per pack.`}
       owned={owned > 0 ? `${owned} ${type.unit} in shop` : undefined}
+      inCart={inCart}
       canAfford={gameState.money >= type.packPrice}
-      onBuy={() => applyAction(buyConsumablePackAction(consumableId))}
+      onAdd={() => applyAction(addToCartAction(line))}
     />
   );
 };

--- a/src/components/store-page/StoreToolsSection.tsx
+++ b/src/components/store-page/StoreToolsSection.tsx
@@ -1,17 +1,17 @@
 import React from "react";
-import { buyBroomAction } from "../../game/game-actions/dust-actions";
-import { buyShopVacAction } from "../../game/game-actions/shop-vac-actions";
-import { buyToolAction } from "../../game/game-actions/tool-actions";
-import { buyUpgradeAction } from "../../game/game-actions/upgrade-actions";
-import { BROOM_COST } from "../../game/HeldTool";
+import { CartLine } from "../../game/cart";
+import { addToCartAction } from "../../game/game-actions/cart-actions";
+import { BROOM_COST, BROOM_NAME } from "../../game/HeldTool";
+import { makeToolItem } from "../../game/material-helpers";
 import { ownedToolIds } from "../../game/progression-helpers";
-import { SHOP_VAC_COST } from "../../game/ShopVac";
+import { SHOP_VAC_COST, SHOP_VAC_NAME } from "../../game/ShopVac";
 import { TOOL_TYPES, ToolId, ToolType } from "../../game/Tool";
 import { UPGRADE_TYPES, UpgradeId, UpgradeType } from "../../game/Upgrade";
 import { BroomIcon, ShopVacIcon, ToolIcon, UpgradeIcon } from "../ItemIcon";
 import { useApplyGameAction, useGameState } from "../useGameState";
 import { AisleSection } from "./AisleSection";
 import { ProductTile } from "./ProductTile";
+import { useCartCount } from "./useStoreTrip";
 
 export const StoreToolsSection: React.FC<{ className?: string }> = ({
   className,
@@ -46,6 +46,8 @@ export const StoreToolsSection: React.FC<{ className?: string }> = ({
 const BroomProductTile: React.FC = () => {
   const applyAction = useApplyGameAction();
   const gameState = useGameState();
+  const line: CartLine = { kind: "broom", price: BROOM_COST };
+  const inCart = useCartCount(line);
 
   if (gameState.broomOwned) {
     return null;
@@ -53,12 +55,13 @@ const BroomProductTile: React.FC = () => {
 
   return (
     <ProductTile
-      name="Shop Broom"
+      name={BROOM_NAME}
       icon={<BroomIcon />}
       price={BROOM_COST}
       info="A push broom with a dustpan. Sweeps sawdust off the floor; empty the pan at the garbage can."
+      inCart={inCart}
       canAfford={gameState.money >= BROOM_COST}
-      onBuy={() => applyAction(buyBroomAction())}
+      onAdd={() => applyAction(addToCartAction(line))}
     />
   );
 };
@@ -76,6 +79,12 @@ const UpgradeProductTile: React.FC<{ upgrade: UpgradeType }> = ({
         sum + (machine.upgrades ?? []).filter((id) => id === upgrade.id).length,
       0,
     );
+  const line: CartLine = {
+    kind: "upgrade",
+    upgradeId: upgrade.id as UpgradeId,
+    price: upgrade.cost,
+  };
+  const inCart = useCartCount(line);
 
   return (
     <ProductTile
@@ -84,8 +93,9 @@ const UpgradeProductTile: React.FC<{ upgrade: UpgradeType }> = ({
       price={upgrade.cost}
       info={`${upgrade.description} Installs into a worktable's upgrade slot.`}
       owned={numberOwned > 0 ? `${numberOwned} owned` : undefined}
+      inCart={inCart}
       canAfford={gameState.money >= upgrade.cost}
-      onBuy={() => applyAction(buyUpgradeAction(upgrade.id as UpgradeId))}
+      onAdd={() => applyAction(addToCartAction(line))}
     />
   );
 };
@@ -98,6 +108,8 @@ const UpgradeProductTile: React.FC<{ upgrade: UpgradeType }> = ({
 const ShopVacProductTile: React.FC = () => {
   const applyAction = useApplyGameAction();
   const gameState = useGameState();
+  const line: CartLine = { kind: "shopVac", price: SHOP_VAC_COST };
+  const inCart = useCartCount(line);
 
   if (gameState.shopVac !== null) {
     return null;
@@ -105,12 +117,13 @@ const ShopVacProductTile: React.FC = () => {
 
   return (
     <ProductTile
-      name="Shop Vac"
+      name={SHOP_VAC_NAME}
       icon={<ShopVacIcon />}
       price={SHOP_VAC_COST}
       info="A canister vacuum on casters. Clears sawdust from the floor, including under machines. Drag it with you and empty it at the garbage can."
+      inCart={inCart}
       canAfford={gameState.money >= SHOP_VAC_COST}
-      onBuy={() => applyAction(buyShopVacAction())}
+      onAdd={() => applyAction(addToCartAction(line))}
     />
   );
 };
@@ -122,6 +135,14 @@ const ToolProductTile: React.FC<{ tool: ToolType }> = ({ tool }) => {
   const numberOwned = ownedToolIds(gameState).filter(
     (id) => id === tool.id,
   ).length;
+  // A tool is bought as the object it is, same as a board — the cart
+  // stamps each one its own id on the way in (see addToCartAction).
+  const line: CartLine = {
+    kind: "material",
+    material: makeToolItem(tool.id as ToolId),
+    price: tool.cost,
+  };
+  const inCart = useCartCount(line);
 
   return (
     <ProductTile
@@ -130,8 +151,9 @@ const ToolProductTile: React.FC<{ tool: ToolType }> = ({ tool }) => {
       price={tool.cost}
       info={`${tool.description} Rides home in the truck's bed; carry it to a workstation and hang it on a bench's rail, or fit it in a machine's accessory slot.`}
       owned={numberOwned > 0 ? `${numberOwned} owned` : undefined}
+      inCart={inCart}
       canAfford={gameState.money >= tool.cost}
-      onBuy={() => applyAction(buyToolAction(tool.id as ToolId))}
+      onAdd={() => applyAction(addToCartAction(line))}
       tutorialTarget={`store-tool-${tool.id}`}
     />
   );

--- a/src/components/store-page/StoreTripOverlay.tsx
+++ b/src/components/store-page/StoreTripOverlay.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { returnFromStoreAction } from "../../game/game-actions/door-actions";
 import { TripHeader } from "../trip/TripHeader";
 import { TripOverlay } from "../trip/TripOverlay";
-import { useHeadHome } from "../trip/TripTransitionLayer";
-import { useApplyGameAction, useGameState } from "../useGameState";
+import { useGameState } from "../useGameState";
 import { BoardSelector } from "./BoardSelector";
+import { StoreCartReadout, StoreCheckoutButton } from "./StoreCart";
+import { useStoreTrip } from "./useStoreTrip";
 import { StoreMachinesSection } from "./StoreMachinesSection";
 import { StoreSheetGoodsSection } from "./StoreSheetGoodsSection";
 import { StoreSuppliesSection } from "./StoreSuppliesSection";
@@ -63,10 +63,15 @@ const OrangeBoxLogo: React.FC = () => (
  */
 export const StoreTripOverlay: React.FC = () => {
   const gameState = useGameState();
-  const applyAction = useApplyGameAction();
-  const beginReturn = useHeadHome();
-  const headHome = () =>
-    beginReturn(() => applyAction(returnFromStoreAction()));
+  const {
+    cart,
+    total,
+    overdrawn,
+    canCheckOut,
+    confirmingLeave,
+    requestLeave,
+    checkOutAndLeave,
+  } = useStoreTrip();
 
   if (
     gameState.player.away?.kind !== "shopping" ||
@@ -76,7 +81,7 @@ export const StoreTripOverlay: React.FC = () => {
   }
 
   return (
-    <TripOverlay label="Orange Box" onHeadHome={headHome}>
+    <TripOverlay label="Orange Box" onHeadHome={requestLeave}>
       <div className="rounded-md overflow-hidden shadow-2xl border border-store-orange-dark grow min-h-0 flex flex-col">
         <TripHeader
           brand={<OrangeBoxLogo />}
@@ -85,7 +90,26 @@ export const StoreTripOverlay: React.FC = () => {
           brandRowClassName="items-center"
           mutedClassName="text-store-orange-dark"
           homeButtonClassName="border-store-orange-dark text-store-orange-dark hover:bg-store-orange/15"
-          onHeadHome={headHome}
+          onHeadHome={requestLeave}
+          confirmingLeave={confirmingLeave}
+          cart={
+            <StoreCartReadout
+              cart={cart}
+              total={total}
+              overdrawn={overdrawn}
+              mutedClassName="text-store-orange-dark"
+              overdrawnClassName="text-ink-red"
+            />
+          }
+          checkout={
+            cart.length > 0 && (
+              <StoreCheckoutButton
+                canCheckOut={canCheckOut}
+                onCheckOut={checkOutAndLeave}
+                className="border-store-orange bg-store-orange text-white hover:bg-store-orange-dark hover:border-store-orange-dark"
+              />
+            )
+          }
         />
         <div className="bg-store-concrete text-ink-black px-6 py-4 grow min-h-0 overflow-auto">
           {/* The floor plan: wood along the left wall, machines straight

--- a/src/components/store-page/useStoreTrip.ts
+++ b/src/components/store-page/useStoreTrip.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useState } from "react";
+import { CartLine, cartCountOf, cartTotal } from "../../game/cart";
+import {
+  checkOutAndReturnAction,
+  currentCart,
+} from "../../game/game-actions/cart-actions";
+import { returnFromStoreAction } from "../../game/game-actions/door-actions";
+import { useHeadHome } from "../trip/TripTransitionLayer";
+import { useApplyGameAction, useGameState } from "../useGameState";
+
+/** How long the armed "Leave cart behind?" button waits before disarming. */
+const CONFIRM_TIMEOUT_MS = 5000;
+
+/**
+ * Everything both store overlays need to run a trip's till: the cart,
+ * what it costs, and the two ways out. Shared so Orange Box and Sawyer &
+ * Sons can't drift apart on the part that handles money.
+ *
+ * The two ways out differ in one place only. Checking out is one press —
+ * pay and drive home together — while walking out on a full cart asks
+ * first: Escape is bound to Head Home, and an unlucky one would
+ * otherwise put a whole afternoon of shopping back on the shelves. An
+ * empty cart has nothing to lose, so it leaves on the first press.
+ */
+export function useStoreTrip() {
+  const gameState = useGameState();
+  const applyAction = useApplyGameAction();
+  const beginReturn = useHeadHome();
+
+  const cart = currentCart(gameState) ?? [];
+  const total = cartTotal(cart);
+  /** The cart outruns the wallet: shown in red, and the register refuses. */
+  const overdrawn = total > gameState.money;
+
+  const [confirmingLeave, setConfirmingLeave] = useState(false);
+
+  const leave = useCallback(() => {
+    setConfirmingLeave(false);
+    beginReturn(() => applyAction(returnFromStoreAction()));
+  }, [applyAction, beginReturn]);
+
+  /** Head Home. Arms a confirmation first when a cart would be left behind. */
+  const requestLeave = useCallback(() => {
+    if (cart.length === 0 || confirmingLeave) {
+      leave();
+      return;
+    }
+    setConfirmingLeave(true);
+  }, [cart.length, confirmingLeave, leave]);
+
+  const checkOutAndLeave = useCallback(() => {
+    setConfirmingLeave(false);
+    beginReturn(() => applyAction(checkOutAndReturnAction()));
+  }, [applyAction, beginReturn]);
+
+  // An armed button that stays armed is a trap: empty the cart (or just
+  // go back to shopping) and the next Escape shouldn't skip the ask.
+  useEffect(() => {
+    if (!confirmingLeave) {
+      return;
+    }
+    if (cart.length === 0) {
+      setConfirmingLeave(false);
+      return;
+    }
+    const timer = setTimeout(
+      () => setConfirmingLeave(false),
+      CONFIRM_TIMEOUT_MS,
+    );
+    return () => clearTimeout(timer);
+  }, [confirmingLeave, cart.length]);
+
+  return {
+    cart,
+    total,
+    overdrawn,
+    canCheckOut: cart.length > 0 && !overdrawn,
+    confirmingLeave,
+    requestLeave,
+    checkOutAndLeave,
+  };
+}
+
+/**
+ * How many of this exact product the cart already holds — the "2 in
+ * cart" line on a shelf tag. Every tile builds the line it would add and
+ * asks with it, so the count and the button can't disagree about what
+ * counts as the same product (see cartLineKey).
+ */
+export function useCartCount(line: CartLine): number {
+  const gameState = useGameState();
+  return cartCountOf(currentCart(gameState) ?? [], line);
+}

--- a/src/components/trip/TripHeader.tsx
+++ b/src/components/trip/TripHeader.tsx
@@ -5,10 +5,14 @@ import { useGameState } from "../useGameState";
 
 /**
  * The sign over a store trip's door: brand on the left, the player's
- * wallet and the Head Home button on the right. Each venue paints it its
- * own colors — Orange Box in safety orange on white, Sawyer & Sons in
- * mill green on cream — so the tint classes come from the caller while
- * the layout stays shared.
+ * wallet, the cart, and the ways out on the right. Each venue paints it
+ * its own colors — Orange Box in safety orange on white, Sawyer & Sons
+ * in mill green on cream — so the tint classes come from the caller
+ * while the layout stays shared.
+ *
+ * The cart and the register arrive as slots rather than props: what goes
+ * in them is store business (see StoreCart.tsx), and a trip with nothing
+ * to buy — the delivery run — just doesn't fill them.
  */
 export const TripHeader: React.FC<{
   /** The brand name itself, already set in the venue's display face. */
@@ -26,6 +30,16 @@ export const TripHeader: React.FC<{
   /** Border and hover tint for the Head Home button, in the same tone. */
   homeButtonClassName: string;
   onHeadHome: () => void;
+  /** The cart's running total, hung between the wallet and the way out. */
+  cart?: React.ReactNode;
+  /** The register: pay for the cart and drive home, when there's a cart to pay for. */
+  checkout?: React.ReactNode;
+  /**
+   * Head Home is armed and asking about the cart it would abandon. The
+   * button says so rather than a dialog saying it: the next press is the
+   * answer, and the store is still right there behind it.
+   */
+  confirmingLeave?: boolean;
 }> = ({
   brand,
   tagline,
@@ -34,6 +48,9 @@ export const TripHeader: React.FC<{
   mutedClassName,
   homeButtonClassName,
   onHeadHome,
+  cart,
+  checkout,
+  confirmingLeave = false,
 }) => {
   const gameState = useGameState();
   return (
@@ -68,6 +85,8 @@ export const TripHeader: React.FC<{
             {formatMoney(gameState.money)}
           </span>
         </div>
+        {cart}
+        {checkout}
         <button
           className={classNames(
             "border-2 rounded-sm px-3 py-1.5 font-condensed font-bold uppercase tracking-[0.2em] text-sm",
@@ -76,7 +95,7 @@ export const TripHeader: React.FC<{
           onClick={onHeadHome}
           data-sfx="ui-back"
         >
-          Head Home
+          {confirmingLeave ? "Leave cart behind?" : "Head Home"}
         </button>
       </div>
     </div>

--- a/src/game/HeldTool.ts
+++ b/src/game/HeldTool.ts
@@ -18,6 +18,9 @@ export type HeldToolId = "broom" | "vacHose";
 /** What the store charges for the shop broom (dustpan included). */
 export const BROOM_COST = 15;
 
+/** What it's called on the shelf tag, and on the cart's receipt. */
+export const BROOM_NAME = "Shop Broom";
+
 export function holdingBroom(gameState: GameState): boolean {
   return gameState.broomOwned && gameState.broomPosition === null;
 }

--- a/src/game/Person.ts
+++ b/src/game/Person.ts
@@ -1,3 +1,4 @@
+import { CartLine } from "./cart";
 import { StoreId } from "./lumberStock";
 import { MachineState } from "./Machine";
 import { MaterialInstance, Pallet } from "./Materials";
@@ -116,6 +117,13 @@ export type ShoppingTrip = {
   readonly kind: "shopping";
   /** Which store the trip is to; each is its own overlay. */
   readonly store: StoreId;
+  /**
+   * What's off the shelves and not paid for yet (see cart.ts). It hangs
+   * on the trip rather than on the shop because that's what it is: a
+   * cart you're pushing around a store. Driving away is what empties it,
+   * whether you checked out or abandoned it at the end of an aisle.
+   */
+  readonly cart: ReadonlyArray<CartLine>;
 };
 
 /**

--- a/src/game/ShopVac.ts
+++ b/src/game/ShopVac.ts
@@ -19,6 +19,8 @@ export interface ShopVacState {
 }
 
 export const SHOP_VAC_COST = 350;
+/** What it's called on the shelf tag, and on the cart's receipt. */
+export const SHOP_VAC_NAME = "Shop Vac";
 /** Dozens of cells filled to DUST_MAX_PER_CELL before a trip to the garbage. */
 export const SHOP_VAC_CANISTER_CAPACITY = 500;
 /** Dragging it over dust cleans a trickle underfoot, every tick. */

--- a/src/game/cart.ts
+++ b/src/game/cart.ts
@@ -1,0 +1,118 @@
+import { ConsumableId } from "./Consumable";
+import { MachineId } from "./Machine";
+import { MaterialInstance } from "./Materials";
+import { UpgradeId } from "./Upgrade";
+
+/**
+ * The shopping cart: what a store trip has picked off the shelves and
+ * not paid for yet.
+ *
+ * Nothing here transacts. A line is a note of what the register will be
+ * asked to ring up, and every kind of line maps to exactly one of the
+ * buy actions the store already had — which is the point of the split:
+ * the buy actions stay the one place that knows what a purchase *does*
+ * (into the bed, into a crate, into the shop's supply), and the cart
+ * only decides *when*. See game-actions/cart-actions.ts for the fold.
+ *
+ * The cart hangs off the trip itself (see ShoppingTrip in Person.ts), so
+ * driving away is what empties it — there is no cart to clean up once
+ * you're home, and a reload mid-trip finds it where you left it.
+ *
+ * Each line carries the price it was shelved at, so the running total
+ * and the receipt never re-derive a price from a registry that a
+ * reputation tier may have moved under them.
+ */
+export type CartLine =
+  /** Boards, sheets, and tools — everything that rides home as an object. */
+  | {
+      readonly kind: "material";
+      readonly material: MaterialInstance;
+      readonly price: number;
+    }
+  | {
+      readonly kind: "machine";
+      readonly machineTypeId: MachineId;
+      readonly price: number;
+    }
+  | {
+      readonly kind: "consumablePack";
+      readonly consumableId: ConsumableId;
+      readonly price: number;
+    }
+  | {
+      readonly kind: "upgrade";
+      readonly upgradeId: UpgradeId;
+      readonly price: number;
+    }
+  | { readonly kind: "clamp"; readonly price: number }
+  | { readonly kind: "broom"; readonly price: number }
+  | { readonly kind: "shopVac"; readonly price: number };
+
+/** Kinds the shop can only ever own one of — two in a cart is a mistake. */
+const ONE_TO_A_SHOP: ReadonlyArray<CartLine["kind"]> = ["broom", "shopVac"];
+
+export function isOneToAShop(line: CartLine): boolean {
+  return ONE_TO_A_SHOP.includes(line.kind);
+}
+
+export function cartTotal(cart: ReadonlyArray<CartLine>): number {
+  return cart.reduce((sum, line) => sum + line.price, 0);
+}
+
+/**
+ * What makes two lines the same product. Material ids are dropped — two
+ * boards off the same tile are two distinct objects with distinct ids,
+ * and a cart that listed them separately would be unreadable.
+ */
+export function cartLineKey(line: CartLine): string {
+  return JSON.stringify(line, (key, value) =>
+    key === "id" ? undefined : value,
+  );
+}
+
+/** One product's worth of cart, however many of it were picked up. */
+export type CartGroup = {
+  readonly key: string;
+  /** The first line of the group: what to draw, and what another one copies. */
+  readonly line: CartLine;
+  readonly count: number;
+  /** Where this group's lines sit in the cart; the last is what "−" drops. */
+  readonly indices: ReadonlyArray<number>;
+  /** What the group costs all together. */
+  readonly price: number;
+};
+
+/**
+ * The cart as the shopper reads it: one row per product with a count,
+ * in the order things were first picked up.
+ */
+export function groupCartLines(
+  cart: ReadonlyArray<CartLine>,
+): ReadonlyArray<CartGroup> {
+  const groups = new Map<string, CartGroup>();
+  cart.forEach((line, index) => {
+    const key = cartLineKey(line);
+    const existing = groups.get(key);
+    groups.set(
+      key,
+      existing
+        ? {
+            ...existing,
+            count: existing.count + 1,
+            indices: [...existing.indices, index],
+            price: existing.price + line.price,
+          }
+        : { key, line, count: 1, indices: [index], price: line.price },
+    );
+  });
+  return [...groups.values()];
+}
+
+/** How many of this product are already in the cart. */
+export function cartCountOf(
+  cart: ReadonlyArray<CartLine>,
+  line: CartLine,
+): number {
+  const key = cartLineKey(line);
+  return cart.filter((candidate) => cartLineKey(candidate) === key).length;
+}

--- a/src/game/delivery.test.ts
+++ b/src/game/delivery.test.ts
@@ -135,7 +135,11 @@ describe("canHandOff", () => {
       ...state,
       player: {
         ...state.player,
-        away: { kind: "shopping" as const, store: "orangeBox" as const },
+        away: {
+          kind: "shopping" as const,
+          store: "orangeBox" as const,
+          cart: [],
+        },
       },
     };
     assert.strictEqual(canHandOff(away), false);

--- a/src/game/game-actions/cart-actions.test.ts
+++ b/src/game/game-actions/cart-actions.test.ts
@@ -1,0 +1,181 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { board } from "../board-helpers";
+import { CartLine, cartTotal, groupCartLines } from "../cart";
+import { CLAMP_COST } from "../Clamp";
+import { CONSUMABLE_TYPES } from "../Consumable";
+import { GameState } from "../GameState";
+import { BROOM_COST } from "../HeldTool";
+import { initialGameState } from "../initialGameState";
+import { MACHINE_TYPES } from "../Machine";
+import { SHOP_VAC_COST } from "../ShopVac";
+import {
+  addToCartAction,
+  canCheckOut,
+  checkoutAction,
+  clearCartAction,
+  currentCart,
+  removeFromCartAction,
+} from "./cart-actions";
+import { returnFromStoreAction } from "./door-actions";
+
+// Prices come off the same registries the shelf tags read, because
+// that's the invariant worth protecting: some buy actions take the
+// price they're handed and some look it up themselves, so a line
+// carrying a made-up number would charge one figure and promise
+// another. "checkout takes exactly the cart's total" below is what
+// holds those two together.
+const PINE: CartLine = {
+  kind: "material",
+  material: board("pine", 96, 4, 8, "smooth"),
+  price: 20,
+};
+const NAILS: CartLine = {
+  kind: "consumablePack",
+  consumableId: "nails",
+  price: CONSUMABLE_TYPES.nails.packPrice,
+};
+const SAW: CartLine = {
+  kind: "machine",
+  machineTypeId: "miterSaw",
+  price: MACHINE_TYPES.miterSaw.cost,
+};
+const CLAMP: CartLine = { kind: "clamp", price: CLAMP_COST };
+const BROOM: CartLine = { kind: "broom", price: BROOM_COST };
+const VAC: CartLine = { kind: "shopVac", price: SHOP_VAC_COST };
+
+/** A shop mid-trip, standing in an aisle with the given cart. */
+function atStore(money: number, cart: ReadonlyArray<CartLine> = []): GameState {
+  return {
+    ...initialGameState,
+    money,
+    player: {
+      ...initialGameState.player,
+      away: { kind: "shopping", store: "orangeBox", cart },
+    },
+  };
+}
+
+function cartOf(state: GameState): ReadonlyArray<CartLine> {
+  return currentCart(state) ?? [];
+}
+
+describe("addToCartAction", () => {
+  it("puts a line in the cart without touching the money", () => {
+    const result = addToCartAction(PINE)(atStore(100));
+    assert.strictEqual(result.money, 100);
+    assert.strictEqual(cartOf(result).length, 1);
+    assert.strictEqual(cartTotal(cartOf(result)), 20);
+  });
+
+  it("stamps each material its own id, so two boards are two boards", () => {
+    let state = addToCartAction(PINE)(atStore(100));
+    state = addToCartAction(PINE)(state);
+    const [first, second] = cartOf(state);
+    assert.strictEqual(cartOf(state).length, 2);
+    assert.notStrictEqual(
+      (first as { material: { id: string } }).material.id,
+      (second as { material: { id: string } }).material.id,
+    );
+    // ...and still read as one product with a count of two
+    assert.deepStrictEqual(
+      groupCartLines(cartOf(state)).map((group) => group.count),
+      [2],
+    );
+  });
+
+  it("lets the cart outrun the wallet — the register is what refuses", () => {
+    const result = addToCartAction(SAW)(atStore(10));
+    assert.strictEqual(cartOf(result).length, 1);
+    assert.strictEqual(canCheckOut(result), false);
+  });
+
+  it("refuses a second broom — there is only ever one to a shop", () => {
+    const broom: CartLine = { kind: "broom", price: 15 };
+    const once = addToCartAction(broom)(atStore(100));
+    const twice = addToCartAction(broom)(once);
+    assert.strictEqual(cartOf(twice).length, 1);
+  });
+
+  it("does nothing when the player isn't at a store", () => {
+    const home = initialGameState;
+    assert.strictEqual(addToCartAction(PINE)(home), home);
+  });
+});
+
+describe("removeFromCartAction / clearCartAction", () => {
+  it("puts one line back on the shelf", () => {
+    const state = atStore(100, [PINE, NAILS]);
+    const result = removeFromCartAction(0)(state);
+    assert.deepStrictEqual(
+      cartOf(result).map((line) => line.kind),
+      ["consumablePack"],
+    );
+  });
+
+  it("ignores an index that isn't in the cart", () => {
+    const state = atStore(100, [PINE]);
+    assert.strictEqual(removeFromCartAction(4)(state), state);
+  });
+
+  it("empties the whole cart", () => {
+    const result = clearCartAction()(atStore(100, [PINE, NAILS, SAW]));
+    assert.deepStrictEqual(cartOf(result), []);
+  });
+});
+
+describe("checkoutAction", () => {
+  it("rings every line up through its own buy action, then empties", () => {
+    const result = checkoutAction()(atStore(1000, [PINE, NAILS, SAW]));
+
+    // Each kind lands where that kind lands: stock in the bed, machines
+    // crated in the bed, supplies straight into the shop's stock
+    assert.strictEqual(result.truck.bed.length, 1);
+    assert.strictEqual(result.truck.bed[0].type, "board");
+    assert.deepStrictEqual(
+      result.truck.crates.map((crate) => crate.machineTypeId),
+      ["miterSaw"],
+    );
+    assert.strictEqual(
+      result.consumables.nails,
+      initialGameState.consumables.nails + CONSUMABLE_TYPES.nails.packSize,
+    );
+    assert.deepStrictEqual(cartOf(result), []);
+  });
+
+  it("takes exactly the total the cart was showing, kind by kind", () => {
+    // Every kind of line at once: whatever a buy action charges has to
+    // be the number the header quoted, or the store lies to the player.
+    const cart = [PINE, NAILS, SAW, CLAMP, BROOM, VAC];
+    const result = checkoutAction()(atStore(2000, cart));
+    assert.strictEqual(result.money, 2000 - cartTotal(cart));
+  });
+
+  it("refuses the whole cart when it outruns the wallet", () => {
+    const state = atStore(100, [PINE, SAW]);
+    const result = checkoutAction()(state);
+    assert.strictEqual(result.money, 100);
+    assert.strictEqual(result.truck.bed.length, 0);
+    assert.strictEqual(cartOf(result).length, 2);
+  });
+
+  it("takes a cart that costs exactly the wallet", () => {
+    const result = checkoutAction()(atStore(20, [PINE]));
+    assert.strictEqual(result.money, 0);
+    assert.strictEqual(result.truck.bed.length, 1);
+  });
+
+  it("does nothing when the player isn't at a store", () => {
+    const home = initialGameState;
+    assert.strictEqual(checkoutAction()(home), home);
+  });
+});
+
+describe("driving away", () => {
+  it("leaves an unpaid cart behind with the trip", () => {
+    const result = returnFromStoreAction(() => 0.5)(atStore(100, [PINE, SAW]));
+    assert.strictEqual(result.player.away, null);
+    assert.strictEqual(result.money, 100);
+    assert.strictEqual(result.truck.bed.length, 0);
+  });
+});

--- a/src/game/game-actions/cart-actions.ts
+++ b/src/game/game-actions/cart-actions.ts
@@ -1,0 +1,176 @@
+import { CartLine, cartTotal, isOneToAShop } from "../cart";
+import { GameAction, GameState } from "../GameState";
+import { makeMaterial } from "../material-helpers";
+import { MaterialInstance } from "../Materials";
+import { buyBroomAction } from "./dust-actions";
+import { returnFromStoreAction } from "./door-actions";
+import { buyShopVacAction } from "./shop-vac-actions";
+import {
+  buyClampAction,
+  buyConsumablePackAction,
+  buyMachineAction,
+  buyMaterialAction,
+} from "./store-actions";
+import { buyUpgradeAction } from "./upgrade-actions";
+
+/**
+ * The cart's verbs: picking things off the shelf, putting them back, and
+ * the one moment money changes hands.
+ *
+ * This module sits above every buy action and is imported by none of
+ * them, which is the whole arrangement: `store-actions` (and its
+ * siblings for the broom, the vac, and upgrades) still own what a
+ * purchase *does*, and checkout is a fold of the cart through exactly
+ * those actions. Nothing here duplicates a price, a destination, or a
+ * milestone check.
+ *
+ * A cart may exceed the wallet — the register is what refuses, not the
+ * shelf, the same way it works in a real store (the store's total goes
+ * red and Check Out greys out). See cart.ts for the line shapes.
+ */
+
+/** The buy action a line rings up as. */
+function buyActionForLine(line: CartLine): GameAction {
+  switch (line.kind) {
+    case "material":
+      return buyMaterialAction(line.material, line.price);
+    case "machine":
+      return buyMachineAction(line.machineTypeId, line.price);
+    case "consumablePack":
+      return buyConsumablePackAction(line.consumableId);
+    case "upgrade":
+      return buyUpgradeAction(line.upgradeId);
+    case "clamp":
+      return buyClampAction();
+    case "broom":
+      return buyBroomAction();
+    case "shopVac":
+      return buyShopVacAction();
+  }
+}
+
+/** The cart of the trip in progress, or null when the player isn't shopping. */
+export function currentCart(
+  gameState: GameState,
+): ReadonlyArray<CartLine> | null {
+  return gameState.player.away?.kind === "shopping"
+    ? gameState.player.away.cart
+    : null;
+}
+
+function withCart(
+  gameState: GameState,
+  cart: ReadonlyArray<CartLine>,
+): GameState {
+  if (gameState.player.away?.kind !== "shopping") {
+    return gameState;
+  }
+  return {
+    ...gameState,
+    player: {
+      ...gameState.player,
+      away: { ...gameState.player.away, cart },
+    },
+  };
+}
+
+/**
+ * Take another one off the shelf. Material lines are re-stamped with a
+ * fresh id on the way in, so picking up a second identical board really
+ * is a second board — the caller can hand the same line back for the
+ * cart's "+" without minting one itself.
+ */
+export function addToCartAction(line: CartLine): GameAction {
+  return (gameState) => {
+    const cart = currentCart(gameState);
+    if (!cart) {
+      console.warn("Tried to add to a cart while not at a store");
+      return gameState;
+    }
+    // Nobody needs two brooms, and the shelf tag disappears once one is
+    // owned — so a second in the cart could only ever be a misclick
+    if (isOneToAShop(line) && cart.some((other) => other.kind === line.kind)) {
+      return gameState;
+    }
+    return withCart(gameState, [...cart, freshLine(line)]);
+  };
+}
+
+/** A line's own copy: a distinct object needs a distinct id. */
+function freshLine(line: CartLine): CartLine {
+  if (line.kind !== "material") {
+    return line;
+  }
+  const { id: _id, ...withoutId } = line.material as MaterialInstance & {
+    id: string;
+  };
+  return {
+    ...line,
+    material: makeMaterial(withoutId as Omit<MaterialInstance, "id">),
+  };
+}
+
+/** Put one back on the shelf, by its place in the cart. */
+export function removeFromCartAction(index: number): GameAction {
+  return (gameState) => {
+    const cart = currentCart(gameState);
+    if (!cart || index < 0 || index >= cart.length) {
+      return gameState;
+    }
+    return withCart(gameState, [
+      ...cart.slice(0, index),
+      ...cart.slice(index + 1),
+    ]);
+  };
+}
+
+/** Abandon the cart at the end of an aisle. */
+export function clearCartAction(): GameAction {
+  return (gameState) => {
+    const cart = currentCart(gameState);
+    return cart ? withCart(gameState, []) : gameState;
+  };
+}
+
+/** Whether the register would take the cart as it stands. */
+export function canCheckOut(gameState: GameState): boolean {
+  const cart = currentCart(gameState);
+  return cart !== null && cart.length > 0 && cartTotal(cart) <= gameState.money;
+}
+
+/**
+ * Ring the cart up: every line through its own buy action, in the order
+ * it was picked up, then an empty cart. All or nothing — a cart that
+ * outruns the wallet is refused whole rather than part-filled, so the
+ * total on the header is always what checkout will cost.
+ */
+export function checkoutAction(): GameAction {
+  return (gameState) => {
+    const cart = currentCart(gameState);
+    if (!cart) {
+      console.warn("Tried to check out while not at a store");
+      return gameState;
+    }
+    if (cartTotal(cart) > gameState.money) {
+      console.warn("Tried to check out with a cart the wallet can't cover");
+      return gameState;
+    }
+    const rungUp = cart.reduce(
+      (state, line) => buyActionForLine(line)(state),
+      gameState,
+    );
+    return withCart(rungUp, []);
+  };
+}
+
+/**
+ * The one button at the register: pay for the cart and drive home. There
+ * is no checking out and carrying on shopping — the load goes in the bed
+ * and the bed goes home, which is also what stops a trip from becoming a
+ * till the player rings up over and over.
+ */
+export function checkOutAndReturnAction(
+  rng: () => number = Math.random,
+): GameAction {
+  return (gameState) => returnFromStoreAction(rng)(checkoutAction()(gameState));
+}

--- a/src/game/game-actions/door-actions.test.ts
+++ b/src/game/game-actions/door-actions.test.ts
@@ -78,6 +78,7 @@ describe("goToStoreAction / returnFromStoreAction", () => {
     assert.deepStrictEqual(out.player.away, {
       kind: "shopping",
       store: "orangeBox",
+      cart: [],
     });
     assert.strictEqual(personCanWork(out.player), false);
 
@@ -91,6 +92,7 @@ describe("goToStoreAction / returnFromStoreAction", () => {
     assert.deepStrictEqual(out.player.away, {
       kind: "shopping",
       store: "lumberyard",
+      cart: [],
     });
   });
 
@@ -136,6 +138,7 @@ describe("goToStoreAction / returnFromStoreAction", () => {
     assert.deepStrictEqual(state.player.away, {
       kind: "shopping",
       store: "orangeBox",
+      cart: [],
     });
     assert.strictEqual(personCanWork(state.player), false);
   });

--- a/src/game/game-actions/door-actions.ts
+++ b/src/game/game-actions/door-actions.ts
@@ -76,7 +76,7 @@ export function goToStoreAction(
         ...gameState,
         player: {
           ...gameState.player,
-          away: { kind: "shopping", store },
+          away: { kind: "shopping", store, cart: [] },
         },
       },
       rng,

--- a/src/game/gameStateSchema.ts
+++ b/src/game/gameStateSchema.ts
@@ -79,6 +79,37 @@ const machineStateSchema = z.object({
     .optional(),
 });
 
+/**
+ * A shopping cart's lines (see cart.ts). Every line carries the price it
+ * was shelved at, so a reloaded trip rings up exactly what the aisle
+ * quoted.
+ */
+const cartLineSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("material"),
+    material: materialSchema,
+    price: z.number(),
+  }),
+  z.object({
+    kind: z.literal("machine"),
+    machineTypeId: machineIdSchema,
+    price: z.number(),
+  }),
+  z.object({
+    kind: z.literal("consumablePack"),
+    consumableId: consumableIdSchema,
+    price: z.number(),
+  }),
+  z.object({
+    kind: z.literal("upgrade"),
+    upgradeId: upgradeIdSchema,
+    price: z.number(),
+  }),
+  z.object({ kind: z.literal("clamp"), price: z.number() }),
+  z.object({ kind: z.literal("broom"), price: z.number() }),
+  z.object({ kind: z.literal("shopVac"), price: z.number() }),
+]);
+
 const awayTripSchema = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("scavenging"),
@@ -98,6 +129,7 @@ const awayTripSchema = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("shopping"),
     store: z.string(),
+    cart: z.array(cartLineSchema),
   }),
   z.object({
     kind: z.literal("delivering"),

--- a/src/game/lot.test.ts
+++ b/src/game/lot.test.ts
@@ -109,7 +109,11 @@ describe("walking the lot", () => {
       ...initialGameState,
       player: {
         ...initialGameState.player,
-        away: { kind: "shopping" as const, store: "orangeBox" as const },
+        away: {
+          kind: "shopping" as const,
+          store: "orangeBox" as const,
+          cart: [],
+        },
       },
     };
     const down = walk([6.5, 15], [0, 1], 2, collisionWorld(away));

--- a/src/game/saveLoad.ts
+++ b/src/game/saveLoad.ts
@@ -9,7 +9,7 @@ const SAVE_KEY = "woodworking-tycoon-save";
  * schema shows as incompatible on the start menu, and starting a new game
  * writes over it.
  */
-const SAVE_VERSION = 15;
+const SAVE_VERSION = 16;
 
 export type SaveStatus = "none" | "ok" | "incompatible";
 

--- a/src/game/time-flow.test.ts
+++ b/src/game/time-flow.test.ts
@@ -61,7 +61,11 @@ describe("timeSpeed", () => {
 
   it("idles through a store's aisles — browsing is thinking", () => {
     assert.equal(
-      timeSpeed(withPlayer({ away: { kind: "shopping", store: "orangeBox" } })),
+      timeSpeed(
+        withPlayer({
+          away: { kind: "shopping", store: "orangeBox", cart: [] },
+        }),
+      ),
       "idle",
     );
   });

--- a/tests/floor.spec.ts
+++ b/tests/floor.spec.ts
@@ -1,10 +1,10 @@
 import { test, expect } from "@playwright/test";
 import { machineCard, takeAllHere } from "./machine-panel";
 import {
+  checkOutAndLeaveStore,
   dismissClientCard,
   goToStore,
   deliverFromTruck,
-  leaveStore,
   loadTruckBed,
   movePlayerToCab,
   openTruckMenu,
@@ -342,18 +342,27 @@ test.describe("Shop floor", () => {
       // stability check can starve on slow machines
       await page
         .locator("li", { hasText: "Jobsite Table Saw" })
-        .getByRole("button", { name: "Buy" })
+        .getByRole("button", { name: "Add Jobsite Table Saw to cart" })
         .click({ force: true });
       await page.waitForTimeout(30);
+      // A shelf tag is not a receipt: the saw is in the cart and the bed
+      // is still empty until the register
+      const shopping = await page.evaluate(() => window.__GET_GAME_STATE__());
+      expect(shopping.truck.crates).toHaveLength(0);
+      expect(shopping.money).toBe(500);
+      await expect(page.getByTestId("store-cart-total")).toContainText("1 item");
+
+      // One press pays for the cart and drives home
+      await checkOutAndLeaveStore(page);
       const state = await page.evaluate(() => window.__GET_GAME_STATE__());
       expect(state.truck.crates).toHaveLength(1);
       expect(state.truck.crates[0].machineTypeId).toBe("jobsiteTableSaw");
+      expect(state.money).toBeLessThan(500);
       // Nothing lands on the shop floor until it's carried in
       expect(state.machineCrates).toHaveLength(0);
     });
 
     await test.step("the crate lifts out of the bed at the tailgate", async () => {
-      await leaveStore(page);
       // Stand in the tailgate aisle, one step out the garage door
       await teleportPlayer(page, [6, 17]);
       // The cargo box names itself, and its verbs name the thing they move

--- a/tests/market.spec.ts
+++ b/tests/market.spec.ts
@@ -3,10 +3,10 @@ import { modesOf, selectMode } from "./machine-panel";
 import {
   advanceTicks,
   answerPhoneCall,
+  checkOutAndLeaveStore,
   closePhone,
   goToStore,
   deliverFromTruck,
-  leaveStore,
   movePlayerToCab,
   openTruckMenu,
   openPhone,
@@ -535,15 +535,17 @@ test.describe("Market, supplies, and sound", () => {
 
       await page
         .locator("li", { hasText: "Mineral Oil Bottle" })
-        .getByRole("button", { name: "Buy" })
+        .getByRole("button", { name: "Add Mineral Oil Bottle to cart" })
         .click();
       await page.waitForTimeout(30);
-      await expect(page.getByText("16 oz in shop")).toBeVisible();
+      // On the cart, not in the cabinet — the shelf tag still reads empty
+      await expect(page.getByText("16 oz in shop")).toHaveCount(0);
+
+      await checkOutAndLeaveStore(page, returnTo);
       const money = await page.evaluate(
         () => (window as any).__GET_GAME_STATE__().money,
       );
       expect(money).toBe(10);
-      await leaveStore(page, returnTo);
     });
 
     await test.step("the oil wipe is the finishing kit's work, not a plan", async () => {

--- a/tests/milling.spec.ts
+++ b/tests/milling.spec.ts
@@ -270,7 +270,7 @@ test.describe("Milling", () => {
       await expect(page.getByText("Rough Rack")).toBeVisible();
       // Rough walnut sells at the deepest discount in town. Every
       // species hangs in the rack at once — boards carry no species text,
-      // so the Buy button's accessible name is the board's identity.
+      // so the board button's accessible name is its identity.
       const roughRack = page
         .locator("div")
         .filter({ has: page.getByText("Rough Rack", { exact: true }) })
@@ -279,7 +279,7 @@ test.describe("Milling", () => {
       // Dims tags hang under each standing board: size, then length
       await expect(roughRack.getByText(/4\/4×6"\s*8'/).first()).toBeVisible();
       const roughWalnut = roughRack.getByRole("button", {
-        name: `Buy Walnut 4/4 — 6" × 8' (rough sawn)`,
+        name: `Add Walnut 4/4 — 6" × 8' (rough sawn) to cart`,
       });
       await expect(roughWalnut).toBeVisible();
       // 4 board feet of walnut at the rough rack's 0.55 discount

--- a/tests/navigation.ts
+++ b/tests/navigation.ts
@@ -229,9 +229,29 @@ export async function unloadTruckBed(page: any) {
  * on coming home with it in hand.
  */
 export async function leaveStore(page: any, returnTo?: [number, number]) {
+  // exact: the register's button also ends in "Head Home", and a
+  // substring match would find both once there's a cart
   await page
-    .getByRole("button", { name: "Head Home" })
+    .getByRole("button", { name: "Head Home", exact: true })
     .click({ force: true });
+  await driveHome(page, returnTo);
+}
+
+/**
+ * Pay for the cart and drive home in one press — the register's button.
+ * Nothing in a store is bought until this happens (see cart.ts), so any
+ * spec that shops has to end its trip this way rather than with
+ * `leaveStore`, which walks out on the cart.
+ */
+export async function checkOutAndLeaveStore(
+  page: any,
+  returnTo?: [number, number],
+) {
+  await page.getByTestId("store-check-out").click({ force: true });
+  await driveHome(page, returnTo);
+}
+
+async function driveHome(page: any, returnTo?: [number, number]) {
   // The click starts the arrival performance; returnFromStoreAction (which
   // also PARKS THE PLAYER AT THE CAB) only lands when it finishes. Wait it
   // out, or that late position write clobbers the returnTo teleport below.

--- a/tests/stations.spec.ts
+++ b/tests/stations.spec.ts
@@ -9,6 +9,7 @@ import {
   takeAllHere,
 } from "./machine-panel";
 import {
+  checkOutAndLeaveStore,
   closeJournal,
   goToLumberyard,
   goToStore,
@@ -356,18 +357,24 @@ test.describe("Stations", () => {
       await page
         .locator("li", { hasText: "Shop Plywood" })
         .filter({ hasText: "2×2 Panel" })
-        .getByRole("button", { name: "Buy" })
+        .getByRole("button", { name: /Add Shop Plywood to cart/ })
         .click();
       await page.waitForTimeout(30);
+      // $11.20: 2 board feet of shop-grade ply, at the small-piece
+      // premium — quoted on the cart before a cent leaves the wallet
+      await expect(page.getByTestId("store-cart-total")).toContainText("$11.20");
+      expect(
+        await page.evaluate(() => (window as any).__GET_GAME_STATE__().money),
+      ).toBe(100);
+
+      await checkOutAndLeaveStore(page, afterStore);
       const money = await page.evaluate(
         () => (window as any).__GET_GAME_STATE__().money,
       );
-      // $11.20: 2 board feet of shop-grade ply, at the small-piece premium
       expect(money).toBe(88.8);
     });
 
     await test.step("learn Jigs & Fixtures and End-Grain Boards", async () => {
-      await leaveStore(page, afterStore);
       // The panel goes across the saw before it's a sled base — that rip
       // is milling.spec's and sheet-breakdown-chain's business, so stage
       // its result here rather than walking the whole cut again.
@@ -496,24 +503,53 @@ test.describe("Stations", () => {
 
       await page
         .locator("li", { hasText: "Hand Saw" })
-        .getByRole("button", { name: "Buy" })
+        .getByRole("button", { name: "Add Hand Saw to cart" })
         .click();
       await page.waitForTimeout(30);
       await page
         .locator("li", { hasText: "Drill" })
-        .getByRole("button", { name: "Buy" })
+        .getByRole("button", { name: "Add Drill to cart" })
         .click();
       await page.waitForTimeout(30);
 
       await expect(page.getByText("Box of Screws")).toBeVisible();
       await page
         .locator("li", { hasText: "Box of Screws" })
-        .getByRole("button", { name: "Buy" })
+        .getByRole("button", { name: "Add Box of Screws to cart" })
         .click();
       await page.waitForTimeout(30);
-      await expect(page.getByText("50 screws in shop")).toBeVisible();
 
-      await leaveStore(page, returnTo);
+      // A whole trip's shopping sits on one cart, and nothing has been
+      // paid for yet — the supply cabinet is still empty of screws
+      await expect(page.getByTestId("store-cart-total")).toContainText(
+        "3 items",
+      );
+      await expect(page.getByText("50 screws in shop")).toHaveCount(0);
+
+      // The cart itemizes on hover, and a quantity is changed there
+      await page.getByTestId("store-cart-total").hover();
+      const cartPanel = page.getByTestId("store-cart-panel");
+      await expect(cartPanel).toBeVisible();
+      await expect(cartPanel.getByText("Hand Saw")).toBeVisible();
+      await cartPanel
+        .getByRole("button", { name: "Add another Drill" })
+        .click();
+      await expect(page.getByTestId("store-cart-total")).toContainText(
+        "4 items",
+      );
+      // ...and put back: one drill too many goes back on the wall
+      await cartPanel.getByRole("button", { name: "Remove one Drill" }).click();
+      await expect(page.getByTestId("store-cart-total")).toContainText(
+        "3 items",
+      );
+
+      await checkOutAndLeaveStore(page, returnTo);
+      // The register is where everything lands at once: the two tools in
+      // the bed (unloaded on the way in) and the screws in shop supply
+      const shop = await page.evaluate(() =>
+        (window as any).__GET_GAME_STATE__(),
+      );
+      expect(shop.consumables.screws).toBe(50);
     });
 
     await test.step("both tools mount at the workbench and add their trades", async () => {


### PR DESCRIPTION
Closes #171.

A store trip was a row of tills: every tile transacted on its own, so a misclick was money gone, and there was no way to see what a trip was about to cost before committing to it. Shopping now fills a cart, and the register is one press at the door.

## How it's built

- **`src/game/cart.ts`** — the `CartLine` union (one variant per thing the store sells) plus the totals and grouping. Each line carries the price it was shelved at.
- **`ShoppingTrip.cart`** — the cart hangs off the trip itself, so driving away is what empties it (no cleanup path), and it rides in the save, so a reload mid-trip finds it where you left it. `SAVE_VERSION` 15 → 16.
- **`src/game/game-actions/cart-actions.ts`** — add / remove / clear / checkout. Checkout folds each line through the buy action it always had, so `buyMaterialAction` and friends stay the one place that knows where a purchase lands (bed, crate, shop supply) and the cart only decides *when*. Nothing here duplicates a price or a milestone check, and `ShopDriver` keeps buying instantly — the sequence tier models the shop, not the store UI.

## What it looks like

- Cart total sits in the top bar between the wallet and the way out, with the cart icon; hovering it opens an itemized panel with −/+ steppers, per-line and running totals, and Empty Cart.
- **The shelf never refuses.** Anything goes in the cart whatever the wallet holds — a real store doesn't check at the shelf, and a tile that greyed out at its own price sat oddly beside a cart already allowed to exceed the wallet in aggregate. The register is the only gate: over budget, the total turns red (ink red on the store's white bar, a lighter red on the yard's green one), the panel says "More than your wallet — put something back", and **Check Out** greys out.
- Tiles say **Add to Cart** and count what's already in there; the lumber racks' board tags do too.
- **Check Out & Head Home** is one press: pay and drive. There's no ring-up-and-keep-shopping, because what you buy goes in the bed and the bed goes home.
- Walking out on a full cart asks first (the button becomes "Leave cart behind?", disarming after 5s). Escape follows the same rule — it's bound to Head Home, and one unlucky press would otherwise reshelve a whole afternoon. An empty cart leaves on the first press.

## Verification

`npm run test` green: 1139 unit tests and all 7 E2E specs. New unit coverage in `cart-actions.test.ts` includes the invariant that checkout takes *exactly* the total the header quoted, across every line kind — some buy actions take the price they're handed and some look it up themselves, and that test is what holds the two together. The cart's own E2E lives in `stations.spec.ts` (the aisles spec): add three, edit quantities in the hover panel, go broke and confirm the shelf still hands things over while Check Out doesn't, then pay and confirm the goods land. Also driven by hand in a browser: both stores, the popover, the red overdrawn state, and all four leave/checkout paths.

The wider button surfaced a real layout bug on the way through — it overhung its tile and sat under the neighbouring tile's price tag, swallowing clicks. The tile's bottom row now wraps, so the button drops to its own full-width line when the price won't share it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)