### PR TITLE
Keep the coach's card up over the bench view

### DIFF
--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -31,9 +31,13 @@ export const HomePage: React.FC = () => {
  */
 const HomePageContent: React.FC = () => {
   // Leaned over a bench, the corner chips fade: the bench scene draws
-  // in the shop's canvas underneath them, and they were unreachable
+  // in the shop's canvas underneath them, and they'd be unreachable
   // behind the bench view's pointer surface anyway. The top bar stays —
-  // it deliberately rides above the bench view.
+  // it deliberately rides above the bench view — and so does the
+  // coach's card, because the guided opening's bench steps are read
+  // mid-dive: its column rises over the bench view and slides down its
+  // corner to clear the station nameplate. The one-time notes beneath
+  // it read the shop floor, so they fade with the rest.
   const benchDive = useBenchDiveActive();
   const chipClass = `transition-opacity duration-150 ${
     benchDive ? "opacity-0" : "opacity-100"
@@ -51,12 +55,15 @@ const HomePageContent: React.FC = () => {
       </div>
 
       <div
-        inert={benchDive}
-        className={`absolute left-6 top-6 z-20 w-80 space-y-3 ${chipClass}`}
+        className={`absolute left-6 w-80 space-y-3 transition-[top] duration-300 ${
+          benchDive ? "top-16 z-[36]" : "top-6 z-20"
+        }`}
       >
         <TutorialCard />
-        <DustTutorialCard />
-        <NightfallCard />
+        <div inert={benchDive} className={`space-y-3 ${chipClass}`}>
+          <DustTutorialCard />
+          <NightfallCard />
+        </div>
       </div>
 
       <div

--- a/tests/bench.spec.ts
+++ b/tests/bench.spec.ts
@@ -237,6 +237,26 @@ test.describe("Bench view", () => {
       }, stale);
     });
 
+    await test.step("the coach's card stays up over the bench view", async () => {
+      // The guided opening's bench steps are read mid-dive, so the
+      // card rides above the bench view instead of fading with the
+      // rest of the corner chips. The fixture retired the tutorial;
+      // wake it back up.
+      await page.evaluate(() => {
+        window.__UPDATE_GAME_STATE__((state: any) => ({
+          ...state,
+          progression: { ...state.progression, tutorialDismissed: false },
+        }));
+      });
+      const card = page.getByTestId("tutorial-card");
+      await expect(card).toBeVisible();
+      // A real click, not a visibility check: it fails if the card is
+      // ghosted behind the bench view's pointer surface or inert. It
+      // also puts the fixture's dismissed tutorial back.
+      await card.getByTestId("tutorial-skip").click();
+      await expect(card).toBeHidden();
+    });
+
     await test.step("right-click hangs the held tool back up", async () => {
       // At a bench the pointer is the hand, so letting go of a tool
       // shouldn't mean reaching for the keyboard. The binding is


### PR DESCRIPTION
Bench-view half of #147 — the tutorial card no longer vanishes when the player dives into a bench.

## What changed

- The card's HUD column in `HomePage` no longer fades/goes inert during the bench dive. While the dive is on, it rides above the bench view's portal (`z-[36]` over the sheet's `z-[35]`, still under the top bar's `z-40`) and slides down from `top-6` to `top-16` so it clears the station nameplate that occupies the same corner.
- The one-time notes that share the column (`DustTutorialCard`, `NightfallCard`) keep the old behavior — they read the shop floor, so they still fade with the rest of the chrome.

## Scope

Per discussion on #147, only the bench view. The trip overlays (store/lumberyard/scavenge) are left alone — where the card should sit over those pages is still undecided, so #147 stays open.

## Testing

- New `test.step` in `bench.spec.ts`: with the bench open, the card is visible and its Skip button takes a real click (which fails if the card is ghosted, inert, or under the pointer surface). Verified the step fails against the previous `HomePage`.
- Full suite green: unit + all seven E2E specs.
- Screenshot-checked both states: shop-floor placement unchanged; in the bench view the card sits just below the nameplate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)