### PR TITLE
Nudge the player home when night falls

### DIFF
--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useBenchDiveActive } from "./bench-view/benchSceneSlot";
 import { CommissionTracker } from "./CommissionTracker";
 import { DustTutorialCard } from "./DustTutorialCard";
+import { NightfallCard } from "./NightfallCard";
 import { HandsStrip } from "./HandsStrip";
 import { NavBar } from "./NavBar";
 import { SuppliesSection } from "./SuppliesSection";
@@ -58,6 +59,7 @@ const HomePageContent: React.FC = () => {
         <CommissionTracker />
         <TutorialCard />
         <DustTutorialCard />
+        <NightfallCard />
       </div>
 
       <div

--- a/src/components/NightfallCard.tsx
+++ b/src/components/NightfallCard.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { isNight } from "../game/time-flow";
+import { ShortcutKeys } from "./shortcuts/Kbd";
+import { Thumbtack } from "./Thumbtack";
+import { useGameState } from "./useGameState";
+
+/**
+ * The nudge home at close: pinned up when the day's hours are spent and
+ * the player is still on the lot, taken down by the drive home. While it
+ * shows, the truck wears the coach outline in the world (see ShopView) —
+ * the same pairing the guided opening uses, a card naming the thing and
+ * the thing lit up.
+ */
+export const NightfallCard: React.FC = () => {
+  const gameState = useGameState();
+
+  if (!isNight(gameState) || gameState.player.away !== null) {
+    return null;
+  }
+
+  return (
+    <section
+      className="paper-card relative space-y-2"
+      data-testid="nightfall-card"
+    >
+      <Thumbtack />
+      <header className="border-b-2 border-ink-black/40 pb-1">
+        <h3 className="font-condensed font-bold text-lg uppercase tracking-wide">
+          Closed for the Night
+        </h3>
+      </header>
+      <p className="text-sm leading-snug">
+        The day's working hours are spent. Head out to the truck, press{" "}
+        <ShortcutKeys shortcut="pick-up" /> at the cab, and drive home. Anything
+        still curing is dry by morning.
+      </p>
+    </section>
+  );
+};

--- a/src/components/shop-view/ShopView.tsx
+++ b/src/components/shop-view/ShopView.tsx
@@ -63,6 +63,7 @@ import { BenchDiveLayer } from "./BenchDiveLayer";
 import { useBenchDiveActive } from "../bench-view/benchSceneSlot";
 import { useTruckStage } from "./truckStageStore";
 import { atTruckBed, lotSize } from "../../game/lot";
+import { isNight } from "../../game/time-flow";
 import { TruckHighlight } from "./TruckSprite";
 import { PIXELS_PER_CELL, cellToPixel, cellToPixelCenter } from "./shop-scale";
 import { WorktableShadowSprite } from "../machine-sprites/WorktableSprite";
@@ -219,6 +220,13 @@ export const ShopView: React.FC = () => {
   // Where the guided opening is pointing, in the world. Empty once the
   // tutorial is done, so this costs nothing for the rest of the game.
   const coach = tutorialTargets(gameState);
+
+  // At close the corner card points home (see NightfallCard), and the
+  // truck wears the same coach outline so the card and the world agree.
+  const homewardNudge: TruckHighlight =
+    isNight(gameState) && !gameState.player.away && truckStage === "parked"
+      ? "truck"
+      : null;
 
   // Which of the floor's pieces answer to the cursor: pointing at one aims
   // E at it (the rummage key's job, done by hand), and right-clicking
@@ -408,7 +416,7 @@ export const ShopView: React.FC = () => {
                     viewport={worldViewport}
                     truckHighlight={truckHighlight}
                     truckCargoHighlight={truckCargoHighlight}
-                    truckTutorialHighlight={coach.truck}
+                    truckTutorialHighlight={coach.truck ?? homewardNudge}
                   />
                   <pixiTilingSprite
                     eventMode="static"

--- a/tests/floor.spec.ts
+++ b/tests/floor.spec.ts
@@ -737,6 +737,10 @@ test.describe("Shop floor", () => {
       await expect(panel).not.toContainText("Orange Box");
       await expect(panel).not.toContainText("Scavenge");
 
+      // ...and the corner card points the way there
+      const nightfallCard = page.getByTestId("nightfall-card");
+      await expect(nightfallCard).toContainText("Closed for the Night");
+
       const dayBefore = await page.evaluate(
         () => (window as any).__GET_GAME_STATE__().day,
       );
@@ -756,6 +760,8 @@ test.describe("Shop floor", () => {
       );
       // Sleeping is what turns the calendar over, so the dial's date moved.
       await expect(page.getByTestId("day-date")).not.toHaveText(dateBefore!);
+      // Morning takes the nudge home back down
+      await expect(nightfallCard).toHaveCount(0);
     });
 
     await test.step("a refresh keeps the shop, without anyone saving it", async () => {


### PR DESCRIPTION
Closes #150.

From the playtest note: nothing told you the day was over. Now, when the shop closes for the night and the player is still on the lot:

- **A card joins the HUD's left column** (`NightfallCard`, same slot and paper style as the dust tip): "Closed for the Night — head out to the truck, press E at the cab, and drive home. Anything still curing is dry by morning." The key comes from the shortcut registry, and the curing line matches the truck card's Home row so the two never disagree.
- **The truck wears the coach outline** in the world while the card shows — the same card-plus-outline pairing the guided opening uses, reusing the existing `tutorialHighlight` plumbing in `ShopView`/`TruckSprite`.

The card needs no dismissal state: it appears each night the player is still in the shop and takes itself down with the drive home (or any trip already underway).

Tested by extending the existing night step in `floor.spec.ts` — the card is up at night and gone by morning. Unit tier and the floor spec pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)