### PR TITLE
Let the shelf hand over anything, and the register do the checking

### DIFF
--- a/src/components/store-page/BoardSelector.tsx
+++ b/src/components/store-page/BoardSelector.tsx
@@ -213,9 +213,8 @@ const BoardForSale: React.FC<{
   return (
     <Tooltip content={tooltip}>
       <button
-        className="relative block shrink-0 transition-[filter] enabled:cursor-pointer enabled:hover:brightness-110 disabled:opacity-60"
+        className="relative block shrink-0 cursor-pointer transition-[filter] hover:brightness-110"
         style={{ height: (sku.length / 12) * PX_PER_FOOT }}
-        disabled={gameState.money < price}
         aria-label={`Add ${fullName} to cart`}
         onClick={() => applyAction(addToCartAction(line))}
       >

--- a/src/components/store-page/ProductTile.tsx
+++ b/src/components/store-page/ProductTile.tsx
@@ -20,8 +20,11 @@ export const ProductTile: React.FC<{
   info: React.ReactNode;
   /** One short line under the name — what the shop already has of this. */
   owned?: React.ReactNode;
-  canAfford: boolean;
-  /** Put one in the cart. Nothing is paid for until the register. */
+  /**
+   * Put one in the cart. Never refused for want of money: a shelf hands
+   * over anything, and the register is the only thing that checks the
+   * wallet (see StoreCart.tsx).
+   */
   onAdd: () => void;
   /** How many of this are already in the cart, called out under the name. */
   inCart?: number;
@@ -37,7 +40,6 @@ export const ProductTile: React.FC<{
   price,
   info,
   owned,
-  canAfford,
   onAdd,
   inCart = 0,
   tutorialTarget,
@@ -79,7 +81,6 @@ export const ProductTile: React.FC<{
       <PriceTag price={price} />
       <BuyButton
         size="compact"
-        disabled={!canAfford}
         onClick={onAdd}
         aria-label={`Add ${name} to cart`}
         className="flex grow items-center justify-center gap-1 whitespace-nowrap"

--- a/src/components/store-page/StoreMachinesSection.tsx
+++ b/src/components/store-page/StoreMachinesSection.tsx
@@ -82,7 +82,6 @@ const MachineProductTile: React.FC<{ machine: MachineType }> = ({
       info={`${machine.description} Rides home crated in the truck's bed.`}
       owned={numberOwned > 0 ? `${numberOwned} owned` : undefined}
       inCart={inCart}
-      canAfford={gameState.money >= price}
       onAdd={() => applyAction(addToCartAction(line))}
     />
   );

--- a/src/components/store-page/StoreSheetGoodsSection.tsx
+++ b/src/components/store-page/StoreSheetGoodsSection.tsx
@@ -93,7 +93,6 @@ const SheetSkuTile: React.FC<{ sku: SheetSku; size: SheetSize }> = ({
         numberOwned > 0 ? `${size.label} · ${numberOwned} owned` : size.label
       }
       inCart={inCart}
-      canAfford={gameState.money >= price}
       onAdd={() => applyAction(addToCartAction(line))}
     />
   );

--- a/src/components/store-page/StoreSuppliesSection.tsx
+++ b/src/components/store-page/StoreSuppliesSection.tsx
@@ -49,7 +49,6 @@ const ClampTile: React.FC = () => {
           : undefined
       }
       inCart={inCart}
-      canAfford={gameState.money >= CLAMP_COST}
       onAdd={() => applyAction(addToCartAction(line))}
     />
   );
@@ -81,7 +80,6 @@ const ConsumablePackTile: React.FC<{ consumableId: ConsumableId }> = ({
       info={`${type.description} ${type.packSize} ${type.unit} per pack.`}
       owned={owned > 0 ? `${owned} ${type.unit} in shop` : undefined}
       inCart={inCart}
-      canAfford={gameState.money >= type.packPrice}
       onAdd={() => applyAction(addToCartAction(line))}
     />
   );

--- a/src/components/store-page/StoreToolsSection.tsx
+++ b/src/components/store-page/StoreToolsSection.tsx
@@ -16,7 +16,6 @@ import { useCartCount } from "./useStoreTrip";
 export const StoreToolsSection: React.FC<{ className?: string }> = ({
   className,
 }) => {
-  const gameState = useGameState();
   return (
     <AisleSection title="Tools" className={className}>
       {Object.values(TOOL_TYPES)
@@ -60,7 +59,6 @@ const BroomProductTile: React.FC = () => {
       price={BROOM_COST}
       info="A push broom with a dustpan. Sweeps sawdust off the floor; empty the pan at the garbage can."
       inCart={inCart}
-      canAfford={gameState.money >= BROOM_COST}
       onAdd={() => applyAction(addToCartAction(line))}
     />
   );
@@ -94,7 +92,6 @@ const UpgradeProductTile: React.FC<{ upgrade: UpgradeType }> = ({
       info={`${upgrade.description} Installs into a worktable's upgrade slot.`}
       owned={numberOwned > 0 ? `${numberOwned} owned` : undefined}
       inCart={inCart}
-      canAfford={gameState.money >= upgrade.cost}
       onAdd={() => applyAction(addToCartAction(line))}
     />
   );
@@ -122,7 +119,6 @@ const ShopVacProductTile: React.FC = () => {
       price={SHOP_VAC_COST}
       info="A canister vacuum on casters. Clears sawdust from the floor, including under machines. Drag it with you and empty it at the garbage can."
       inCart={inCart}
-      canAfford={gameState.money >= SHOP_VAC_COST}
       onAdd={() => applyAction(addToCartAction(line))}
     />
   );
@@ -152,7 +148,6 @@ const ToolProductTile: React.FC<{ tool: ToolType }> = ({ tool }) => {
       info={`${tool.description} Rides home in the truck's bed; carry it to a workstation and hang it on a bench's rail, or fit it in a machine's accessory slot.`}
       owned={numberOwned > 0 ? `${numberOwned} owned` : undefined}
       inCart={inCart}
-      canAfford={gameState.money >= tool.cost}
       onAdd={() => applyAction(addToCartAction(line))}
       tutorialTarget={`store-tool-${tool.id}`}
     />

--- a/tests/stations.spec.ts
+++ b/tests/stations.spec.ts
@@ -543,6 +543,36 @@ test.describe("Stations", () => {
         "3 items",
       );
 
+      // The shelf hands over anything — only the register checks the
+      // wallet. Broke, the Add buttons still work and Check Out doesn't.
+      const wallet = await page.evaluate(
+        () => (window as any).__GET_GAME_STATE__().money,
+      );
+      await page.evaluate(() => {
+        (window as any).__UPDATE_GAME_STATE__((state: any) => ({
+          ...state,
+          money: 1,
+        }));
+      });
+      await expect(page.getByTestId("store-check-out")).toBeDisabled();
+      const handSaw = page
+        .locator("li", { hasText: "Hand Saw" })
+        .getByRole("button", { name: "Add Hand Saw to cart" });
+      await expect(handSaw).toBeEnabled();
+      await handSaw.click();
+      await expect(page.getByTestId("store-cart-total")).toContainText(
+        "4 items",
+      );
+      // Put it back and pay with the money that was actually there
+      await page.getByTestId("store-cart-total").hover();
+      await cartPanel.getByRole("button", { name: "Remove one Hand Saw" }).click();
+      await page.evaluate((money: number) => {
+        (window as any).__UPDATE_GAME_STATE__((state: any) => ({
+          ...state,
+          money,
+        }));
+      }, wallet);
+
       await checkOutAndLeaveStore(page, returnTo);
       // The register is where everything lands at once: the two tools in
       // the bed (unloaded on the way in) and the screws in shop supply


### PR DESCRIPTION
Follow-up to #179, which merged before this change was pushed — the commit ended up orphaned on the deleted branch, so this re-lands it on current `main`.

A tile that greyed out at its own price sat oddly beside a cart that is allowed to outrun the wallet in aggregate: four saws you can't afford went in fine, one you couldn't wouldn't. So the shelf stops checking entirely — a real one doesn't — and the red total plus a dead **Check Out** button are the whole of the gate.

- `ProductTile` loses its `canAfford` prop; the four aisle sections stop passing it, and the lumber racks' board buttons drop `disabled` and the greyed styling.
- Removed a dead `useGameState()` in `StoreToolsSection` that the affordability check had been the last user of.
- New E2E coverage in `stations.spec.ts`: with $1 in the wallet an $18 hand saw still goes in the cart, while Check Out is disabled.

Verified on top of current `main`: `npm run tsc` clean, 1168 unit tests and all 7 E2E specs green. Also driven by hand in a browser — with $12 in the wallet every Add to Cart button is live, a $700 band saw drops in, the total reads red, and Check Out & Head Home is the only disabled control on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)