### PR TITLE
Claim seated boards first so a half-seated build can't refuse

### DIFF
--- a/src/game/game-actions/player-actions.test.ts
+++ b/src/game/game-actions/player-actions.test.ts
@@ -503,4 +503,57 @@ describe("the blueprint assembly's claim", () => {
       spares.map((m) => m.id).sort(),
     );
   });
+
+  it("builds with a half-seated frame — an empty slot can't take a seated board", () => {
+    // Only the second stringer slot is seated, and its board sits first
+    // in the bay. Filling the slots in one pass would hand that board to
+    // the empty first slot, leaving the seated slot with nothing.
+    const stringer = () => board("pallet", 48, 6, 6);
+    const deckBoard = () => board("pallet", 36, 4, 2);
+    const seatedStringer = stringer();
+    const loose = [stringer(), deckBoard(), deckBoard(), deckBoard()];
+    const base: MachineState = {
+      machineTypeId: "workspace",
+      position: [4, 2],
+      rotation: 0,
+      selectedOperationId: "buildRusticPalletShelf",
+      selectedParameters: undefined,
+      operationProgress: {
+        status: "notStarted",
+        phaseIndex: 0,
+        ticksRemaining: 0,
+      },
+      inputMaterials: [seatedStringer, ...loose],
+      processingMaterials: [],
+      outputMaterials: [],
+      tools: ["hammer"],
+    };
+    const frame = assemblyFramePlacement(
+      benchTopSizeIn(new Machine(base).type),
+    );
+    const secondSlot = RUSTIC_SHELF_BLUEPRINT.slots[1];
+    const bench: MachineState = {
+      ...base,
+      benchLayout: {
+        [seatedStringer.id]: {
+          ...slotOnBench(RUSTIC_SHELF_BLUEPRINT, frame, secondSlot),
+          onEdge: secondSlot.onEdge,
+        },
+      },
+    };
+    const state: GameState = {
+      ...initialGameState,
+      machines: [bench],
+      consumables: { ...initialGameState.consumables, nails: 6 },
+    };
+    const result = operateMachineAction(new Machine(bench))(state);
+    assert.strictEqual(
+      result.machines[0].operationProgress.status,
+      "inProgress",
+    );
+    assert.deepStrictEqual(
+      result.machines[0].processingMaterials.map((m) => m.id).sort(),
+      [seatedStringer, ...loose].map((m) => m.id).sort(),
+    );
+  });
 });

--- a/src/game/game-actions/player-actions.ts
+++ b/src/game/game-actions/player-actions.ts
@@ -708,17 +708,50 @@ export function operateMachineAction(
         : null;
     if (blueprint) {
       const seatedBySlot = seatedAssemblyPieces(machine, blueprint);
+      // Every seated board is claimed before any unseated slot goes
+      // looking, in two passes: one pass in slot order would let an
+      // unseated slot's first match take the very board a *later* slot
+      // has seated, and that slot then finds nothing and the build
+      // refuses with stock lying right there on its outline.
+      const picked = new Map<string, MaterialInstance>();
+      const take = (slotId: string, index: number): boolean => {
+        if (index === -1) {
+          return false;
+        }
+        picked.set(slotId, inventory[index]);
+        inventory.splice(index, 1);
+        return true;
+      };
       for (const slot of blueprint.slots) {
         const seatedId = seatedBySlot.get(slot.id)?.id;
-        const index = seatedId
-          ? inventory.findIndex((m) => m.id === seatedId)
-          : inventory.findIndex((m) => materialMeetsInput(m, slot.requirement));
-        if (index === -1) {
+        if (seatedId === undefined) {
+          continue;
+        }
+        if (
+          !take(
+            slot.id,
+            inventory.findIndex((m) => m.id === seatedId),
+          )
+        ) {
           console.warn("Tried to perform operation without required materials");
           return gameState;
         }
-        materialsToConsume.push(inventory[index]);
-        inventory.splice(index, 1);
+      }
+      for (const slot of blueprint.slots) {
+        if (picked.has(slot.id)) {
+          continue;
+        }
+        const index = inventory.findIndex((m) =>
+          materialMeetsInput(m, slot.requirement),
+        );
+        if (!take(slot.id, index)) {
+          console.warn("Tried to perform operation without required materials");
+          return gameState;
+        }
+      }
+      // Slot order, so the bill of materials lines up with the blueprint.
+      for (const slot of blueprint.slots) {
+        materialsToConsume.push(picked.get(slot.id)!);
       }
     } else {
       // Validate that we have all required materials


### PR DESCRIPTION
## Summary

Salvages the still-relevant half of the old `worktree-seed-tick-rng` branch. That branch fixed two things: seeding the sequence tier's rng (#105) and a blueprint slot-claiming bug the seeded runs exposed. The rng half landed on main separately in 971te85, but the slot-claiming fix never did — main still fills blueprint slots in one pass.

**The bug**: a blueprint build claimed its slots in a single pass in slot order, so an unseated slot's first match could take the very board a *later* slot had seated. That later slot then found nothing, and the build refused with its stock lying right there on the outline. Whether it struck depended on where the boards scattered on the bench.

**The fix**: seated boards are claimed in their own pass before any unseated slot goes looking; unseated slots then fill by first match from what remains. The bill of materials is still emitted in slot order.

## Test plan

- New unit test: a half-seated frame where the seated board sits first in the bay — exactly the ordering that made one-pass claiming fail
- `npm run tsc` clean, all 1154 unit/sequence/progression tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)