### PR TITLE
Start new games on the shop floor, not the welcome article

### DIFF
--- a/docs/shop-manual.md
+++ b/docs/shop-manual.md
@@ -34,9 +34,7 @@ Typewriter-set article text per `docs/design-system.md`.
   follow).
 - A new unlock puts a small badge on the `?` button and a "NEW" marker
   on the article's tab; opening the article clears both. No toasts and
-  no auto-opens — the one exception is Welcome, which shows itself while
-  it is unlocked-but-unread (state-driven, so a fixture-loaded save
-  dissolves it automatically).
+  no auto-opens.
 - State is two persistent `ProgressionState` lists: `unlockedArticles`
   (appended by the same milestone checks that flip the underlying
   features — no parallel boolean flags) and `readArticles` (drives the

--- a/src/components/manual/ManualProvider.tsx
+++ b/src/components/manual/ManualProvider.tsx
@@ -20,33 +20,19 @@ const manualContext = createContext<
 /**
  * Binds `?`, hosts the shop manual, and lets anything open it to a specific
  * article (the NavBar's `?` button, the ActionBar's "All shortcuts" link).
- *
- * The welcome article gets one special behavior: on a brand-new game it is
- * unlocked but unread, and the manual shows itself until it's been closed
- * once. That's state-driven, not an effect — so a test (or migration) that
- * marks welcome read makes the auto-open dissolve on its own.
  */
 export const ManualProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const { progression } = useGameState();
   const applyAction = useApplyGameAction();
-  const [uiOpen, setUiOpen] = useState(false);
-  const [active, setActive] = useState<ManualArticleId>("welcome");
-
-  const autoWelcome =
-    progression.unlockedArticles.includes("welcome") &&
-    !progression.readArticles.includes("welcome");
-  const visible = uiOpen || autoWelcome;
-  // When only the auto-open is holding the manual up, it shows welcome.
-  const activeId = uiOpen ? active : "welcome";
+  const [visible, setVisible] = useState(false);
+  const [activeId, setActiveId] = useState<ManualArticleId>("welcome");
 
   // The binder opening is the sound of the manual appearing, however it was
-  // summoned — the ? key, the NavBar button, a ManualLink, the auto-welcome.
-  // (Openers that are buttons carry `data-sfx="none"` so the generic click
-  // doesn't stack on top.) On the auto-welcome this fires before any user
-  // gesture, where the still-locked AudioContext swallows it — fine, a brand
-  // new game shouldn't open with a noise anyway.
+  // summoned — the ? key, the NavBar button, a ManualLink. (Openers that are
+  // buttons carry `data-sfx="none"` so the generic click doesn't stack on
+  // top.)
   useEffect(() => {
     if (visible) playUiSound("ui-book-open");
   }, [visible]);
@@ -60,24 +46,21 @@ export const ManualProvider: React.FC<{ children: React.ReactNode }> = ({
         ) ??
         progression.unlockedArticles[0] ??
         "welcome";
-      setActive(target);
-      setUiOpen(true);
+      setActiveId(target);
+      setVisible(true);
       applyAction(markArticlesReadAction([target]));
     },
     [applyAction, progression.unlockedArticles, progression.readArticles],
   );
 
   const select = (articleId: ManualArticleId) => {
-    setActive(articleId);
-    setUiOpen(true);
+    setActiveId(articleId);
+    setVisible(true);
     applyAction(markArticlesReadAction([articleId]));
   };
 
   const close = () => {
-    // Closing always acknowledges welcome — it's what the auto-open shows,
-    // and leaving it unread would just pop the binder right back up.
-    applyAction(markArticlesReadAction([activeId, "welcome"]));
-    setUiOpen(false);
+    setVisible(false);
   };
 
   useShortcut("toggle-help", () => open());

