### PR TITLE
Start the game with a basic lumber shelf

### DIFF
--- a/docs/asset-backlog.md
+++ b/docs/asset-backlog.md
@@ -131,6 +131,9 @@ wiring: same path, same size, same component.
 
 - [ ] Storage rack — `machine-sprites/StorageRackSprite.tsx`. Art for the
       empty rack; parked stock keeps its data-driven slat colors.
+- [ ] Lumber shelf — `machine-sprites/LumberShelfSprite.tsx`. The starter
+      2×1 shelf every shop opens with; art for the empty shelf, with
+      parked stock keeping its data-driven board colors.
 - [ ] Sawhorses — `machine-sprites/SawhorsesSprite.tsx`. Two folding horses
       seen from above, a couple of feet apart across a 3×2-ft span. The
       sheet lying across them is staged stock and keeps rendering through

--- a/src/components/machine-sprites/LumberShelfSprite.tsx
+++ b/src/components/machine-sprites/LumberShelfSprite.tsx
@@ -1,0 +1,95 @@
+import { Graphics } from "pixi.js";
+import React, { useCallback } from "react";
+import { Machine } from "../../game/Machine";
+import { MaterialInstance } from "../../game/Materials";
+import { colorToNumber } from "../../utils/colorUtils";
+import { seededRandom } from "../../utils/randUtils";
+import {
+  colorBySheetGoodKind,
+  colorBySpecies,
+} from "../shop-view/colorBySpecies";
+import { PIXELS_PER_CELL } from "../shop-view/shop-scale";
+
+/** What color a board of parked stock reads as from above. */
+function storedStockColor(material: MaterialInstance): number {
+  if ("species" in material) {
+    return colorToNumber(colorBySpecies[material.species].primary);
+  }
+  if (material.type === "plywood") {
+    return colorToNumber(colorBySheetGoodKind[material.kind].primary);
+  }
+  return 0x9a8062;
+}
+
+/**
+ * The starter lumber shelf: a single plank on short legs, drawn from
+ * above. Parked stock (storedMaterials) lies as boards along the plank,
+ * so a loaded shelf looks loaded from across the shop.
+ */
+export const LumberShelfSprite: React.FC<{ machine: Machine }> = ({
+  machine,
+}) => {
+  const stored = machine.storedMaterials;
+
+  const draw = useCallback(
+    (g: Graphics) => {
+      g.clear();
+      const halfW = PIXELS_PER_CELL * 0.94;
+      const halfH = PIXELS_PER_CELL * 0.44;
+      const rng = seededRandom("lumber-shelf");
+
+      // Drop shadow toward the lower right
+      g.roundRect(-halfW + 3, -halfH + 4, halfW * 2, halfH * 2, 4);
+      g.fill({ color: 0x000000, alpha: 0.18 });
+
+      // Legs peeking out from under the plank at the corners
+      const leg = PIXELS_PER_CELL * 0.22;
+      for (const [px, py] of [
+        [-halfW + 1, -halfH + 1],
+        [halfW - leg - 1, -halfH + 1],
+        [-halfW + 1, halfH - leg - 1],
+        [halfW - leg - 1, halfH - leg - 1],
+      ]) {
+        g.rect(px - 1.5, py - 1.5, leg + 3, leg + 3);
+        g.fill({ color: 0x5c3b1e });
+      }
+
+      // The plank itself, inset so the legs peek out, with a faint grain
+      const inset = 3;
+      const deckW = halfW - inset;
+      const deckH = halfH - inset;
+      g.roundRect(-deckW, -deckH, deckW * 2, deckH * 2, 3);
+      g.fill(0x8a6a44);
+      for (let i = 0; i < 8; i++) {
+        const y = -deckH + 2 + rng() * (deckH * 2 - 4);
+        const x = -deckW + 2 + rng() * (deckW * 0.8);
+        const w = deckW * (0.5 + rng() * 0.9);
+        g.rect(x, y, Math.min(w, deckW * 2 - 4), 1);
+        g.fill({ color: 0x6b4a26, alpha: 0.5 });
+      }
+      g.roundRect(-deckW, -deckH, deckW * 2, deckH * 2, 3);
+      g.stroke({ width: 2, color: 0x6b4a26 });
+
+      // Parked stock lies as boards along the shelf
+      const slots = Math.min(stored.length, 4);
+      for (let i = 0; i < slots; i++) {
+        const boardLength = halfW * 2 * (0.62 + rng() * 0.2);
+        const y = -halfH + 6 + (i * (halfH * 2 - 12)) / 4;
+        const x = -boardLength / 2 + (rng() * 2 - 1) * 3;
+        g.rect(x, y, boardLength, 4);
+        g.fill(storedStockColor(stored[i]));
+        g.rect(x, y, boardLength, 4);
+        g.stroke({ width: 1, color: 0x000000, alpha: 0.25 });
+      }
+    },
+    [stored],
+  );
+
+  // Centered on the 2×1-ft footprint: half a cell past the origin in x,
+  // on-center in y.
+  return (
+    <pixiContainer x={PIXELS_PER_CELL * 0.5} y={0}>
+      <pixiGraphics draw={draw} />
+    </pixiContainer>
+  );
+};

