### PR TITLE
Walk the body into the standard working stance when a bench view opens

### DIFF
--- a/docs/bench-work.md
+++ b/docs/bench-work.md
@@ -183,7 +183,11 @@ The world does not stop for the bench view. Overlays never stop the
 world (only the pause menu does), and the player is standing at the
 station the whole time — the planer keeps power-feeding, glue keeps
 curing, dust keeps settling. Movement keys are pinned until Tab steps
-back. **Dust and foley don't wait for the commit**: active stroking
+back, and opening the view walks the body into the standard working
+stance — centered on the bench's operation cell, squared up to the top
+(`workStance` in `player-motion.ts`, stepped by `PlayerMotionLayer`) —
+so the dive's zoomed-in look always finds the woodworker standing at
+the bench the way a person works at one. **Dust and foley don't wait for the commit**: active stroking
 dispatches a throttled dust-emission action so the dust simulation stays
 honest, and continuous tool foley runs UI-side with the completion
 stinger going through the `SoundEvent` queue as usual.

--- a/src/components/bench-view/BenchWorkSurface.tsx
+++ b/src/components/bench-view/BenchWorkSurface.tsx
@@ -1601,6 +1601,7 @@ export const BenchWorkSurface: React.FC<{
       // clock would otherwise think it already landed and never fire
       // onRest again).
       benchKey: diveKey,
+      bench: machine,
       sceneElement,
       frameFit,
       group,

--- a/src/components/bench-view/benchSceneSlot.ts
+++ b/src/components/bench-view/benchSceneSlot.ts
@@ -1,5 +1,6 @@
 import React from "react";
 import { BenchGroup } from "../../game/bench-work/bench-group";
+import { Machine } from "../../game/Machine";
 import { StageFit } from "./stageMath";
 
 /**
@@ -26,6 +27,12 @@ export interface BenchSceneSlot {
   readonly benchKey: string;
   /** The scene subtree (backdrop + work surface), closures and all. */
   readonly sceneElement: React.ReactNode;
+  /**
+   * The bench the player opened (the group member the view was entered
+   * through). PlayerMotionLayer walks the body into the standard working
+   * stance at this bench while the slot is leaning in.
+   */
+  readonly bench: Machine;
   /** The whole-frame fit: the dive's pivot and scale denominator. */
   readonly frameFit: StageFit;
   /** The bench run: anchor center and the un-turn angle. */

--- a/src/components/shop-view/PlayerMotionLayer.tsx
+++ b/src/components/shop-view/PlayerMotionLayer.tsx
@@ -5,11 +5,14 @@ import { collisionWorld } from "../../game/machine-collision";
 import { setPlayerPositionAction } from "../../game/game-actions/player-actions";
 import {
   directionFromInput,
+  headingForDirection,
   motionCell,
   playerWalkSpeed,
   stepPlayerMotion,
+  workStance,
 } from "../../game/player-motion";
 import { Direction, Vector, vectorEquals } from "../../game/Vectors";
+import { benchSceneSlot } from "../bench-view/benchSceneSlot";
 import { useApplyGameAction, useGameState } from "../useGameState";
 import { readHeldMovement } from "./heldMovementInput";
 import { playerMotion, snapPlayerMotionToCell } from "./playerMotionStore";
@@ -44,6 +47,12 @@ export const PlayerMotionLayer: React.FC<{ paused: boolean }> = ({
     direction: gameState.player.direction,
   });
 
+  // The dive (benchKey) whose step-in the body gave up on — wedged
+  // against something on the way to the stance. Remembered so a blocked
+  // walk doesn't shove at the obstacle every frame; a fresh dive tries
+  // again.
+  const stanceBlocked = useRef<string | null>(null);
+
   useEffect(() => {
     snapPlayerMotionToCell(stateRef.current.player.position);
     // The body should come up already facing the way the simulation says.
@@ -67,6 +76,66 @@ export const PlayerMotionLayer: React.FC<{ paused: boolean }> = ({
     const gs = stateRef.current;
     if (gs.player.away || pausedRef.current || (gs.player.busyTicks ?? 0) > 0) {
       playerMotion.moving = false;
+      return;
+    }
+
+    // Leaning over a bench pins the walk keys (ShopView), and the body
+    // steps into the standard working stance instead: centered on the
+    // bench's operation cell, squared up to the top, so the dive's
+    // zoomed-in look always finds the woodworker standing at the bench
+    // properly. Same collision step as walking — the body slides around
+    // whatever is in the way, and gives up rather than shoving if the
+    // way is truly blocked.
+    const lean = benchSceneSlot();
+    if (lean && lean.target === 1) {
+      const stance = workStance(lean.bench);
+      if (stance) {
+        playerMotion.heading = stance.heading;
+        const dx = stance.pos[0] - playerMotion.pos[0];
+        const dy = stance.pos[1] - playerMotion.pos[1];
+        const distance = Math.hypot(dx, dy);
+        if (distance < 0.01) {
+          playerMotion.pos = stance.pos;
+          playerMotion.moving = false;
+        } else if (stanceBlocked.current !== lean.benchKey) {
+          const speed = playerWalkSpeed(gs);
+          // Never overshoot: the last step is cut to land exactly on the
+          // stance. Reduced motion takes the whole way in one step, the
+          // same cut the dive's ramp takes.
+          const dt = lean.instant
+            ? distance / speed
+            : Math.min(ticker.deltaMS / 1000, 0.1, distance / speed);
+          const next = stepPlayerMotion(
+            playerMotion.pos,
+            [dx / distance, dy / distance],
+            speed,
+            dt,
+            collisionWorld(gs),
+          );
+          const remaining = Math.hypot(
+            stance.pos[0] - next[0],
+            stance.pos[1] - next[1],
+          );
+          if (remaining >= distance - 1e-6) {
+            stanceBlocked.current = lean.benchKey;
+          }
+          playerMotion.moving = remaining < distance - 1e-6;
+          playerMotion.pos = next;
+        } else {
+          playerMotion.moving = false;
+        }
+        // Facing the bench is the stance too, wherever the walk got to.
+        const cell = motionCell(playerMotion.pos);
+        if (
+          !vectorEquals(cell, lastSynced.current.cell) ||
+          stance.direction !== lastSynced.current.direction
+        ) {
+          lastSynced.current = { cell, direction: stance.direction };
+          applyAction(setPlayerPositionAction(cell, stance.direction));
+        }
+      } else {
+        playerMotion.moving = false;
+      }
       return;
     }
 
@@ -105,17 +174,3 @@ export const PlayerMotionLayer: React.FC<{ paused: boolean }> = ({
 
   return null;
 };
-
-/** The continuous heading matching a 4-way simulation direction. */
-function headingForDirection(direction: Direction): number {
-  switch (direction) {
-    case 0:
-      return 0;
-    case 1:
-      return -Math.PI / 2;
-    case 2:
-      return Math.PI;
-    case 3:
-      return Math.PI / 2;
-  }
-}

--- a/src/game/player-motion.test.ts
+++ b/src/game/player-motion.test.ts
@@ -1,19 +1,22 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
 import { initialGameState } from "./initialGameState";
+import { Machine } from "./Machine";
 import {
   BASE_WALK_SPEED,
   cellCenter,
   CollisionWorld,
   directionFromInput,
+  headingForDirection,
   motionCell,
   PLAYER_RADIUS,
   playerWalkSpeed,
   Solid,
   SolidBox,
   stepPlayerMotion,
+  workStance,
 } from "./player-motion";
-import { Vector } from "./Vectors";
+import { Direction, Vector } from "./Vectors";
 import { DUST_MAX_PER_CELL } from "./Dust";
 
 /** A roomy floor so wall clamping never interferes unless a test wants it. */
@@ -238,5 +241,56 @@ describe("motionCell / cellCenter", () => {
     assert.deepStrictEqual(motionCell(cellCenter([3, 7])), [3, 7]);
     assert.deepStrictEqual(motionCell([0.999, 2.001]), [0, 2]);
     assert.deepStrictEqual(motionCell([-0.2, 1.5]), [-1, 1]);
+  });
+});
+
+describe("workStance", () => {
+  const bench = (rotation: Direction): Machine =>
+    new Machine({
+      machineTypeId: "worktable1x2",
+      position: [4, 4],
+      rotation,
+      selectedOperationId: "none",
+      operationProgress: {
+        status: "notStarted",
+        phaseIndex: 0,
+        ticksRemaining: 0,
+      },
+      inputMaterials: [],
+      processingMaterials: [],
+      outputMaterials: [],
+      tools: [],
+    });
+
+  it("stands centered on the operation cell, facing the bench, at every rotation", () => {
+    // worktable1x2: 4×2 footprint, operation cell mid-front ([1, 2] local)
+    const cases: Array<{
+      rotation: Direction;
+      pos: Vector;
+      direction: Direction;
+    }> = [
+      { rotation: 0, pos: [5.5, 6.5], direction: 1 },
+      { rotation: 1, pos: [6.5, 3.5], direction: 2 },
+      { rotation: 2, pos: [3.5, 2.5], direction: 3 },
+      { rotation: 3, pos: [2.5, 5.5], direction: 0 },
+    ];
+    for (const { rotation, pos, direction } of cases) {
+      const stance = workStance(bench(rotation));
+      assert.ok(stance, `rotation ${rotation}`);
+      assert.deepStrictEqual(stance.pos, pos, `rotation ${rotation}`);
+      assert.strictEqual(stance.direction, direction, `rotation ${rotation}`);
+      assert.strictEqual(
+        stance.heading,
+        headingForDirection(direction),
+        `rotation ${rotation}`,
+      );
+    }
+  });
+
+  it("returns null for a station with no operation position", () => {
+    assert.strictEqual(
+      workStance({ absoluteOperationPosition: null, occupiedCells: [[0, 0]] }),
+      null,
+    );
   });
 });

--- a/src/game/player-motion.ts
+++ b/src/game/player-motion.ts
@@ -257,3 +257,60 @@ export function motionCell([x, y]: Vector): Vector {
 export function cellCenter([x, y]: Vector): Vector {
   return [x + 0.5, y + 0.5];
 }
+
+/** The continuous heading matching a 4-way simulation direction. */
+export function headingForDirection(direction: Direction): number {
+  switch (direction) {
+    case 0:
+      return 0;
+    case 1:
+      return -Math.PI / 2;
+    case 2:
+      return Math.PI;
+    case 3:
+      return Math.PI / 2;
+  }
+}
+
+/** Where the body stands and faces while working at a station. */
+export interface WorkStance {
+  /** Body center, in continuous cell coordinates. */
+  readonly pos: Vector;
+  /** Facing, in radians (playerMotion's convention). */
+  readonly heading: number;
+  /** The same facing as the simulation's 4-way direction. */
+  readonly direction: Direction;
+}
+
+/**
+ * The standard working stance at a station: body centered on the
+ * operation cell, squared up to face the footprint. The bench view walks
+ * the body into this stance as the camera dives in, so the zoomed-in
+ * look always finds the woodworker standing at the bench the way a
+ * person works at one, whatever angle they shuffled up at.
+ */
+export function workStance(station: {
+  readonly absoluteOperationPosition: Vector | null;
+  readonly occupiedCells: Vector[];
+}): WorkStance | null {
+  const cell = station.absoluteOperationPosition;
+  if (cell === null || station.occupiedCells.length === 0) {
+    return null;
+  }
+  const pos = cellCenter(cell);
+  // Face the footprint's middle, quantized to the dominant axis: the
+  // operation cell can sit off the footprint's centerline (a wide bench),
+  // and the stance still squares up rather than facing a corner.
+  let sumX = 0;
+  let sumY = 0;
+  for (const occupied of station.occupiedCells) {
+    sumX += occupied[0] + 0.5;
+    sumY += occupied[1] + 0.5;
+  }
+  const count = station.occupiedCells.length;
+  const direction = directionFromInput(
+    [sumX / count - pos[0], sumY / count - pos[1]],
+    1,
+  );
+  return { pos, heading: headingForDirection(direction), direction };
+}

--- a/tests/bench.spec.ts
+++ b/tests/bench.spec.ts
@@ -183,9 +183,33 @@ test.describe("Bench view", () => {
     });
 
     await test.step("Tab spreads the bench open onto the scene — no plan for tool work", async () => {
+      // Park the player a cell to the side of the operation cell, facing
+      // away, so the stance walk below has somewhere to walk from.
+      await page.evaluate(() => {
+        window.__UPDATE_GAME_STATE__((state: any) => ({
+          ...state,
+          player: { ...state.player, position: [2, 4], direction: 0 },
+        }));
+      });
+      await page.waitForTimeout(50);
       await blur();
       await page.keyboard.press("Tab");
       await expect(page.getByTestId("station-sheet")).toBeVisible();
+      // Opening the view walks the body into the standard working
+      // stance — centered on the bench's operation cell, squared up to
+      // face the top — so the zoomed-in look finds the woodworker
+      // standing at the bench properly.
+      await expect
+        .poll(() =>
+          page.evaluate(() => {
+            const s = window.__GET_GAME_STATE__();
+            return {
+              position: s.player.position,
+              direction: s.player.direction,
+            };
+          }),
+        )
+        .toEqual({ position: [1, 4], direction: 1 });
       // Tool work isn't a plan: the stale Sand Board selection in the
       // fixture is inert, the bench opens idle with the board lying on
       // it, and the plan pile holds only builds — no sanding sheet


### PR DESCRIPTION
## What

When the player opens a bench (Tab), the body now walks itself into the standard working stance — centered on the bench's operation cell, squared up to face the top — while the camera dives in. The bench view's backdrop is the live shop, so the zoomed-in look now always finds the woodworker standing at the bench the way a person works at one, instead of frozen at whatever angle they shuffled up at.

## How

- `workStance` (`src/game/player-motion.ts`): pure helper — operation cell center plus the facing that squares up to the footprint (dominant axis toward the footprint's middle, so wide benches don't face a corner). `headingForDirection` moved here from `PlayerMotionLayer` and is exported.
- `PlayerMotionLayer`: while the bench scene slot is leaning in (`target === 1`), the body steps toward the stance using the same collision-resolved `stepPlayerMotion` as walking — it slides around obstacles, never overshoots (the last step is cut to land exactly), gives up rather than shoving if truly blocked, and takes the whole way in one step under reduced motion. Cell/direction sync goes through the layer's existing `lastSynced` bookkeeping, so the teleport-reconciliation path never fights the glide.
- `benchSceneSlot` now carries the opened bench (`bench: Machine`), published by `BenchWorkSurface`, so the motion layer knows which member of a bench run the player entered through.

## Tests

- Unit: `workStance` at all four rotations + the no-operation-position null case (`player-motion.test.ts`).
- E2E: `bench.spec.ts` now parks the player a cell aside facing away before Tab and asserts the stance lands (`position [1,4]`, facing the bench).
- `npm run tsc`, full unit suite (1057 passing), and all seven Playwright specs pass. floor.spec's 30s load-budget check flaked once mid-verification; it passes on re-run and on unmodified main — the known environment flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)