--- a/src/game/initialGameState.tsx
+++ b/src/game/initialGameState.tsx
@@ -68,7 +68,8 @@ export const initialGameState: GameState = {
     commissionArrivalSeen: true,
     sweepingUnlocked: false,
     dustTipDismissed: false,
-    // Welcome starts unread on purpose: the manual auto-opens to it once.
+    // Welcome starts unread on purpose: it keeps the ? badge lit until the
+    // player opens the manual for the first time.
     unlockedArticles: STARTING_ARTICLES,
     readArticles: [],
     xp: 0,

--- a/tests/bench.spec.ts
+++ b/tests/bench.spec.ts
@@ -71,12 +71,6 @@ test.describe("Bench view", () => {
     await page.goto("/");
     await startNewGame(page);
     await page.waitForFunction(() => (window as any).__UPDATE_GAME_STATE__);
-    // The manual greets a new game and holds the keyboard until dismissed
-    const manual = page.getByRole("dialog", { name: "Shop manual" });
-    if (await manual.count()) {
-      await page.keyboard.press("Escape");
-      await manual.waitFor({ state: "detached" });
-    }
     await page.evaluate(() => {
       window.__UPDATE_GAME_STATE__(
         () => window.__TEST_FIXTURES__["bench-work-shop"],

--- a/tests/floor.spec.ts
+++ b/tests/floor.spec.ts
@@ -161,13 +161,8 @@ test.describe("Shop floor", () => {
       await page.waitForFunction(() => (window as any).__GET_GAME_STATE__);
     });
 
-    await test.step("the shop manual greets a new game and closes for good", async () => {
+    await test.step("a new game starts on the shop floor, no manual in the way", async () => {
       const manual = page.getByRole("dialog", { name: "Shop manual" });
-      await expect(manual).toBeVisible();
-      await expect(
-        manual.getByRole("heading", { name: "Welcome to the Shop" }),
-      ).toBeVisible();
-      await page.keyboard.press("Escape");
       await expect(manual).toHaveCount(0);
     });
 
@@ -529,12 +524,6 @@ test.describe("Shop floor", () => {
       await page.goto("/");
       await startNewGame(page);
       await page.waitForFunction(() => (window as any).__UPDATE_GAME_STATE__);
-      // A fresh game re-opens the manual, and a modal swallows the door key.
-      const manual = page.getByRole("dialog", { name: "Shop manual" });
-      if (await manual.count()) {
-        await page.keyboard.press("Escape");
-        await manual.waitFor({ state: "detached" });
-      }
       await page.waitForTimeout(500);
     });
 

--- a/tests/market.spec.ts
+++ b/tests/market.spec.ts
@@ -66,11 +66,6 @@ async function bootShopCountingAudio(page: Page) {
   // A real click also unlocks the AudioContext, which playback depends on.
   await startNewGame(page);
   await page.waitForFunction(() => (window as any).__GET_GAME_STATE__);
-  // Dismiss the shop manual's one-time welcome so it can't cover the UI.
-  const manual = page.getByRole("dialog", { name: "Shop manual" });
-  await manual.waitFor();
-  await page.keyboard.press("Escape");
-  await manual.waitFor({ state: "detached" });
 }
 
 async function queueCue(page: Page, cue: Record<string, string>) {

--- a/tests/milling.spec.ts
+++ b/tests/milling.spec.ts
@@ -227,12 +227,6 @@ test.describe("Milling", () => {
     await page.goto("/");
     await startNewGame(page);
     await page.waitForFunction(() => (window as any).__UPDATE_GAME_STATE__);
-    // The manual greets a new game and holds the keyboard until dismissed
-    const manual = page.getByRole("dialog", { name: "Shop manual" });
-    if (await manual.count()) {
-      await page.keyboard.press("Escape");
-      await manual.waitFor({ state: "detached" });
-    }
     await page.waitForTimeout(500);
 
     await test.step("load the milling-shop", async () => {

--- a/tests/screens.spec.ts
+++ b/tests/screens.spec.ts
@@ -37,13 +37,19 @@ test.describe("Screens", () => {
     page.on("dialog", (d) => d.accept());
     const manual = page.getByRole("dialog", { name: "Shop manual" });
 
-    await test.step("auto-opens to Welcome on a brand-new game", async () => {
+    await test.step("a brand-new game starts on the shop floor, ? badge waiting", async () => {
       await page.goto("/");
       await page.waitForLoadState("domcontentloaded");
       await page.waitForSelector("main");
       await startNewGame(page);
       await page.waitForFunction(() => (window as any).__GET_GAME_STATE__);
 
+      await expect(manual).toHaveCount(0);
+      await expect(page.getByTestId("manual-badge")).toBeVisible();
+    });
+
+    await test.step("? opens to Welcome, the first unread article", async () => {
+      await page.keyboard.press("Shift+/");
       await expect(manual).toBeVisible();
       await expect(
         manual.getByRole("heading", { name: "Welcome to the Shop" }),
@@ -59,7 +65,7 @@ test.describe("Screens", () => {
       ).toHaveCount(0);
     });
 
-    await test.step("closing acknowledges Welcome and stays closed", async () => {
+    await test.step("closing leaves Welcome read and stays closed", async () => {
       await page.keyboard.press("Escape");
       await expect(manual).toHaveCount(0);
       const state = await getState(page);
@@ -457,11 +463,6 @@ test.describe("Screens", () => {
     await test.step("the reloaded store rehydrates into the UI", async () => {
       await startNewGame(page);
       await page.waitForFunction(() => (window as any).__GET_GAME_STATE__);
-      // A second fresh game greets us with the manual again; dismiss it.
-      const manual = page.getByRole("dialog", { name: "Shop manual" });
-      await manual.waitFor();
-      await page.keyboard.press("Escape");
-      await expect(manual).toHaveCount(0);
       await page.keyboard.press("Escape");
       await expect(page.getByRole("slider", { name: "Master" })).toHaveValue(
         "30",

--- a/tests/stations.spec.ts
+++ b/tests/stations.spec.ts
@@ -106,12 +106,6 @@ test.describe("Stations", () => {
     await page.goto("/");
     await startNewGame(page);
     await page.waitForFunction(() => (window as any).__UPDATE_GAME_STATE__);
-    // The manual greets a new game and holds the keyboard until dismissed
-    const manual = page.getByRole("dialog", { name: "Shop manual" });
-    if (await manual.count()) {
-      await page.keyboard.press("Escape");
-      await manual.waitFor({ state: "detached" });
-    }
     await page.waitForTimeout(500);
 
     // Where the store trip returns the player to.


### PR DESCRIPTION
Fixes #149.

Per the comment on the issue, the fix is simply to not start with the article open: `ManualProvider` loses its welcome auto-open special case, so a brand-new game begins on the shop floor with the tutorial's first coach card as the opening beat. The welcome article still starts unlocked-but-unread, which keeps the badge on the `?` button lit until the player opens the manual — and opening it lands on Welcome, since it's the first unread article.

Also cleaned up along the way:
- `close()` no longer needs to force-acknowledge welcome, and the provider's open/active state collapses to two plain `useState`s
- Five E2E specs dropped their "dismiss the manual that greets a new game" boilerplate; `screens.spec.ts` now asserts the new-game flow (no manual, badge lit, `?` opens to Welcome)
- `docs/shop-manual.md` and the `initialGameState` comment updated to match

Verified: `tsc` clean, all 1169 unit tests pass, all 7 E2E specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)