### PR TITLE
Guarantee tutorial-pointed RNG outcomes: first pallet and first sale

### DIFF
--- a/src/game/game-actions/scavenge-actions.test.ts
+++ b/src/game/game-actions/scavenge-actions.test.ts
@@ -84,6 +84,48 @@ describe("rollScavengeStops", () => {
   });
 });
 
+describe("the first-trip guarantee", () => {
+  it("moves the washout plant to the first stop", () => {
+    const stops = rollScavengeStops(fakeRng([0.9]), true);
+    assert.ok(stops[0].pallet, "stop one should hold the guaranteed find");
+  });
+
+  it("leaves a lucky circuit alone", () => {
+    const stops = rollScavengeStops(fakeRng([0.1]), true);
+    // Every stop found its own pallet; nothing extra was planted
+    assert.strictEqual(
+      stops.filter((stop) => stop.pallet !== null).length,
+      SCAVENGE_STOP_NAMES.length,
+    );
+  });
+
+  it("a brand-new shop's trip can't miss at stop one", () => {
+    const result = startScavengingAction(fakeRng([0.9]))(
+      stateWithFreeSelling(),
+    );
+    const away = result.player.away as ScavengingTrip;
+    assert.ok(away.stops[0].pallet);
+  });
+
+  it("a shop that has wood rolls the circuit straight", () => {
+    const pallet = rollScavengeStops(fakeRng([0.1]))[0].pallet;
+    assert.ok(pallet);
+    const base = stateWithFreeSelling();
+    const state: GameState = {
+      ...base,
+      truck: { ...base.truck, bed: [pallet] },
+    };
+    const result = startScavengingAction(fakeRng([0.9]))(state);
+    const away = result.player.away as ScavengingTrip;
+    // The washout plant lands wherever the roll says, not at stop one
+    assert.strictEqual(away.stops[0].pallet, null);
+    assert.strictEqual(
+      away.stops.filter((stop) => stop.pallet !== null).length,
+      1,
+    );
+  });
+});
+
 describe("startScavengingAction", () => {
   it("sends the player into the first stop's search", () => {
     const result = startScavengingAction(fakeRng([0.1]))(
@@ -165,11 +207,16 @@ describe("the search tick", () => {
   });
 
   it("stays quiet over an empty-handed stop", () => {
-    // All-0.9 rolls leave every stop empty except the planted find at
-    // the last stop, so the first stop reveals nothing
-    const started = startScavengingAction(fakeRng([0.9]))(
-      stateWithFreeSelling(),
-    );
+    // A shop with wood already, so the first-trip guarantee stays out of
+    // it: all-0.9 rolls leave every stop empty except the planted find
+    // at the last stop, so the first stop reveals nothing
+    const pallet = rollScavengeStops(fakeRng([0.1]))[0].pallet;
+    assert.ok(pallet);
+    const base = stateWithFreeSelling();
+    const started = startScavengingAction(fakeRng([0.9]))({
+      ...base,
+      truck: { ...base.truck, bed: [pallet] },
+    });
     const trip = started.player.away as ScavengingTrip;
     const doneTick =
       trip.phase.kind === "searching" ? trip.phase.doneTick : NaN;

--- a/src/game/game-actions/scavenge-actions.ts
+++ b/src/game/game-actions/scavenge-actions.ts
@@ -7,6 +7,7 @@ import { ScavengeStopResult, ScavengingTrip } from "../Person";
 import { Tuple } from "../../utils/typeUtils";
 import { TICKS_PER_DAY } from "../time";
 import { dayTicksSpent, isNight } from "../time-flow";
+import { needsFirstPallet } from "../tutorial";
 import { canLeaveShop } from "./door-actions";
 
 /**
@@ -60,15 +61,30 @@ export const SCAVENGE_STOP_TICKS = IS_DEV ? DEV_STOP_TICKS : FULL_STOP_TICKS;
  * would strand a brand-new shop with no wood and no way to get any (the
  * first sale starts from a scavenged pallet), so a washed-out roll
  * plants a find at one stop.
+ *
+ * That backstop isn't enough for the very first trip, though: only
+ * searched stops pay out, so a plant at stop four does nothing for a
+ * player who calls it after stop one. While the shop has never had a
+ * pallet (needsFirstPallet — the same condition the to-do card's
+ * scavenge step reads), `guaranteeFirstStop` moves the plant to the
+ * first stop, so the trip the card points at delivers no matter when
+ * the player heads home. The extra pallet roll comes after the circuit's
+ * own, so a scripted rng tape reads the same either way.
  */
 export function rollScavengeStops(
   rng: () => number = Math.random,
+  guaranteeFirstStop = false,
 ): ScavengeStopResult[] {
   const stops: ScavengeStopResult[] = SCAVENGE_STOP_NAMES.map((stopName) => ({
     stopName,
     pallet: rng() < FIND_CHANCE ? makeDamagedPallet(rng) : null,
   }));
-  if (stops.every((stop) => stop.pallet === null)) {
+  if (guaranteeFirstStop && stops[0].pallet === null) {
+    stops[0] = {
+      ...stops[0],
+      pallet: makeDamagedPallet(rng),
+    };
+  } else if (stops.every((stop) => stop.pallet === null)) {
     const index = Math.min(stops.length - 1, Math.floor(rng() * stops.length));
     stops[index] = {
       ...stops[index],
@@ -160,7 +176,7 @@ export function startScavengingAction(
         away: {
           kind: "scavenging",
           startTick: gameState.tick,
-          stops: rollScavengeStops(rng),
+          stops: rollScavengeStops(rng, needsFirstPallet(gameState)),
           stopsSearched: 0,
           phase: {
             kind: "searching",

--- a/src/game/game-actions/stand-actions.test.ts
+++ b/src/game/game-actions/stand-actions.test.ts
@@ -173,11 +173,66 @@ describe("the street pass", () => {
       state: "browsing",
       browseTicksLeft: 1,
     };
-    const state = atTheStand([], { stand: [piece], customers: [browser] });
+    // A shop with a sale behind it — the first browse never walks away.
+    const state = atTheStand([], {
+      stand: [piece],
+      customers: [browser],
+      progression: { ...initialGameState.progression, salesCompleted: 1 },
+    });
     // Spawn roll misses, then the buy roll misses too.
     const result = standTickPass(tape([0.99, 0.9]))(state);
     assert.deepStrictEqual(result.stand, [piece]);
     assert.strictEqual(result.money, state.money);
     assert.strictEqual(result.customers[0].state, "leaving");
+  });
+});
+
+describe("the first sale", () => {
+  it("summons a customer to a first-stocked stand without waiting on the dice", () => {
+    const state = atTheStand([], { stand: [shelf()] });
+    // The spawn roll never comes up — the customer appears anyway.
+    const result = standTickPass(tape([], 0.99))(state);
+    assert.strictEqual(result.customers.length, 1);
+
+    // No second summons while that one is still headed for the table.
+    const again = standTickPass(tape([], 0.99))(result);
+    assert.strictEqual(again.customers.length, 1);
+  });
+
+  it("never summons after the shop has sold something", () => {
+    const state = atTheStand([], {
+      stand: [shelf()],
+      progression: { ...initialGameState.progression, salesCompleted: 1 },
+    });
+    const result = standTickPass(tape([], 0.99))(state);
+    assert.strictEqual(result.customers.length, 0);
+  });
+
+  it("the first browse always buys, even on a cold roll", () => {
+    const piece = shelf();
+    const browser: Customer = {
+      id: "customer-test",
+      x: 2,
+      walkDirection: 1,
+      state: "browsing",
+      browseTicksLeft: 1,
+    };
+    const state = atTheStand([], { stand: [piece], customers: [browser] });
+    const result = standTickPass(tape([], 0.99))(state);
+    assert.deepStrictEqual(result.stand, []);
+    assert.strictEqual(result.progression.salesCompleted, 1);
+  });
+
+  it("carries an unlucky shop all the way to its first sale", () => {
+    // Every roll as cold as they come: no spawn would pass, no buy
+    // would pass. The guarantee walks its customer to the table anyway.
+    const cold = () => 0.99;
+    let state = atTheStand([], { stand: [shelf()] });
+    for (let i = 0; i < 400 && state.progression.salesCompleted === 0; i++) {
+      state = standTickPass(cold)(state);
+    }
+    assert.strictEqual(state.progression.salesCompleted, 1);
+    assert.deepStrictEqual(state.stand, []);
+    assert.ok(state.money > initialGameState.money);
   });
 });

--- a/src/game/game-actions/stand-actions.ts
+++ b/src/game/game-actions/stand-actions.ts
@@ -116,25 +116,43 @@ export function standTopItem(
  * count move in the same reducer — and queues a PayoutEvent, which
  * RewardFlightLayer turns into the cha-ching and the fly-in wherever
  * the player happens to be standing.
+ *
+ * The first sale ever is dealt, not rolled: until something has sold, a
+ * stocked stand summons its customer immediately and the browse below
+ * always buys, so the opening's "set it out at the stand" step pays off
+ * while the player is still standing there. From the second sale on the
+ * street runs on the dice.
  */
 export function standTickPass(rng: () => number = Math.random): GameAction {
   return (gameState) => {
+    const span = customerSpan(gameState.shopInfo);
+    const frontage = standFrontage(gameState.shopInfo);
+
     // Foot traffic follows the stand: a stocked table draws people down
     // the street, a bare one sees the odd stroller. Nobody at night.
     const spawnChance =
       gameState.stand.length > 0
         ? CUSTOMER_SPAWN_CHANCE_STOCKED
         : CUSTOMER_SPAWN_CHANCE_EMPTY;
+    const firstSaleDue =
+      gameState.progression.salesCompleted === 0 && gameState.stand.length > 0;
+    // The guaranteed customer is only summoned while nobody already on
+    // the street could still make the sale — one at a time, no crowd.
+    const buyerEnRoute = gameState.customers.some(
+      (customer) =>
+        customer.state === "browsing" ||
+        (customer.state === "walking" &&
+          (customer.walkDirection === 1
+            ? customer.x < frontage.right
+            : customer.x > frontage.left)),
+    );
     const spawning =
       !isNight(gameState) &&
       gameState.customers.length < MAX_CUSTOMERS &&
-      rng() < spawnChance;
+      ((firstSaleDue && !buyerEnRoute) || rng() < spawnChance);
     if (gameState.customers.length === 0 && !spawning) {
       return gameState;
     }
-
-    const span = customerSpan(gameState.shopInfo);
-    const frontage = standFrontage(gameState.shopInfo);
 
     let stand = gameState.stand;
     let money = gameState.money;
@@ -154,9 +172,12 @@ export function standTickPass(rng: () => number = Math.random): GameAction {
           continue;
         }
         // Decision time. One purchase per browse at most; either way
-        // they move along afterwards and don't stop again.
+        // they move along afterwards and don't stop again. The shop's
+        // first sale skips the coin flip — see the header.
         const purchase =
-          rng() < CUSTOMER_BUY_CHANCE ? pickPurchase(stand, rng) : null;
+          salesCompleted === 0 || rng() < CUSTOMER_BUY_CHANCE
+            ? pickPurchase(stand, rng)
+            : null;
         if (purchase) {
           const value = roundToCents(getSellValue(purchase));
           const reputationGain = saleReputationGain(value);

--- a/src/game/tutorial.ts
+++ b/src/game/tutorial.ts
@@ -178,6 +178,19 @@ const hasBirdhouse = (gameState: GameState) =>
 const soldFirstPiece = (gameState: GameState) =>
   gameState.progression.salesCompleted > 0;
 
+/**
+ * Whether the shop has yet to see its first pallet in any form — no
+ * pallet, none of its boards, no shelf, no sale. The scavenge step reads
+ * this, and so does startScavengingAction: while it holds, a scavenging
+ * trip plants its find at the first stop, so the trip the card points
+ * at can't come home empty.
+ */
+export const needsFirstPallet = (gameState: GameState): boolean =>
+  countOf(gameState, isPallet) === 0 &&
+  !hasShelfParts(gameState) &&
+  !hasShelf(gameState) &&
+  !soldFirstPiece(gameState);
+
 const isBirdhousePartStock = (material: MaterialInstance): material is Board =>
   isPalletBoard(material) && isBoard(material);
 
@@ -251,11 +264,7 @@ export const TUTORIAL_GOALS: ReadonlyArray<TutorialGoal> = [
         id: "scavenge",
         label: "Scavenge a pallet",
         targets: [{ kind: "truck", part: "cab" }],
-        satisfied: (gameState) =>
-          countOf(gameState, isPallet) > 0 ||
-          hasShelfParts(gameState) ||
-          hasShelf(gameState) ||
-          soldFirstPiece(gameState),
+        satisfied: (gameState) => !needsFirstPallet(gameState),
       },
       {
         id: "dismantle",


### PR DESCRIPTION
Closes #146.

The guided opening points at two dice rolls, and both first outcomes are now fixed:

**First scavenging trip always yields a pallet.** `rollScavengeStops` already planted a find on an all-empty roll, but at a random stop — and only searched stops pay out, so calling the trip after one stop could still come home empty. While the shop has never had a pallet, the plant now goes to stop one. The condition (`needsFirstPallet`, extracted in `tutorial.ts`) is the same one the to-do card's scavenge step reads, so the guarantee and the card can't drift apart. The extra pallet roll comes after the circuit's own rolls, so scripted rng tapes (ShopDriver's `pristineFindsRng`, the unit tapes) read the same either way.

**The first piece set out at the stand sells right away** (per the retarget note on the issue, from listings to the #184 stand). Until `progression.salesCompleted > 0`, a stocked stand summons a customer immediately instead of waiting on the 1/30 spawn roll — one at a time, only while nobody already on the street could still make the sale — and the browse decision skips the 75% coin flip. From the second sale on, the street runs entirely on the dice. Night still holds customers off, as before.

## Tests

- Unit: guarantee plants at stop one on a washout, leaves a lucky circuit alone, applies only to a shop with no wood; the stand summons exactly one customer, never after a sale, always closes the first browse, and an end-to-end cold-rng run still reaches the first sale.
- Two existing tests updated because their premises are now impossible for a brand-new shop by design ("stays quiet over an empty-handed stop", "lets a browser walk away empty-handed") — each now runs against a shop with history.
- `npm run tsc`, all 1055 unit/sequence tests, and all 7 E2E specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)