--- a/src/components/shop-view/MachineSprite.tsx
+++ b/src/components/shop-view/MachineSprite.tsx
@@ -24,6 +24,7 @@ import {
 import { BandSawSprite } from "../machine-sprites/BandSawSprite";
 import { GarbageCanSprite } from "../machine-sprites/GarbageCanSprite";
 import { SawhorsesSprite } from "../machine-sprites/SawhorsesSprite";
+import { LumberShelfSprite } from "../machine-sprites/LumberShelfSprite";
 import { StorageRackSprite } from "../machine-sprites/StorageRackSprite";
 import { JobsiteTableSawSprite } from "../machine-sprites/JobsiteTableSawSprite";
 import { JointerSprite } from "../machine-sprites/JointerSprite";
@@ -295,6 +296,9 @@ const LocalMachineSprite: React.FC<{ machine: Machine }> = ({ machine }) => {
   }
   if (machine.type.id === MACHINE_TYPES.storageRack.id) {
     return <StorageRackSprite machine={machine} />;
+  }
+  if (machine.type.id === MACHINE_TYPES.lumberShelf.id) {
+    return <LumberShelfSprite machine={machine} />;
   }
 
   const art = (() => {

--- a/src/game/Machine.ts
+++ b/src/game/Machine.ts
@@ -18,6 +18,7 @@ import { bandSaw } from "./machines/bandSaw";
 import { garbageCan } from "./machines/garbageCan";
 import { jobsiteTableSaw } from "./machines/jobsiteTableSaw";
 import { jointer } from "./machines/jointer";
+import { lumberShelf } from "./machines/lumberShelf";
 import { lunchboxPlaner } from "./machines/lunchboxPlaner";
 import { miterSaw } from "./machines/miterSaw";
 import { sawhorses } from "./machines/sawhorses";
@@ -240,6 +241,7 @@ export const MACHINE_TYPES = {
   bandSaw,
   garbageCan,
   storageRack,
+  lumberShelf,
   sawhorses,
 } satisfies { [id: string]: MachineType };
 export type MachineId = keyof typeof MACHINE_TYPES;

--- a/src/game/initialGameState.tsx
+++ b/src/game/initialGameState.tsx
@@ -41,6 +41,9 @@ export const initialGameState: GameState = {
     machine("workspace", [2, 2], 0, ["hammer"]),
     // Garbage can for disposing unwanted materials (2×2 ft, in a corner)
     machine("garbageCan", [0, 13], 0),
+    // A small lumber shelf against the back wall, so the first scavenged
+    // boards have an obvious home besides the floor (2×1 ft)
+    machine("lumberShelf", [8, 0], 0),
   ],
   machineCrates: [],
   truck: { bed: [], crates: [] },
@@ -104,7 +107,9 @@ function machine(
     outputMaterials: [],
     tools,
     storedMaterials: [],
-    selectedOperationId: firstOperation.id,
+    // Stations with no operations (the lumber shelf) park on "none",
+    // matching freshMachineState in machine-actions.ts
+    selectedOperationId: firstOperation ? firstOperation.id : "none",
     selectedParameters,
     operationProgress: {
       status: "notStarted",

--- a/src/game/machines/lumberShelf.ts
+++ b/src/game/machines/lumberShelf.ts
@@ -1,0 +1,34 @@
+import { MachineType } from "../Machine";
+
+/**
+ * The starter shelf every shop opens with: a plank on short legs against
+ * the wall, so the first scavenged boards have somewhere to live besides
+ * the floor. Half the footprint and half the capacity of the buildable
+ * storage rack (storageRack.ts), which stays the upgrade. Never sold and
+ * never built — it exists only in the starting layout.
+ */
+export const lumberShelf: MachineType = {
+  id: "lumberShelf",
+  name: "Lumber Shelf",
+  description: "A plank on short legs. Keeps a few boards off the floor.",
+  // A 2×1-ft shelf: one board deep, stock laid along it.
+  cellsOccupied: [
+    [0, 0],
+    [1, 0],
+  ],
+  // Hand-set (drawn procedurally): the deck in LumberShelfSprite fills
+  // the footprint to a small inset.
+  collisionShapes: [{ kind: "box", min: [-0.44, -0.44], max: [1.44, 0.44] }],
+  // Stand at the front to stow and take — the shelf UI (and everything
+  // else) hangs off the operation cell.
+  freeCellsNeeded: [
+    [0, 1],
+    [1, 1],
+  ],
+  operationPosition: [0, 1],
+  cost: 0,
+  materialStorage: 4,
+  toolSlots: 0,
+  inputSpaces: 0,
+  operations: [],
+};

--- a/src/game/manual.ts
+++ b/src/game/manual.ts
@@ -110,7 +110,7 @@ const defs = [
     category: "The Shop",
     // Carrying is never locked; the article arrives with the first machine
     // worth arranging — a crate in the bed or on the floor, or anything
-    // bought beyond the starter bench and garbage can.
+    // bought beyond the starting loadout (bench, garbage can, lumber shelf).
     unlocked: (gameState: GameState) =>
       gameState.machineCrates.length > 0 ||
       gameState.truck.crates.length > 0 ||
@@ -118,7 +118,8 @@ const defs = [
       gameState.machines.some(
         (machine) =>
           machine.machineTypeId !== "workspace" &&
-          machine.machineTypeId !== "garbageCan",
+          machine.machineTypeId !== "garbageCan" &&
+          machine.machineTypeId !== "lumberShelf",
       ),
   },
   {


### PR DESCRIPTION
Closes #166

The starting shop gains a **Lumber Shelf** against the back wall at `[8,0]` — a 2×1-ft plank on short legs holding 4 stock — so new players have an obvious place to put boards instead of strewing them on the floor.

Per the issue's open call, this is a smaller starter variant rather than a seeded storage rack: the bench-built 2×2 Storage Rack (holds 8) stays the upgrade. The shelf is never sold and never built — it exists only in the starting layout.

- `src/game/machines/lumberShelf.ts` — the new machine type (no operations, `materialStorage: 4`)
- `LumberShelfSprite` — procedural top-down art (plank on legs; parked stock draws as data-colored boards); row added to `docs/asset-backlog.md`
- `initialGameState`'s `machine()` helper now handles operation-less stations (parks on `"none"`, matching `freshMachineState`) instead of crashing on `operations[0].id`
- The manual's *Moving Machines* article treats the shelf as part of the starting loadout, so it doesn't unlock on a fresh game

Rebased onto the roadside-stand pivot and verified on the combined tree: `tsc` clean, 1047 unit tests pass, all 7 E2E specs pass, and a fresh game screenshot confirms the shelf renders (empty and loaded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)