### PR TITLE
Plans UI Overhaul: the full-screen plan drawer

### DIFF
--- a/docs/bench-work.md
+++ b/docs/bench-work.md
@@ -44,7 +44,9 @@ per-operation scripts that compose it.
    hands the workpiece's spot to its outputs (`inheritedBenchLayout`) — a
    sanded board doesn't move, a sawn board parts into two pieces lying
    end to end at the mark. Plans survive only where they genuinely choose
-   between products: assembly builds, picked from the blueprint pile.
+   between products: assembly builds, pulled from the plan drawer
+   (`PlanBrowser`, listed by skill from `bench-work/plan-registry.ts`
+   rather than by what's mounted).
    Glue-ups are plan-free — clamps-first (`bench-work/glue-up.ts`): bar
    clamps set out on the top, glue-ready stock laid across them edge to
    edge, the contiguous run deciding the credited recipe
@@ -64,8 +66,8 @@ per-operation scripts that compose it.
    machines, whose whole interface is the floor, and to the garbage can,
    which empties where it stands. A bench answers none of it: out there
    it is a table you set stock on, take stock off, and carry, plus the
-   one door in. Q survives as the bench view's own key, thumbing the
-   blueprint pile with the drawing in front of you.
+   one door in. Q survives as the bench view's own key, opening the plan
+   drawer with the bench in front of you.
 2. **Performance affects speed, never quality.** A sloppy pass takes more
    strokes; it never produces a worse board. Outputs are computed from
    inputs and parameters (`Operation.output`), so material identity,

--- a/src/components/bench-view/BenchWorkSurface.tsx
+++ b/src/components/bench-view/BenchWorkSurface.tsx
@@ -2241,7 +2241,9 @@ export const BenchWorkSurface: React.FC<{
 
         {/* The plans pile in the corner and whatever the bench keeps
           underneath — the whole of the old paperwork card that survived */}
-        {isBench && <BlueprintCorner machine={machine} />}
+        {isBench && (
+          <BlueprintCorner machine={machine} keysEnabled={interactive} />
+        )}
         {isBench && <UnderBenchPanel machine={machine} />}
 
         {/* Instruction and key hints, floating below the bench */}

--- a/src/components/bench-view/BlueprintCorner.tsx
+++ b/src/components/bench-view/BlueprintCorner.tsx
@@ -1,53 +1,38 @@
 import React, { useState } from "react";
+import { Machine, operationParameters } from "../../game/Machine";
+import { selectedBenchPlan } from "../../game/bench-work/tool-work";
+import { unlockedBenchPlans } from "../../game/bench-work/plan-registry";
 import {
-  defaultParametersFor,
-  Machine,
-  Operation,
-  operationParameters,
-} from "../../game/Machine";
-import { stationWorkSpeed } from "../../game/bench-mounting";
-import { isToolWork, selectedBenchPlan } from "../../game/bench-work/tool-work";
-import { machineDustMultiplier } from "../../game/Dust";
-import { MACHINE_ARTICLES } from "../../game/manual";
-import { setMachineOperationAction } from "../../game/game-actions/player-actions";
+  clearMachineOperationAction,
+  setMachineOperationAction,
+} from "../../game/game-actions/player-actions";
 import { parameterValueSatisfiable } from "../../game/machine-helpers";
-import {
-  availableOperations,
-  getOperationDuration,
-} from "../../game/skill-helpers";
-import { formatDuration } from "../../game/time";
-import { classNames } from "../../utils/classNames";
-import {
-  BLUEPRINT_BLUE,
-  BLUEPRINT_BLUE_DEEP,
-  BlueprintSheet,
-} from "../station/BlueprintStack";
-import { MachineManualLink } from "../station/racks";
+import { BLUEPRINT_BLUE, BLUEPRINT_BLUE_DEEP } from "../station/BlueprintStack";
 import { ParameterScaleRow } from "../station/ParameterScaleRow";
 import { loadedStockDimension } from "../station/station-helpers";
 import { ShortcutKeys } from "../shortcuts/Kbd";
+import { useShortcut } from "../shortcuts/ShortcutProvider";
 import { useTargetedMachine } from "../TargetedMachineContext";
 import { useApplyGameAction, useGameState } from "../useGameState";
+import { PlanBrowser } from "./PlanBrowser";
 
 /**
  * The bench's plans, as the thing they diegetically are: a pile of shop
- * drawings sitting in the corner of the bench view. Folded, it's just
- * the pile (and the name of whatever drawing is set out); unfolded, the
- * pulled sheet lies on top — blueprint blue, white line work, a title
- * block reading supplies against the shop's stock — with the rest of
- * the stack showing as sheet edges below it. Pulling a sheet IS
- * selecting the plan; its ghost outlines land on the bench top. There
- * is no input/output diagram and no separate paperwork card: a bench
- * top holds stock, not bays.
+ * drawings sitting in the corner of the bench view. The pile itself is a
+ * small chip naming whatever drawing is set out (with a put-back button
+ * to return it — the ghosts leave the bench with it); clicking the pile,
+ * or Q, spreads the whole drawer across the view (PlanBrowser), where
+ * drawings are filed under category tabs and pulled by name. Pulling a
+ * sheet IS selecting the plan; its ghost outlines land on the bench top.
  *
- * Every sheet edge carries `data-mode-option`, exactly once per
- * operation name, and the fold toggle carries `aria-expanded`, so the
- * spec helpers that drive plan selection (tests/machine-panel.ts) work
- * here unchanged.
+ * The chip carries `aria-expanded` and the browser marks every plan name
+ * with `data-mode-option`, exactly once, so the spec helpers that drive
+ * plan selection (tests/machine-panel.ts) keep working here.
  */
-export const BlueprintCorner: React.FC<{ machine: Machine }> = ({
-  machine,
-}) => {
+export const BlueprintCorner: React.FC<{
+  machine: Machine;
+  keysEnabled?: boolean;
+}> = ({ machine, keysEnabled = true }) => {
   const gameState = useGameState();
   const applyAction = useApplyGameAction();
   const { isTargeted } = useTargetedMachine();
@@ -57,206 +42,122 @@ export const BlueprintCorner: React.FC<{ machine: Machine }> = ({
   // tool offers its strokes and cuts, all on the bench top itself
   // (bench-work/tool-work.ts), and glue-ups are clamps-first — the run
   // lying in the clamps decides the composition (bench-work/glue-up.ts).
-  // So the pile lists only assembly builds, and never honors a stale
-  // selection of the plan-free kinds (old saves may carry one).
-  const operations = availableOperations(machine, gameState.progression).filter(
-    (op) => !isToolWork(op),
-  );
+  // The drawer holds only assembly builds, listed by skill from the plan
+  // registry rather than by what's mounted.
+  const plans = unlockedBenchPlans(gameState.progression);
   const selected = selectedBenchPlan(machine);
   // A running job resolves against the plan and settings it finds when
   // it finishes, so both hold still until the work comes off.
-  const working = machine.operationProgress.status === "inProgress";
-  const dustMultiplier = machineDustMultiplier(
-    gameState.dust,
-    machine,
-    gameState.shopInfo.size,
+  const working = machine.state.operationProgress.status === "inProgress";
+
+  // Q opens and closes the drawer — the drawer's open state lives here,
+  // so the key does too (registered only while the bench view is up).
+  useShortcut(
+    "open-plan-browser",
+    () => setOpen((current) => !current),
+    keysEnabled && plans.length > 0,
   );
 
-  if (operations.length === 0) {
+  if (plans.length === 0) {
     return null;
   }
 
   const params = selected ? operationParameters(selected) : [];
-  // The manual pointer only earns its paper chip once the article exists
-  // and has been unlocked (ManualLink itself renders nothing otherwise)
-  const article = MACHINE_ARTICLES[machine.state.machineTypeId];
-  const manualUnlocked =
-    article != null && gameState.progression.unlockedArticles.includes(article);
 
   return (
-    <div className="pointer-events-auto absolute bottom-5 right-4 z-10 flex w-80 max-w-[85vw] flex-col items-stretch gap-1.5">
-      {open && (
-        <div className="max-h-[62vh] space-y-1.5 overflow-y-auto rounded-sm bg-ink-black/75 p-1.5 shadow-xl">
-          {selected ? (
-            <BlueprintSheet
-              operation={selected}
-              machine={machine}
-              locked={working}
-            />
-          ) : (
-            <div
-              className="rounded-sm border-2 border-dashed px-3 py-4 text-center font-condensed uppercase tracking-[0.15em] text-[0.65rem] text-white/60"
-              style={{ borderColor: "rgba(232,238,245,0.35)" }}
-            >
-              Pull a drawing from the stack
-            </div>
-          )}
+    <>
+      {open && <PlanBrowser machine={machine} onClose={() => setOpen(false)} />}
 
-          {/* Settings ride the pulled drawing on a paper strip — the one
-              piece of the old card a drawing can't carry in its margins */}
-          {selected && params.length > 0 && (
-            <div className="paper-card space-y-2 !p-2">
-              {params.map((param, index) => (
-                <ParameterScaleRow
-                  key={param.id}
-                  param={param}
-                  value={
-                    machine.selectedParameters?.[param.id] ??
-                    param.defaultValue ??
-                    param.values[0]
-                  }
-                  showShortcut={index === 0 && isTargeted(machine)}
-                  locked={working}
-                  onSelect={(value) =>
-                    applyAction(
-                      setMachineOperationAction(machine, selected, {
-                        ...machine.selectedParameters,
-                        [param.id]: value,
-                      }),
-                    )
-                  }
-                  satisfiable={(value) =>
-                    parameterValueSatisfiable(
-                      machine,
-                      selected,
-                      param.id,
-                      value,
-                    )
-                  }
-                  stockValue={loadedStockDimension(machine, param.id)}
-                />
-              ))}
-            </div>
-          )}
+      <div className="pointer-events-auto absolute bottom-5 right-4 z-10 flex w-80 max-w-[85vw] flex-col items-stretch gap-1.5">
+        {/* Settings ride the pulled drawing on a paper strip — the one
+            piece of the plan a chip can't carry in its margins */}
+        {selected && params.length > 0 && (
+          <div className="paper-card space-y-2 !p-2">
+            {params.map((param, index) => (
+              <ParameterScaleRow
+                key={param.id}
+                param={param}
+                value={
+                  machine.state.selectedParameters?.[param.id] ??
+                  param.defaultValue ??
+                  param.values[0]
+                }
+                showShortcut={index === 0 && isTargeted(machine)}
+                locked={working}
+                onSelect={(value) =>
+                  applyAction(
+                    setMachineOperationAction(machine, selected, {
+                      ...machine.state.selectedParameters,
+                      [param.id]: value,
+                    }),
+                  )
+                }
+                satisfiable={(value) =>
+                  parameterValueSatisfiable(machine, selected, param.id, value)
+                }
+                stockValue={loadedStockDimension(machine, param.id)}
+              />
+            ))}
+          </div>
+        )}
 
-          {/* The rest of the stack: sheet edges sticking out under the
-              pulled drawing, one per plan, thumbed through by clicking */}
-          <ul
-            className="rounded-b-sm shadow-inner"
-            data-testid="blueprint-stack"
+        {/* The pile itself: click (or Q) to spread the drawer open */}
+        <div className="ml-auto flex items-center gap-1.5">
+          <button
+            type="button"
+            aria-expanded={open}
+            data-testid="blueprint-corner"
+            onClick={() => setOpen((current) => !current)}
+            className="group flex items-center gap-2.5 rounded bg-ink-black/70 px-2.5 py-1.5 shadow-lg hover:bg-ink-black/80"
           >
-            {operations.map((operation, index) => {
-              const isSelected = operation === selected;
-              return (
-                <li key={operation.id}>
-                  <button
-                    disabled={working}
-                    data-sfx="ui-page-turn"
-                    onClick={() =>
-                      applyAction(
-                        setMachineOperationAction(
-                          machine,
-                          operation,
-                          defaultParametersFor(operation),
-                        ),
-                      )
-                    }
-                    className={classNames(
-                      "flex w-full items-baseline justify-between gap-2 border-b px-2 py-0.5 text-left",
-                      "border-[#0f2c47]/60",
-                      isSelected
-                        ? "text-white"
-                        : "text-[#bcd0e2] hover:text-white hover:brightness-110",
-                      working && "cursor-not-allowed opacity-70",
-                    )}
-                    style={{
-                      // Sheets deeper in the pile read a shade darker
-                      backgroundColor:
-                        index % 2 === 0 ? BLUEPRINT_BLUE : BLUEPRINT_BLUE_DEEP,
-                    }}
-                  >
-                    <span className="flex min-w-0 items-baseline gap-1.5">
-                      {isSelected && (
-                        <span aria-hidden className="shrink-0 text-[0.6rem]">
-                          ▸
-                        </span>
-                      )}
-                      <span
-                        data-mode-option
-                        className={classNames(
-                          "truncate font-condensed",
-                          isSelected && "font-semibold",
-                        )}
-                      >
-                        {operation.name}
-                      </span>
-                    </span>
-                    <span className="shrink-0 font-condensed text-[0.62rem] tabular-nums opacity-70">
-                      {formatDuration(
-                        getOperationDuration(
-                          operation,
-                          gameState.progression,
-                          dustMultiplier,
-                          stationWorkSpeed(machine, gameState),
-                        ),
-                      )}
-                    </span>
-                  </button>
-                </li>
-              );
-            })}
-          </ul>
-
-          {manualUnlocked && (
-            <div className="flex justify-end px-1 pb-0.5">
-              <span className="rounded bg-paper-manila/90 px-1.5 py-0.5">
-                <MachineManualLink machine={machine} />
+            <span aria-hidden className="relative block h-9 w-12">
+              {[
+                { rotate: -6, dx: -2, dy: 1, deep: true },
+                { rotate: 3, dx: 2, dy: 0, deep: false },
+                { rotate: -1, dx: 0, dy: -1, deep: false },
+              ].map((sheet, index) => (
+                <span
+                  key={index}
+                  className="absolute inset-0 rounded-[2px] border border-white/35 shadow"
+                  style={{
+                    backgroundColor: sheet.deep
+                      ? BLUEPRINT_BLUE_DEEP
+                      : BLUEPRINT_BLUE,
+                    transform: `translate(${sheet.dx}px, ${sheet.dy}px) rotate(${sheet.rotate}deg)`,
+                  }}
+                >
+                  <span className="absolute inset-[3px] border border-white/25" />
+                </span>
+              ))}
+            </span>
+            <span className="flex flex-col items-start">
+              <span className="flex items-center gap-1.5 font-condensed uppercase tracking-[0.15em] text-[0.6rem] text-paper-manila/60">
+                Plans
+                {isTargeted(machine) && (
+                  <ShortcutKeys shortcut="open-plan-browser" />
+                )}
               </span>
-            </div>
+              <span className="max-w-44 truncate font-condensed uppercase tracking-wide text-[0.72rem] text-paper-manila">
+                {selected ? selected.name : "Pull a drawing"}
+              </span>
+            </span>
+          </button>
+          {selected && (
+            <button
+              type="button"
+              data-testid="put-back-plan-chip"
+              data-sfx="ui-page-turn"
+              disabled={working}
+              onClick={() => applyAction(clearMachineOperationAction(machine))}
+              aria-label="Put the drawing back"
+              title="Put the drawing back"
+              className="rounded border border-paper-manila/40 bg-ink-black/70 px-1.5 py-1.5 text-xs leading-none text-paper-manila/80 shadow-lg hover:bg-ink-black/80 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              ✕
+            </button>
           )}
         </div>
-      )}
-
-      {/* The pile itself: fold and unfold the corner */}
-      <button
-        type="button"
-        aria-expanded={open}
-        data-testid="blueprint-corner"
-        onClick={() => setOpen((current) => !current)}
-        className="group ml-auto flex items-center gap-2.5 rounded bg-ink-black/70 px-2.5 py-1.5 shadow-lg hover:bg-ink-black/80"
-      >
-        <span aria-hidden className="relative block h-9 w-12">
-          {[
-            { rotate: -6, dx: -2, dy: 1, deep: true },
-            { rotate: 3, dx: 2, dy: 0, deep: false },
-            { rotate: -1, dx: 0, dy: -1, deep: false },
-          ].map((sheet, index) => (
-            <span
-              key={index}
-              className="absolute inset-0 rounded-[2px] border border-white/35 shadow"
-              style={{
-                backgroundColor: sheet.deep
-                  ? BLUEPRINT_BLUE_DEEP
-                  : BLUEPRINT_BLUE,
-                transform: `translate(${sheet.dx}px, ${sheet.dy}px) rotate(${sheet.rotate}deg)`,
-              }}
-            >
-              <span className="absolute inset-[3px] border border-white/25" />
-            </span>
-          ))}
-        </span>
-        <span className="flex flex-col items-start">
-          <span className="flex items-center gap-1.5 font-condensed uppercase tracking-[0.15em] text-[0.6rem] text-paper-manila/60">
-            Plans
-            {isTargeted(machine) && !working && operations.length > 1 && (
-              <ShortcutKeys shortcut="cycle-operation" />
-            )}
-          </span>
-          <span className="max-w-44 truncate font-condensed uppercase tracking-wide text-[0.72rem] text-paper-manila">
-            {selected ? selected.name : "Pull a drawing"}
-          </span>
-        </span>
-      </button>
-    </div>
+      </div>
+    </>
   );
 };

--- a/src/components/bench-view/PlanBrowser.tsx
+++ b/src/components/bench-view/PlanBrowser.tsx
@@ -1,0 +1,370 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { defaultParametersFor, Machine } from "../../game/Machine";
+import { stationWorkSpeed } from "../../game/bench-mounting";
+import { machineDustMultiplier } from "../../game/Dust";
+import {
+  planReadiness,
+  PlanReadiness,
+} from "../../game/bench-work/plan-readiness";
+import {
+  BenchPlan,
+  PLAN_CATEGORIES,
+  unlockedBenchPlans,
+} from "../../game/bench-work/plan-registry";
+import { selectedBenchPlan } from "../../game/bench-work/tool-work";
+import {
+  clearMachineOperationAction,
+  setMachineOperationAction,
+} from "../../game/game-actions/player-actions";
+import { getOperationDuration } from "../../game/skill-helpers";
+import { formatDuration } from "../../game/time";
+import { classNames } from "../../utils/classNames";
+import {
+  BLUEPRINT_BLUE,
+  BLUEPRINT_BLUE_DEEP,
+  BlueprintSchematic,
+  BlueprintSheet,
+  ReadinessStamp,
+} from "../station/BlueprintStack";
+import { MachineManualLink } from "../station/racks";
+import { useApplyGameAction, useGameState } from "../useGameState";
+
+/**
+ * The plan drawer, spread out: every assembly build the player's skills
+ * unlock, filed under manila category tabs, each drawing a thumbnail of
+ * its own schematic with a READY/SHORT stamp. Clicking a drawing sets it
+ * out for reading — full schematic, the bill of materials against the
+ * shop's stock, the margin note — and pulling it selects the plan and
+ * closes the drawer. Listing comes from the plan registry, not the
+ * bench's mounted tools, so a build whose driver is in the drawers still
+ * shows, wearing the missing tool as a shortfall.
+ *
+ * Test contract (tests/machine-panel.ts): each plan's name carries
+ * `data-mode-option` exactly once, and the focused drawing's pull button
+ * is `data-testid="pull-plan"`.
+ */
+export const PlanBrowser: React.FC<{
+  machine: Machine;
+  onClose: () => void;
+}> = ({ machine, onClose }) => {
+  const gameState = useGameState();
+  const applyAction = useApplyGameAction();
+  const working = machine.state.operationProgress.status === "inProgress";
+  const selected = selectedBenchPlan(machine);
+
+  const plans = useMemo(
+    () => unlockedBenchPlans(gameState.progression),
+    [gameState.progression],
+  );
+  const readinessById = useMemo(() => {
+    const map = new Map<string, PlanReadiness>();
+    for (const plan of plans) {
+      map.set(plan.operation.id, planReadiness(gameState, machine, plan));
+    }
+    return map;
+  }, [gameState, machine, plans]);
+
+  const categories = PLAN_CATEGORIES.filter((category) =>
+    plans.some((plan) => plan.category === category.id),
+  );
+
+  const [focusedId, setFocusedId] = useState<string | null>(
+    selected?.id ?? plans[0]?.operation.id ?? null,
+  );
+  const focused =
+    plans.find((plan) => plan.operation.id === focusedId) ?? plans[0] ?? null;
+
+  const dustMultiplier = machineDustMultiplier(
+    gameState.dust,
+    machine,
+    gameState.shopInfo.size,
+  );
+  const workSpeed = stationWorkSpeed(machine, gameState);
+
+  const pull = (plan: BenchPlan) => {
+    if (working) return;
+    applyAction(
+      setMachineOperationAction(
+        machine,
+        plan.operation,
+        defaultParametersFor(plan.operation),
+      ),
+    );
+    onClose();
+  };
+
+  const putBack = () => {
+    if (working) return;
+    applyAction(clearMachineOperationAction(machine));
+  };
+
+  // The drawer owns the keyboard while it's open: arrows walk the
+  // drawings, Enter pulls, Esc closes. stopPropagation keeps Esc from
+  // also backing out of the bench view underneath; Q is deliberately
+  // let through — the same key that opened the drawer closes it
+  // (BlueprintCorner's shortcut).
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const thumbRefs = useRef(new Map<string, HTMLButtonElement>());
+  const groupRefs = useRef(new Map<string, HTMLDivElement>());
+
+  useEffect(() => {
+    overlayRef.current?.focus();
+  }, []);
+
+  const moveFocus = (step: number) => {
+    if (plans.length === 0) return;
+    const index = plans.findIndex((plan) => plan.operation.id === focusedId);
+    const next =
+      plans[(index + step + plans.length) % plans.length] ?? plans[0];
+    setFocusedId(next.operation.id);
+    thumbRefs.current
+      .get(next.operation.id)
+      ?.scrollIntoView({ block: "nearest" });
+  };
+
+  const onKeyDown = (event: React.KeyboardEvent) => {
+    switch (event.key) {
+      case "Escape":
+        event.preventDefault();
+        event.stopPropagation();
+        onClose();
+        return;
+      case "ArrowRight":
+      case "ArrowDown":
+        event.preventDefault();
+        event.stopPropagation();
+        moveFocus(1);
+        return;
+      case "ArrowLeft":
+      case "ArrowUp":
+        event.preventDefault();
+        event.stopPropagation();
+        moveFocus(-1);
+        return;
+      case "Enter":
+        if (focused) {
+          event.preventDefault();
+          event.stopPropagation();
+          pull(focused);
+        }
+        return;
+    }
+  };
+
+  return (
+    <div
+      ref={overlayRef}
+      tabIndex={-1}
+      data-testid="plan-browser"
+      onKeyDown={onKeyDown}
+      className="pointer-events-auto absolute inset-0 z-20 flex flex-col bg-ink-black/90 outline-none"
+      onClick={onClose}
+    >
+      <div
+        className="mx-auto flex min-h-0 w-full max-w-6xl flex-1 flex-col p-4 pt-16"
+        onClick={(event) => event.stopPropagation()}
+      >
+        {/* The drawer's header rail */}
+        <div className="flex items-baseline gap-3 pb-2">
+          <h4 className="font-condensed text-lg font-bold uppercase tracking-wide text-paper-manila">
+            Plans
+          </h4>
+          <span className="font-condensed uppercase tracking-[0.15em] text-[0.62rem] text-paper-manila/50">
+            Pull a drawing to set it out on the bench
+          </span>
+          <span className="ml-auto flex items-center gap-3">
+            <span className="rounded bg-paper-manila/90 px-1.5 py-0.5">
+              <MachineManualLink machine={machine} />
+            </span>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close the plan drawer"
+              className="rounded border border-paper-manila/40 px-2 py-0.5 text-sm text-paper-manila/80 hover:bg-paper-manila/10"
+            >
+              ✕
+            </button>
+          </span>
+        </div>
+
+        <div className="flex min-h-0 flex-1 gap-4">
+          {/* Manila folder tabs, one per category with anything in it */}
+          <nav className="flex w-36 shrink-0 flex-col gap-1 pt-1">
+            {categories.map((category, index) => (
+              <button
+                key={category.id}
+                type="button"
+                onClick={() =>
+                  groupRefs.current
+                    .get(category.id)
+                    ?.scrollIntoView({ block: "start", behavior: "smooth" })
+                }
+                className="rounded-r-sm rounded-tl-lg border border-b-2 border-black/30 bg-paper-manila px-2.5 py-1.5 text-left font-condensed text-[0.72rem] font-semibold uppercase tracking-[0.12em] text-ink-black shadow hover:brightness-105"
+                style={{
+                  transform: `rotate(${index % 2 === 0 ? -0.6 : 0.5}deg)`,
+                }}
+              >
+                {category.label}
+                <span className="ml-1.5 tabular-nums text-ink-fade">
+                  {plans.filter((plan) => plan.category === category.id).length}
+                </span>
+              </button>
+            ))}
+          </nav>
+
+          {/* The drawings themselves, grouped under their dividers */}
+          <div
+            ref={scrollRef}
+            className="min-h-0 flex-1 space-y-4 overflow-y-auto pb-4 pr-1"
+          >
+            {categories.map((category) => (
+              <div
+                key={category.id}
+                ref={(el) => {
+                  if (el) groupRefs.current.set(category.id, el);
+                }}
+                className="scroll-mt-2"
+              >
+                <div className="mb-1.5 inline-block rounded-t border border-b-0 border-paper-manila/30 bg-paper-manila/15 px-3 py-0.5 font-condensed text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-paper-manila/80">
+                  {category.label}
+                </div>
+                <ul className="grid grid-cols-[repeat(auto-fill,minmax(10rem,1fr))] gap-3">
+                  {plans
+                    .filter((plan) => plan.category === category.id)
+                    .map((plan, index) => {
+                      const readiness = readinessById.get(plan.operation.id);
+                      const isFocused =
+                        focused?.operation.id === plan.operation.id;
+                      const isSelected = selected?.id === plan.operation.id;
+                      return (
+                        <li key={plan.operation.id}>
+                          <button
+                            ref={(el) => {
+                              if (el)
+                                thumbRefs.current.set(plan.operation.id, el);
+                            }}
+                            type="button"
+                            data-sfx="ui-page-turn"
+                            data-testid="plan-thumb"
+                            data-plan-id={plan.operation.id}
+                            onClick={() => setFocusedId(plan.operation.id)}
+                            onDoubleClick={() => pull(plan)}
+                            className={classNames(
+                              "relative block w-full rounded-[3px] border p-2 text-left shadow-md transition-transform",
+                              isFocused
+                                ? "border-white/80 shadow-lg"
+                                : "border-white/30 hover:border-white/60",
+                            )}
+                            style={{
+                              backgroundColor:
+                                index % 2 === 0
+                                  ? BLUEPRINT_BLUE
+                                  : BLUEPRINT_BLUE_DEEP,
+                              // Drawings tossed in a drawer, not printed
+                              // in a catalog: each sits a hair crooked
+                              transform: `rotate(${((index * 37) % 5) * 0.35 - 0.7}deg)`,
+                            }}
+                          >
+                            {/* The sheet's inner margin frame */}
+                            <span className="pointer-events-none absolute inset-1 border border-white/20" />
+                            {/* Dog-eared corner */}
+                            <span
+                              aria-hidden
+                              className="absolute right-0 top-0 h-3 w-3"
+                              style={{
+                                background:
+                                  "linear-gradient(225deg, rgba(10,20,32,0.9) 50%, rgba(232,238,245,0.28) 50%)",
+                              }}
+                            />
+                            {isSelected && (
+                              <span className="absolute left-1.5 top-1.5 rounded-sm bg-paper-manila px-1 font-condensed text-[0.55rem] font-bold uppercase tracking-[0.15em] text-ink-black">
+                                Out
+                              </span>
+                            )}
+                            {/* Tall drawings letterbox inside the card
+                                instead of spilling over their neighbors */}
+                            <span className="pointer-events-none mx-auto flex h-20 items-center justify-center overflow-hidden [&_svg]:h-full [&_svg]:max-h-full [&_svg]:w-full">
+                              <BlueprintSchematic blueprint={plan.blueprint} />
+                            </span>
+                            <span className="mt-1 flex items-baseline justify-between gap-1">
+                              <span
+                                data-mode-option
+                                className="truncate font-condensed text-[0.7rem] font-semibold uppercase tracking-wide text-white"
+                              >
+                                {plan.operation.name}
+                              </span>
+                              <span className="shrink-0 font-condensed text-[0.6rem] tabular-nums text-white/60">
+                                {formatDuration(
+                                  getOperationDuration(
+                                    plan.operation,
+                                    gameState.progression,
+                                    dustMultiplier,
+                                    workSpeed,
+                                  ),
+                                )}
+                              </span>
+                            </span>
+                            {readiness && (
+                              <span className="absolute -right-1 bottom-6">
+                                <ReadinessStamp ready={readiness.ready} />
+                              </span>
+                            )}
+                          </button>
+                        </li>
+                      );
+                    })}
+                </ul>
+              </div>
+            ))}
+          </div>
+
+          {/* The drawing set out for reading. The supplies tray rides
+              above the bench view in this corner, so take its live
+              footprint the way the glue panel does. */}
+          <div
+            className="hidden w-80 shrink-0 flex-col gap-2 overflow-y-auto md:flex xl:w-96"
+            style={{
+              marginTop: "calc(var(--supplies-clearance, 0px) + 1rem)",
+            }}
+          >
+            {focused && (
+              <>
+                <BlueprintSheet
+                  operation={focused.operation}
+                  machine={machine}
+                  locked={working}
+                  readiness={readinessById.get(focused.operation.id)}
+                  note={focused.note}
+                />
+                {selected?.id === focused.operation.id ? (
+                  <button
+                    type="button"
+                    data-testid="put-back-plan"
+                    data-sfx="ui-page-turn"
+                    disabled={working}
+                    onClick={putBack}
+                    className="rounded border border-paper-manila/50 px-3 py-1.5 font-condensed text-[0.72rem] font-semibold uppercase tracking-[0.15em] text-paper-manila hover:bg-paper-manila/10 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    Put the drawing back
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    data-testid="pull-plan"
+                    data-sfx="ui-page-turn"
+                    disabled={working}
+                    onClick={() => pull(focused)}
+                    className="rounded bg-paper-manila px-3 py-1.5 font-condensed text-[0.72rem] font-bold uppercase tracking-[0.15em] text-ink-black shadow hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    Pull this drawing
+                  </button>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/manual/articles/WelcomeArticle.tsx
+++ b/src/components/manual/articles/WelcomeArticle.tsx
@@ -62,8 +62,8 @@ export const WelcomeArticle: React.FC = () => (
         goes back in your tin.
       </li>
       <li>
-        With the wood already on the bench, switch its plan with{" "}
-        <ShortcutKeys shortcut="cycle-operation" /> to{" "}
+        With the wood already on the bench, open the plan drawer with{" "}
+        <ShortcutKeys shortcut="open-plan-browser" /> and pull{" "}
         <Term>Build Rustic Shelf</Term>: six pallet boards and eight of the
         salvaged nails. Set each piece on its outline, then drive the nails
         home.

--- a/src/components/manual/articles/WorkbenchesArticle.tsx
+++ b/src/components/manual/articles/WorkbenchesArticle.tsx
@@ -12,6 +12,22 @@ export const WorkbenchesArticle: React.FC = () => (
       six, depending on size.
     </P>
 
+    <H>Plans</H>
+    <P>
+      Assembly builds run off plans. Press{" "}
+      <ShortcutKeys shortcut="open-plan-browser" /> over a bench to open the
+      plan drawer. Drawings are filed by kind, and each one lists the stock,
+      fasteners, and tool it needs against what the shop has; a drawing stamped{" "}
+      <Term>Ready</Term> can start right away. Pull a drawing to set it out —
+      its part outlines land on the bench top. Lay each piece on its outline,
+      then drive the fasteners with the tool the plan calls for. Putting the
+      drawing back, from the drawer or the corner of the bench view, clears the
+      outlines.
+    </P>
+    <Note>
+      New plans come with skills — the journal shows what each teaches.
+    </Note>
+
     <H>Tools</H>
     <P>
       Tools are sold on the store's <Term>Tool Wall</Term>. Carry one to a bench

--- a/src/components/shop-view/ShopKeyboardShortcuts.tsx
+++ b/src/components/shop-view/ShopKeyboardShortcuts.tsx
@@ -1,11 +1,9 @@
 import React, { useRef } from "react";
 import {
-  defaultParametersFor,
   getMachines,
   hasFloorControls,
   isSameMachine,
 } from "../../game/Machine";
-import { isToolWork, selectedBenchPlan } from "../../game/bench-work/tool-work";
 import {
   dropMaterialAction,
   moveMaterialsToMachineAction,
@@ -360,48 +358,9 @@ export const ShopKeyboardShortcuts: React.FC = () => {
     present && !carrying && floorControls,
   );
 
-  // Q thumbs through the blueprint pile — the keyboard's version of
-  // pulling a drawing off the stack in the corner of the bench view,
-  // which is where its chip is drawn (BlueprintCorner) and the only
-  // place it fires. Direct-feed machines have no mode to cycle: the
-  // stock in hand decides what a feed does.
-  useShortcut(
-    "cycle-operation",
-    (event) => {
-      const machine = targeted.current;
-      if (!machine || machine.type.directFeed) return;
-
-      // The same list the pile shows: skill-locked recipes are hidden
-      // there and shouldn't be reachable from the keyboard either, and
-      // tool work isn't a plan at all (the staged pallet offers its
-      // nails, the held tool its strokes, cuts, and glue beads).
-      const operations = availableOperations(
-        machine,
-        gameState.current.progression,
-      ).filter((operation) => !isToolWork(operation));
-      if (operations.length === 0) return;
-
-      // An unset (or no-longer-available) selection cycles in from either
-      // end of the list rather than crashing or skipping an entry.
-      const selected = selectedBenchPlan(machine);
-      const operationIndex = selected ? operations.indexOf(selected) : -1;
-      const nextOperation =
-        operationIndex === -1
-          ? operations[event.shiftKey ? operations.length - 1 : 0]
-          : operations[
-              mod(operationIndex + (event.shiftKey ? -1 : 1), operations.length)
-            ];
-
-      applyAction(
-        setMachineOperationAction(
-          machine,
-          nextOperation,
-          defaultParametersFor(nextOperation),
-        ),
-      );
-    },
-    present && !stationWorking && settingKeysLive,
-  );
+  // Q — the plan drawer — is the bench view's own key: BlueprintCorner
+  // registers it (open-plan-browser), since the drawer's open state
+  // lives there. Out on the floor the key does nothing.
 
   // Step one of the machine's settings — the keyboard equivalent of the
   // scales on its card. `kind` picks which: "linear" is the one Z and X

--- a/src/components/station/BlueprintStack.tsx
+++ b/src/components/station/BlueprintStack.tsx
@@ -14,11 +14,16 @@ import {
   ProductBlueprint,
   slotFootprintIn,
 } from "../../game/bench-work/blueprint";
+import { PlanReadiness } from "../../game/bench-work/plan-readiness";
 import { rowLayout } from "../../game/bench-work/workpiece";
-import { createMockMaterial } from "../../game/material-helpers";
+import {
+  createMockMaterial,
+  describeMaterialRequirement,
+} from "../../game/material-helpers";
 import { describeOperationIO } from "../../game/operation-helpers";
 import { getOperationDuration } from "../../game/skill-helpers";
 import { formatDuration } from "../../game/time";
+import { TOOL_TYPES } from "../../game/Tool";
 import { useGameState } from "../useGameState";
 
 /**
@@ -38,12 +43,54 @@ const LINE = "#e8eef5";
 /** Warm callout that stays legible on blueprint blue. */
 const SHORTFALL = "#ffab6b";
 
-/** The pulled drawing: schematic, margin frame, and title block. */
+/** A rubber stamp in the drawing's corner: READY when the shop can
+ * start the build at this bench right now, SHORT otherwise. */
+export const ReadinessStamp: React.FC<{
+  ready: boolean;
+  className?: string;
+}> = ({ ready, className }) => (
+  <span
+    data-testid="plan-stamp"
+    data-ready={ready}
+    className={`pointer-events-none select-none rounded-sm border-2 px-1.5 py-0.5 font-stencil text-[0.6rem] font-bold uppercase tracking-[0.2em] ${className ?? ""}`}
+    style={{
+      color: ready ? "rgba(220,240,225,0.92)" : SHORTFALL,
+      borderColor: ready ? "rgba(220,240,225,0.75)" : SHORTFALL,
+      transform: "rotate(-8deg)",
+      opacity: 0.9,
+    }}
+  >
+    {ready ? "Ready" : "Short"}
+  </span>
+);
+
+/** How the tool line reads on the drawing, by where the tool is. */
+function toolLineText(readiness: PlanReadiness): string | null {
+  if (!readiness.tool) {
+    return null;
+  }
+  const name = TOOL_TYPES[readiness.tool.toolId].name;
+  switch (readiness.tool.status) {
+    case "mounted":
+      return `${name} — on this bench`;
+    case "inShop":
+      return `${name} — in the shop, mount it here`;
+    case "missing":
+      return `${name} — none in the shop`;
+  }
+}
+
+/** The pulled drawing: schematic, margin frame, and title block. When
+ * `readiness` is given, the title block reads the plan's whole bill —
+ * stock, supplies, and the driving tool — against what the shop has. */
 export const BlueprintSheet: React.FC<{
   operation: Operation;
   machine: Machine;
   locked?: boolean;
-}> = ({ operation, machine, locked }) => {
+  readiness?: PlanReadiness;
+  /** The pencil note in the drawing's margin. */
+  note?: string;
+}> = ({ operation, machine, locked, readiness, note }) => {
   const gameState = useGameState();
   const io = useMemo(() => describeOperationIO(operation), [operation]);
   const blueprint =
@@ -69,10 +116,22 @@ export const BlueprintSheet: React.FC<{
       <div className="pointer-events-none absolute inset-[7px] border border-white/20" />
 
       <div className="px-4 pb-3 pt-3">
+        {readiness && (
+          <div className="absolute right-3 top-3 z-10">
+            <ReadinessStamp ready={readiness.ready} />
+          </div>
+        )}
+
         {blueprint ? (
           <BlueprintSchematic blueprint={blueprint} />
         ) : (
           <IngredientSchematic operation={operation} />
+        )}
+
+        {note && (
+          <p className="px-1 pt-1 font-ink text-[0.78rem] leading-snug text-white/75 [transform:rotate(-0.6deg)]">
+            {note}
+          </p>
         )}
 
         {/* Title block, the way real drawings carry one */}
@@ -86,10 +145,41 @@ export const BlueprintSheet: React.FC<{
             </span>
           </div>
           <div className="space-y-0.5 px-2 py-1 font-condensed text-[0.62rem] leading-snug text-white/85">
-            <div>
-              {io.inputs.join(" + ")}
-              {io.outputs.length > 0 && ` → ${io.outputs.join(" + ")}`}
-            </div>
+            {readiness ? (
+              // The cutting list read against the shop's stock, one row
+              // per distinct requirement — a shortfall warms up
+              <ul data-testid="plan-bill">
+                {readiness.rows.map((row, index) => {
+                  const enough = row.have >= row.need;
+                  return (
+                    <li
+                      key={index}
+                      className="flex items-baseline justify-between gap-2"
+                    >
+                      <span className="min-w-0">
+                        {row.need}×{" "}
+                        {describeMaterialRequirement(row.requirement)}
+                      </span>
+                      <span
+                        className="shrink-0 tabular-nums"
+                        style={
+                          enough
+                            ? { color: "rgba(255,255,255,0.65)" }
+                            : { color: SHORTFALL }
+                        }
+                      >
+                        have {row.have}
+                      </span>
+                    </li>
+                  );
+                })}
+              </ul>
+            ) : (
+              <div>
+                {io.inputs.join(" + ")}
+                {io.outputs.length > 0 && ` → ${io.outputs.join(" + ")}`}
+              </div>
+            )}
             <div className="flex flex-wrap gap-x-3 text-white/65">
               <span className="tabular-nums">
                 {formatDuration(
@@ -132,6 +222,18 @@ export const BlueprintSheet: React.FC<{
                   , returned)
                 </span>
               )}
+              {readiness?.tool && (
+                <span
+                  data-testid="plan-tool-line"
+                  style={
+                    readiness.tool.status === "mounted"
+                      ? undefined
+                      : { color: SHORTFALL }
+                  }
+                >
+                  {toolLineText(readiness)}
+                </span>
+              )}
             </div>
           </div>
         </div>
@@ -142,8 +244,9 @@ export const BlueprintSheet: React.FC<{
 
 /** The real part layout, straight off the product blueprint: the same
  * slots the bench view's ghost outlines stand at, fasteners marked the
- * way a drawing calls out its nails. */
-const BlueprintSchematic: React.FC<{ blueprint: ProductBlueprint }> = ({
+ * way a drawing calls out its nails. Exported for the plan browser's
+ * thumbnails, which draw the same schematic small. */
+export const BlueprintSchematic: React.FC<{ blueprint: ProductBlueprint }> = ({
   blueprint,
 }) => {
   const pad = 3;

--- a/src/components/tutorial/TutorialCard.tsx
+++ b/src/components/tutorial/TutorialCard.tsx
@@ -195,7 +195,8 @@ const StepBody: React.FC<{ step: TutorialStepId }> = ({ step }) => {
       return (
         <p>
           You have the wood for a shelf: two thick stringers and three deck
-          boards. Load them at the bench, choose the plan{" "}
+          boards. Load them at the bench, open the plans with{" "}
+          <ShortcutKeys shortcut="open-plan-browser" /> and pull{" "}
           <em>Build Rustic Pallet Shelf</em>, then set each piece in place and
           drive the nails home.
         </p>

--- a/src/game/Skill.ts
+++ b/src/game/Skill.ts
@@ -23,6 +23,7 @@ export const SKILL_IDS = [
   "quickDryGlue",
   "rusticCarpentry",
   "rusticProjects",
+  "shopFurniture",
   "panelWork",
   "fineShelving",
   "boxJoinery",
@@ -85,7 +86,15 @@ export const SKILL_TYPES: Record<SkillId, SkillType> = {
     id: "rusticProjects",
     name: "Rustic Projects",
     description:
-      "The small stuff pallet wood is good for: birdhouses and slatted crates.",
+      "The small stuff pallet wood is good for: frames, planter boxes, step stools, birdhouses, and crates.",
+    branch: "joinery",
+    requires: ["rusticCarpentry"],
+  },
+  shopFurniture: {
+    id: "shopFurniture",
+    name: "Shop Furniture",
+    description:
+      "Building the shop's own fixtures: worktables, storage racks, and bench upgrades.",
     branch: "joinery",
     requires: ["rusticCarpentry"],
   },

--- a/src/game/bench-work/plan-readiness.ts
+++ b/src/game/bench-work/plan-readiness.ts
@@ -1,0 +1,132 @@
+import { ConsumableAmount } from "../Consumable";
+import { GameState } from "../GameState";
+import {
+  defaultParametersFor,
+  InputMaterialWithQuantity,
+  Machine,
+} from "../Machine";
+import { MaterialInstance } from "../Materials";
+import { materialMeetsInput } from "../material-helpers";
+import { ToolId } from "../Tool";
+import { fastenerToolId } from "./blueprint";
+import { BenchPlan } from "./plan-registry";
+
+/**
+ * What a plan needs against what the shop has, read shop-wide: hauling
+ * is cheap, so "it's across the room" is not a shortfall. Each
+ * requirement row counts independently — a board that would satisfy two
+ * rows counts in both, which errs on the encouraging side and keeps the
+ * readout legible.
+ */
+
+export interface PlanRequirementRow {
+  readonly requirement: InputMaterialWithQuantity;
+  readonly need: number;
+  readonly have: number;
+}
+
+export interface PlanConsumableRow {
+  readonly cost: ConsumableAmount;
+  readonly have: number;
+}
+
+/** Where the plan's driving tool is, nearest first: on this bench's
+ * rail, somewhere in the shop (another station's rail, a shelf, the
+ * floor, the truck), or not owned at all. */
+export type PlanToolStatus = "mounted" | "inShop" | "missing";
+
+export interface PlanToolRow {
+  readonly toolId: ToolId;
+  readonly status: PlanToolStatus;
+}
+
+export interface PlanReadiness {
+  readonly rows: ReadonlyArray<PlanRequirementRow>;
+  readonly consumables: ReadonlyArray<PlanConsumableRow>;
+  /** Null for a fastener-less build (the material shelf). */
+  readonly tool: PlanToolRow | null;
+  /** Everything above is satisfied: the build can start at this bench
+   * right now, give or take carrying the stock over. */
+  readonly ready: boolean;
+}
+
+/** Every loose material in the shop: floor piles, machine bays and
+ * shelves, the player's hands, and the truck's bed. */
+export function allShopMaterials(
+  gameState: GameState,
+): ReadonlyArray<MaterialInstance> {
+  return [
+    ...gameState.materialPiles.map((pile) => pile.material),
+    ...gameState.machines.flatMap((machine) => [
+      ...machine.inputMaterials,
+      ...machine.outputMaterials,
+      ...(machine.storedMaterials ?? []),
+    ]),
+    ...gameState.player.inventory,
+    ...gameState.truck.bed,
+  ];
+}
+
+function toolStatus(
+  gameState: GameState,
+  machine: Machine,
+  toolId: ToolId,
+): PlanToolStatus {
+  if (machine.state.tools.includes(toolId)) {
+    return "mounted";
+  }
+  const mountedElsewhere = gameState.machines.some((m) =>
+    m.tools.includes(toolId),
+  );
+  const looseInShop = allShopMaterials(gameState).some(
+    (material) => material.type === "tool" && material.toolId === toolId,
+  );
+  return mountedElsewhere || looseInShop ? "inShop" : "missing";
+}
+
+/** The plan's whole bill, read against the shop's stock. */
+export function planReadiness(
+  gameState: GameState,
+  machine: Machine,
+  plan: BenchPlan,
+): PlanReadiness {
+  const stock = allShopMaterials(gameState);
+  const rows = plan.operation
+    .getInputMaterials(defaultParametersFor(plan.operation))
+    .map((requirement) => ({
+      requirement,
+      need: requirement.quantity,
+      have: stock.filter((material) =>
+        materialMeetsInput(material, requirement),
+      ).length,
+    }));
+
+  const consumables = (plan.operation.requiredConsumables ?? []).map(
+    (cost) => ({
+      cost,
+      have: gameState.consumables[cost.id] ?? 0,
+    }),
+  );
+
+  const tool =
+    plan.blueprint.fasteners.length > 0
+      ? {
+          toolId: fastenerToolId(plan.blueprint.fastenerConsumable),
+          status: toolStatus(
+            gameState,
+            machine,
+            fastenerToolId(plan.blueprint.fastenerConsumable),
+          ),
+        }
+      : null;
+
+  return {
+    rows,
+    consumables,
+    tool,
+    ready:
+      rows.every((row) => row.have >= row.need) &&
+      consumables.every((row) => row.have >= row.cost.amount) &&
+      (tool === null || tool.status === "mounted"),
+  };
+}

--- a/src/game/bench-work/plan-registry.test.ts
+++ b/src/game/bench-work/plan-registry.test.ts
@@ -1,0 +1,149 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { handToolsShop } from "../../../tests/fixtures/hand-tools-shop";
+import { palletBoard } from "../board-helpers";
+import { GameState } from "../GameState";
+import { Machine } from "../Machine";
+import { STARTER_SKILLS } from "../Skill";
+import { TOOL_TYPES, ToolId } from "../Tool";
+import { BENCH_OPERATIONS } from "../machines/benchOperations";
+import { planReadiness } from "./plan-readiness";
+import {
+  ALL_BENCH_PLANS,
+  benchPlanForOperationId,
+  PLAN_CATEGORIES,
+  unlockedBenchPlans,
+} from "./plan-registry";
+
+describe("plan registry", () => {
+  it("files every assembly operation exactly once", () => {
+    const assemblyIds = [
+      ...BENCH_OPERATIONS,
+      ...(Object.keys(TOOL_TYPES) as ToolId[]).flatMap(
+        (toolId) => TOOL_TYPES[toolId].operations,
+      ),
+    ]
+      .filter((operation) => operation.interaction?.kind === "assembly")
+      .map((operation) => operation.id)
+      .sort();
+    const planIds = ALL_BENCH_PLANS.map((plan) => plan.operation.id).sort();
+    assert.deepEqual(planIds, assemblyIds);
+    assert.equal(new Set(planIds).size, planIds.length);
+  });
+
+  it("lists plans in category order", () => {
+    const order = PLAN_CATEGORIES.map((category) => category.id as string);
+    const seen = ALL_BENCH_PLANS.map((plan) => order.indexOf(plan.category));
+    assert.deepEqual(
+      seen,
+      [...seen].sort((a, b) => a - b),
+    );
+  });
+
+  it("keeps every plan's margin note in the manual's plain-note shape", () => {
+    for (const plan of ALL_BENCH_PLANS) {
+      assert.ok(plan.note.length > 0, `${plan.blueprintId} has no note`);
+      assert.ok(
+        plan.note.length < 90,
+        `${plan.blueprintId}'s note runs too long for a margin`,
+      );
+    }
+  });
+
+  it("a brand-new shop's drawer holds only the rustic shelf", () => {
+    const unlocked = unlockedBenchPlans({
+      unlockedSkills: STARTER_SKILLS,
+    } as never);
+    assert.deepEqual(
+      unlocked.map((plan) => plan.operation.id),
+      ["buildRusticPalletShelf"],
+    );
+  });
+
+  it("resolves an operation id to its plan, and non-plans to null", () => {
+    assert.equal(
+      benchPlanForOperationId("buildRusticPalletShelf")?.blueprintId,
+      "rusticShelf",
+    );
+    assert.equal(benchPlanForOperationId("handSawCut"), null);
+    assert.equal(benchPlanForOperationId("none"), null);
+  });
+});
+
+describe("plan readiness", () => {
+  const shelfPlan = benchPlanForOperationId("buildRusticPalletShelf")!;
+
+  function stateWith(overrides: (state: GameState) => GameState): GameState {
+    return overrides(handToolsShop as unknown as GameState);
+  }
+
+  function bench(state: GameState): Machine {
+    const machineState = state.machines.find(
+      (m) => m.machineTypeId === "workspace",
+    )!;
+    return new Machine(machineState);
+  }
+
+  it("reads the cutting list against shop-wide stock", () => {
+    const state = stateWith((s) => ({
+      ...s,
+      materialPiles: [
+        ...s.materialPiles,
+        ...Array.from({ length: 6 }, (_, i) => ({
+          material: palletBoard(),
+          position: [i, 0] as [number, number],
+          rotation: 0,
+        })),
+      ],
+      consumables: { ...s.consumables, nails: 8 },
+    }));
+    const readiness = planReadiness(state, bench(state), shelfPlan);
+    // Six identical slots fold to one row of six
+    assert.equal(readiness.rows.length, 1);
+    assert.equal(readiness.rows[0].need, 6);
+    assert.ok(readiness.rows[0].have >= 6);
+    assert.equal(readiness.consumables[0].cost.id, "nails");
+    // The hammer isn't on this fixture's bench, so the build can't start
+    assert.equal(readiness.tool?.toolId, "hammer");
+    assert.notEqual(readiness.tool?.status, "mounted");
+    assert.equal(readiness.ready, false);
+  });
+
+  it("goes ready when the driving tool is mounted and the bill is met", () => {
+    const state = stateWith((s) => ({
+      ...s,
+      machines: s.machines.map((m) =>
+        m.machineTypeId === "workspace" ? { ...m, tools: ["hammer"] } : m,
+      ),
+      materialPiles: [
+        ...s.materialPiles,
+        ...Array.from({ length: 6 }, (_, i) => ({
+          material: palletBoard(),
+          position: [i, 0] as [number, number],
+          rotation: 0,
+        })),
+      ],
+      consumables: { ...s.consumables, nails: 8 },
+    })) as GameState;
+    const readiness = planReadiness(state, bench(state), shelfPlan);
+    assert.equal(readiness.tool?.status, "mounted");
+    assert.equal(readiness.ready, true);
+  });
+
+  it("counts a loose tool item as in the shop", () => {
+    const state = stateWith((s) => ({
+      ...s,
+      // The fixture's truck bed carries no tools; the drill in the test
+      // above rides the bed in the sequence tests, so borrow that shape
+      truck: {
+        ...s.truck,
+        bed: [
+          ...s.truck.bed,
+          { id: "t1", type: "tool" as const, toolId: "hammer" as const },
+        ],
+      },
+    }));
+    const readiness = planReadiness(state, bench(state), shelfPlan);
+    assert.equal(readiness.tool?.status, "inShop");
+  });
+});

--- a/src/game/bench-work/plan-registry.ts
+++ b/src/game/bench-work/plan-registry.ts
@@ -1,0 +1,234 @@
+import { ProgressionState } from "../GameState";
+import { Operation } from "../Machine";
+import { hasSkill } from "../skill-helpers";
+import { TOOL_TYPES, ToolId } from "../Tool";
+import { BENCH_OPERATIONS } from "../machines/benchOperations";
+import {
+  BlueprintId,
+  ProductBlueprint,
+  productBlueprintFor,
+} from "./blueprint";
+
+/**
+ * The bench's plan drawer: every assembly build in the game, gathered
+ * from wherever its operation is declared (the shared bench list, the
+ * hammer, the drill) and filed under a category — the dividers the plan
+ * browser shows. This registry exists so the browser can list a plan by
+ * skill alone: a build whose driving tool isn't mounted still shows,
+ * wearing the tool as a missing supply, instead of vanishing with the
+ * tool (Machine.operations only knows what's mounted).
+ *
+ * A plan selected here may therefore name an operation the station
+ * can't currently offer; selectedBenchPlan (tool-work.ts) resolves
+ * through this registry for exactly that reason, and the commit path is
+ * naturally safe — driving a fastener needs the tool in hand, which
+ * needs it mounted.
+ */
+
+export const PLAN_CATEGORIES = [
+  { id: "rustic", label: "Rustic Projects" },
+  { id: "fineGoods", label: "Fine Goods" },
+  { id: "furniture", label: "Furniture" },
+  { id: "shopFurniture", label: "Shop Furniture" },
+  { id: "jigs", label: "Jigs" },
+] as const;
+
+export type PlanCategoryId = (typeof PLAN_CATEGORIES)[number]["id"];
+
+export function planCategoryLabel(id: PlanCategoryId): string {
+  const category = PLAN_CATEGORIES.find((entry) => entry.id === id);
+  return category ? category.label : id;
+}
+
+/**
+ * Where each blueprint files, plus the pencil note in the drawing's
+ * margin — the one place personality belongs (see the voice rules in
+ * docs/shop-manual.md). `plan-registry.test.ts` holds this map complete:
+ * every assembly operation's blueprint must have an entry.
+ */
+const PLAN_FACTS: Partial<
+  Record<BlueprintId, { category: PlanCategoryId; note: string }>
+> = {
+  // Rustic: pallet wood, nailed or screwed, sold off the stand
+  rusticShelf: {
+    category: "rustic",
+    note: "Six boards off one pallet — and the pallet gives the nails back too.",
+  },
+  rusticFrame: {
+    category: "rustic",
+    note: "Reclaimed wood cut to a tolerance it has never been held to.",
+  },
+  birdhouse: {
+    category: "rustic",
+    note: "The slit between the front boards is the door. Wrens aren't picky.",
+  },
+  crate: {
+    category: "rustic",
+    note: "Leave the gaps between the slats — that's the drainage.",
+  },
+  planterBox: {
+    category: "rustic",
+    note: "Screws, not nails. Wet soil works a nail loose by August.",
+  },
+  stepStool: {
+    category: "rustic",
+    note: "It takes a boot every day — every joint gets a screw.",
+  },
+  // Fine goods: mitered and sanded work
+  pictureFrame: {
+    category: "fineGoods",
+    note: "Eight 45° cuts that all have to agree.",
+  },
+  hexFrame: {
+    category: "fineGoods",
+    note: "Six corners at 30°. Trust the angle stops.",
+  },
+  servingTray: {
+    category: "fineGoods",
+    note: 'The rail wrap only closes on a 12" bottom.',
+  },
+  jewelryBox: {
+    category: "fineGoods",
+    note: "Thin stock and light brads. No hurry.",
+  },
+  // Furniture: the pieces that furnish a room
+  shelf: {
+    category: "furniture",
+    note: "The cleat carries it all — screw down the whole seam.",
+  },
+  bookshelf: {
+    category: "furniture",
+    note: "The grain you sanded is the grain they see.",
+  },
+  sideTable: {
+    category: "furniture",
+    note: "Every table is built upside down. Legs on end, top face-down.",
+  },
+  // Shop furniture: the shop building its own fixtures
+  worktable1x1: {
+    category: "shopFurniture",
+    note: "Small, but it stands flat. That's a start.",
+  },
+  worktable1x2: {
+    category: "shopFurniture",
+    note: "The standard bench. Most of the shop happens here.",
+  },
+  worktable1x3: {
+    category: "shopFurniture",
+    note: "Room to lay a long board down at last.",
+  },
+  worktable2x2: {
+    category: "shopFurniture",
+    note: "Big enough to lose a tape measure on.",
+  },
+  storageRack: {
+    category: "shopFurniture",
+    note: "OSB is fine here. Save the good sheets for jigs.",
+  },
+  toolDrawers: {
+    category: "shopFurniture",
+    note: "A place for everything, right under the bench.",
+  },
+  materialShelf: {
+    category: "shopFurniture",
+    note: "Two planks across the stretchers — that's the whole build.",
+  },
+  // Jigs: shop-made tooling
+  crosscutSled: {
+    category: "jigs",
+    note: "Build it square once, trust it forever.",
+  },
+  straightLineSled: {
+    category: "jigs",
+    note: "A straight edge for boards that don't have one.",
+  },
+  resawFence: {
+    category: "jigs",
+    note: "Tall enough to clear the blade, and no taller.",
+  },
+};
+
+/** One drawing in the drawer. */
+export interface BenchPlan {
+  readonly operation: Operation;
+  readonly blueprintId: BlueprintId;
+  readonly blueprint: ProductBlueprint;
+  readonly category: PlanCategoryId;
+  /** The pencil note in the drawing's margin. */
+  readonly note: string;
+  /** The tool whose rail hook the operation lives on, or null for a
+   * build every bench knows on its own. */
+  readonly sourceToolId: ToolId | null;
+}
+
+function plansFrom(
+  operations: ReadonlyArray<Operation>,
+  sourceToolId: ToolId | null,
+): BenchPlan[] {
+  return operations.flatMap((operation) => {
+    if (operation.interaction?.kind !== "assembly") {
+      return [];
+    }
+    const blueprintId = operation.interaction.blueprint;
+    const blueprint = productBlueprintFor(blueprintId);
+    const facts = PLAN_FACTS[blueprintId];
+    if (!blueprint || !facts) {
+      // Surfaced loudly at module load: an assembly op outside the
+      // registry would silently miss the plan browser otherwise.
+      throw new Error(`The ${blueprintId} plan has no registry entry`);
+    }
+    return [
+      {
+        operation,
+        blueprintId,
+        blueprint,
+        category: facts.category,
+        note: facts.note,
+        sourceToolId,
+      },
+    ];
+  });
+}
+
+/**
+ * Every assembly plan in the game, in category order (declaration order
+ * within a category). Tool-borne plans keep their tool's id so readiness
+ * can ask for it by name.
+ */
+export const ALL_BENCH_PLANS: ReadonlyArray<BenchPlan> = (() => {
+  const plans = [
+    ...plansFrom(BENCH_OPERATIONS, null),
+    ...(Object.keys(TOOL_TYPES) as ToolId[]).flatMap((toolId) =>
+      plansFrom(TOOL_TYPES[toolId].operations, toolId),
+    ),
+  ];
+  const order = PLAN_CATEGORIES.map((category) => category.id as string);
+  return plans
+    .map((plan, index) => ({ plan, index }))
+    .sort(
+      (a, b) =>
+        order.indexOf(a.plan.category) - order.indexOf(b.plan.category) ||
+        a.index - b.index,
+    )
+    .map((entry) => entry.plan);
+})();
+
+/** The plans the player's skills unlock — the browser's whole listing.
+ * Locked plans stay invisible; there are no grayed-out teasers. */
+export function unlockedBenchPlans(
+  progression: ProgressionState,
+): ReadonlyArray<BenchPlan> {
+  return ALL_BENCH_PLANS.filter(
+    (plan) =>
+      !plan.operation.requiredSkill ||
+      hasSkill(progression, plan.operation.requiredSkill),
+  );
+}
+
+/** The registry row behind an operation id, or null when the id isn't
+ * an assembly plan (tool work, a direct-feed cut, "none"). */
+export function benchPlanForOperationId(operationId: string): BenchPlan | null {
+  return (
+    ALL_BENCH_PLANS.find((plan) => plan.operation.id === operationId) ?? null
+  );
+}

--- a/src/game/bench-work/tool-work.ts
+++ b/src/game/bench-work/tool-work.ts
@@ -6,6 +6,7 @@ import { materialMeetsInput } from "../material-helpers";
 import { availableOperations } from "../skill-helpers";
 import { TOOL_TYPES, ToolId } from "../Tool";
 import { BenchPlacement } from "./bench-layout";
+import { benchPlanForOperationId } from "./plan-registry";
 
 /**
  * Tool-first work selection: the tool in hand plus the piece under it IS
@@ -38,10 +39,21 @@ export function isToolWork(operation: Operation): boolean {
  * claimed (operateMachineAction writes it), so it only names a plan when
  * it names an assembly build — a bench that just crosscut a board has no
  * drawing out, whatever the id says. Old saves may carry a stale one.
+ *
+ * Resolution falls through to the plan registry so a pulled drawing
+ * survives its driving tool being unmounted (the plan browser lists by
+ * skill, not by what's on the rail); the missing tool then reads as a
+ * supply shortfall rather than the drawing vanishing.
  */
 export function selectedBenchPlan(machine: Machine): Operation | null {
   const selected = machine.selectedOperationOrNull;
-  return selected && !isToolWork(selected) ? selected : null;
+  if (selected) {
+    return isToolWork(selected) ? null : selected;
+  }
+  return (
+    benchPlanForOperationId(machine.state.selectedOperationId)?.operation ??
+    null
+  );
 }
 
 /**

--- a/src/game/game-actions/player-actions.ts
+++ b/src/game/game-actions/player-actions.ts
@@ -14,12 +14,14 @@ import { findFeedableOperation } from "../machine-helpers";
 import { GameAction, MaterialPile } from "../GameState";
 import {
   defaultParametersFor,
+  isBenchType,
   isSameMachine,
   Machine,
   Operation,
   ParameterValues,
   MACHINE_TYPES,
 } from "../Machine";
+import { unlockedBenchPlans } from "../bench-work/plan-registry";
 import { MaterialInstance } from "../Materials";
 import { Direction, Vector, vectorEquals } from "../Vectors";
 import { cellCenter } from "../player-motion";
@@ -374,7 +376,17 @@ export function setMachineOperationAction(
 ): GameAction {
   return (gameState) => {
     const machineState = machine.state;
+    // A bench accepts any skill-unlocked plan from the registry, even one
+    // whose driving tool isn't mounted — the drawing goes out, and the
+    // missing tool reads as a supply shortfall. Everything else must be
+    // an operation the station itself offers.
+    const isBenchPlan =
+      isBenchType(machine.type) &&
+      unlockedBenchPlans(gameState.progression).some(
+        (plan) => plan.operation === operation,
+      );
     if (
+      !isBenchPlan &&
       !availableOperations(machine, gameState.progression).includes(operation)
     ) {
       throw new Error("Tried to set machine operation to invalid operation");
@@ -394,6 +406,29 @@ export function setMachineOperationAction(
               selectedOperationId: operation.id,
               selectedParameters: parameters,
             }
+          : m,
+      ),
+    };
+  };
+}
+
+/**
+ * Put the pulled drawing back on the pile: the bench keeps no selected
+ * plan at all, and the ghost outlines leave the bench top. Refused while
+ * the station is working, like any plan change.
+ */
+export function clearMachineOperationAction(machine: Machine): GameAction {
+  return (gameState) => {
+    const machineState = machine.state;
+    if (machineState.operationProgress.status === "inProgress") {
+      console.warn("Can't change the plan while the station is working");
+      return gameState;
+    }
+    return {
+      ...gameState,
+      machines: gameState.machines.map((m) =>
+        isSameMachine(m, machineState)
+          ? { ...m, selectedOperationId: "none", selectedParameters: undefined }
           : m,
       ),
     };

--- a/src/game/machines/benchOperations.ts
+++ b/src/game/machines/benchOperations.ts
@@ -435,9 +435,9 @@ export const BENCH_OPERATIONS: ReadonlyArray<Operation> = [
   // Shop furniture: worktables are built, never bought. Like the jigs,
   // the output is equipment — the table comes off the bench crated, to
   // be carried into place. Legs are chunky stock — 2×4s, not pallet
-  // wood, the way a real bench is built; the top is plywood. No skill
-  // gate: building a real bench is
-  // every woodworker's first project.
+  // wood, the way a real bench is built; the top is plywood. All of it
+  // sits behind the shopFurniture skill so a brand-new shop's plan pile
+  // holds just the rustic shelf.
   ...worktableBuildOperation("worktable1x1", "Build Small Worktable", 35),
   ...worktableBuildOperation("worktable1x2", "Build Worktable", 45),
   ...worktableBuildOperation("worktable1x3", "Build Long Worktable", 55),
@@ -445,6 +445,7 @@ export const BENCH_OPERATIONS: ReadonlyArray<Operation> = [
   {
     name: "Build Storage Rack",
     id: "buildStorageRack",
+    requiredSkill: "shopFurniture",
     duration: 30,
     // A cheap deck on stout legs — the one build where OSB belongs.
     // Rack-grade only: good sheets are refused so a rack never eats
@@ -465,6 +466,7 @@ export const BENCH_OPERATIONS: ReadonlyArray<Operation> = [
   {
     name: "Build Tool Drawers",
     id: "buildToolDrawers",
+    requiredSkill: "shopFurniture",
     duration: 30,
     // A sheet carcass with thin drawer stock — pallet boards qualify
     interaction: { kind: "assembly", blueprint: "toolDrawers" },
@@ -481,6 +483,7 @@ export const BENCH_OPERATIONS: ReadonlyArray<Operation> = [
   {
     name: "Build Material Shelf",
     id: "buildMaterialShelf",
+    requiredSkill: "shopFurniture",
     duration: 20,
     // Two planks laid side by side — that's the whole build, so the
     // blueprint has no fasteners and laying the second plank commits it
@@ -514,6 +517,7 @@ function worktableBuildOperation(
     {
       name,
       id: `build-${worktableId}`,
+      requiredSkill: "shopFurniture",
       duration,
       interaction: { kind: "assembly", blueprint: worktableId },
       requiredConsumables: blueprintFastenerCost(blueprint),

--- a/src/game/shortcuts.ts
+++ b/src/game/shortcuts.ts
@@ -343,16 +343,17 @@ const defs = [
     group: "Machines",
   },
   {
-    // The bench view's key: it thumbs the blueprint pile in the corner,
-    // and only answers with the drawing in front of you. Out on the floor
-    // a bench is a table, not a machine with a mode dial.
-    id: "cycle-operation",
+    // The bench view's key: it opens the plan drawer — the blueprint
+    // pile in the corner spread out to full size — and only answers with
+    // the bench in front of you. Out on the floor a bench is a table,
+    // not a machine with a mode dial. Handled by BlueprintCorner, which
+    // owns the drawer's open state.
+    id: "open-plan-browser",
     codes: ["KeyQ"],
     keys: [["Q"]],
-    description: "Next plan on the bench",
+    description: "Open the bench's plan drawer",
     scope: "home",
     group: "Machines",
-    shiftHint: "go backwards",
   },
   {
     // One setting, two keys, so it moves the way the thing moves: Z winds

--- a/src/game/tools/drill.ts
+++ b/src/game/tools/drill.ts
@@ -33,7 +33,7 @@ export const drill: ToolType = {
     {
       name: "Build Rustic Planter Box",
       id: "buildPlanterBox",
-      requiredSkill: "rusticCarpentry",
+      requiredSkill: "rusticProjects",
       duration: 25,
       // Screws hold an outdoor box together through wet soil and weather
       // where nails would work loose — and unlike nails, they never come
@@ -52,7 +52,7 @@ export const drill: ToolType = {
     {
       name: "Build Step Stool",
       id: "buildStepStool",
-      requiredSkill: "rusticCarpentry",
+      requiredSkill: "rusticProjects",
       duration: 30,
       // The blueprint: two stout sides on edge (thick hardwood, 6/4 or
       // heavier), two treads screwed flat across them — it has

--- a/src/game/tools/hammer.ts
+++ b/src/game/tools/hammer.ts
@@ -51,12 +51,12 @@ export const hammer: ToolType = {
     {
       name: "Build Rustic Frame",
       id: "buildRusticFrame",
-      requiredSkill: "rusticCarpentry",
+      requiredSkill: "rusticProjects",
       duration: 25,
-      // No skill of its own to buy: the gate is the shop. Mirrored 45s
-      // need the miter saw's angle stops, 2"-wide rails need the table
-      // saw's fence, and the sanded requirement needs something to sand
-      // with — the first build that asks for all three at once.
+      // Beyond the skill there's a shop gate too: mirrored 45s need the
+      // miter saw's angle stops, 2"-wide rails need the table saw's
+      // fence, and the sanded requirement needs something to sand with —
+      // the first build that asks for all three at once.
       interaction: { kind: "assembly", blueprint: "rusticFrame" },
       requiredConsumables: blueprintFastenerCost(RUSTIC_FRAME_BLUEPRINT),
       getInputMaterials: () => blueprintInputs(RUSTIC_FRAME_BLUEPRINT),

--- a/tests/bench.spec.ts
+++ b/tests/bench.spec.ts
@@ -201,17 +201,19 @@ test.describe("Bench view", () => {
       await expect(corner).toBeVisible();
       await expect(corner).not.toContainText("Sand Board");
       await corner.click();
-      await expect(page.getByTestId("blueprint-stack")).toBeVisible();
-      await expect(
-        page.getByTestId("blueprint-stack").getByText("Sand Board"),
-      ).toHaveCount(0);
-      await corner.click();
+      const browser = page.getByTestId("plan-browser");
+      await expect(browser).toBeVisible();
+      await expect(browser.getByText("Sand Board")).toHaveCount(0);
+      await page.keyboard.press("Escape");
+      await expect(browser).toBeHidden();
+      // Escape closed the drawer, never the bench view under it
+      await expect(page.getByTestId("station-sheet")).toBeVisible();
       // The sanding block hangs on the rail, waiting for a hand
       await expect(page.getByTestId("bench-tool-sandingBlock")).toBeVisible();
 
-      // Leaned in, Q is the pile's key: it thumbs to the next drawing
-      // with that drawing right there to see. (Out on the floor the same
-      // press does nothing — the step above.)
+      // Leaned in, Q is the drawer's key: it spreads the plans across
+      // the view and closes them again. (Out on the floor the same press
+      // does nothing — the step above.)
       const planId = () =>
         page.evaluate(
           () =>
@@ -223,8 +225,25 @@ test.describe("Bench view", () => {
       const stale = await planId();
       await blur();
       await page.keyboard.press("q");
-      await expect.poll(planId).not.toBe(stale);
-      await expect(corner).toContainText("Build");
+      await expect(browser).toBeVisible();
+
+      // The starter shop's drawer holds exactly one drawing — the rustic
+      // shelf — with its readiness stamp. Pulling it selects the plan
+      // and closes the drawer; the chip names the drawing that's out.
+      await expect(page.getByTestId("plan-thumb")).toHaveCount(1);
+      await expect(page.getByTestId("plan-stamp").first()).toBeVisible();
+      await page.locator("[data-mode-option]").click();
+      await page.getByTestId("pull-plan").click();
+      await expect(browser).toBeHidden();
+      await expect.poll(planId).toBe("buildRusticPalletShelf");
+      await expect(corner).toContainText("Build Rustic Pallet Shelf");
+
+      // Put the drawing back from the chip: the bench keeps no plan at
+      // all, and the pile invites pulling another
+      await page.getByTestId("put-back-plan-chip").click();
+      await expect.poll(planId).toBe("none");
+      await expect(corner).toContainText("Pull a drawing");
+
       await page.evaluate((id) => {
         window.__UPDATE_GAME_STATE__((state: any) => ({
           ...state,
@@ -996,6 +1015,15 @@ test.describe("Bench view", () => {
         window.__UPDATE_GAME_STATE__((state: any) => ({
           ...state,
           consumables: { ...state.consumables, screws: 10 },
+          // The planter box rides the rusticProjects skill now that the
+          // starter drawer holds only the shelf
+          progression: {
+            ...state.progression,
+            unlockedSkills: [
+              ...state.progression.unlockedSkills,
+              "rusticProjects",
+            ],
+          },
           machines: state.machines.map((m: any, i: number) =>
             i === 0
               ? {

--- a/tests/fixtures/hand-tools-shop.ts
+++ b/tests/fixtures/hand-tools-shop.ts
@@ -90,7 +90,9 @@ export const handToolsShop: GameState = {
     readArticles: ALL_ARTICLE_IDS,
     xp: 0,
     skillPoints: 0,
-    unlockedSkills: STARTER_SKILLS,
+    // The planter box moved to rusticProjects when the plan pile was
+    // trimmed to just the shelf at the start
+    unlockedSkills: [...STARTER_SKILLS, "rusticProjects"],
   },
   stand: [],
   customers: [],

--- a/tests/machine-panel.ts
+++ b/tests/machine-panel.ts
@@ -1,11 +1,12 @@
 /**
  * Helpers for driving the machine spec sheet's plan and parameter controls.
  *
- * The bench's plan picker is a pile of shop drawings in the bench view's
- * corner (BlueprintCorner): the fold toggle carries `aria-expanded`, and
- * every drawing's edge marks its operation name with `data-mode-option`,
- * exactly once, so selecting a plan is unfolding the pile and clicking
- * the sheet by name — the same contract the older mode controls kept.
+ * The bench's plan picker is the plan drawer (PlanBrowser), opened from
+ * the pile chip in the bench view's corner (BlueprintCorner): the chip
+ * carries `aria-expanded`, and every drawing marks its operation name
+ * with `data-mode-option`, exactly once. Selecting a plan is opening the
+ * drawer, clicking the drawing by name to set it out, and pulling it
+ * (`data-testid="pull-plan"`); the drawer closes itself on the pull.
  */
 
 import { pumpTicks } from "./navigation";
@@ -102,13 +103,32 @@ export async function takeAllHere(page: any) {
   await page.waitForTimeout(30);
 }
 
-/** Unfold a collapsed plan pile (the bench view's blueprint corner, or
+/** Open a collapsed plan drawer (the bench view's blueprint corner, or
  * any older aria-expanded recipe index); no-op for other control shapes. */
 export async function openRecipeIndex(card: any) {
   const toggle = card.locator("button[aria-expanded]");
   if (
     (await toggle.count()) > 0 &&
     (await toggle.first().getAttribute("aria-expanded")) === "false"
+  ) {
+    await toggle.first().click();
+  }
+}
+
+/** Close the plan drawer / fold the pile back up. The drawer's overlay
+ * covers the corner chip, so it closes by Escape rather than the toggle
+ * (Escape is handled inside the overlay and never reaches close-sheet). */
+export async function closeRecipeIndex(page: any, card: any) {
+  const browser = page.getByTestId("plan-browser");
+  if (await browser.isVisible()) {
+    await page.keyboard.press("Escape");
+    await browser.waitFor({ state: "hidden" });
+    return;
+  }
+  const toggle = card.locator("button[aria-expanded]");
+  if (
+    (await toggle.count()) > 0 &&
+    (await toggle.first().getAttribute("aria-expanded")) === "true"
   ) {
     await toggle.first().click();
   }
@@ -128,6 +148,21 @@ export async function selectMode(
     .filter({ hasText: new RegExp(`^${escapeRegExp(label)}$`) })
     .click();
   await page.waitForTimeout(30);
+  // In the plan drawer, clicking a drawing only sets it out for reading;
+  // the pull button commits and closes the drawer. A drawing that is
+  // already pulled offers "put back" instead — the selection is already
+  // in place, so just close the drawer.
+  const browser = page.getByTestId("plan-browser");
+  if (await browser.isVisible()) {
+    const pull = page.getByTestId("pull-plan");
+    if (await pull.isVisible()) {
+      await pull.click();
+    } else {
+      await page.keyboard.press("Escape");
+    }
+    await browser.waitFor({ state: "hidden" });
+  }
+  await page.waitForTimeout(30);
 }
 
 /** The operation names the station currently offers, in display order. */
@@ -139,14 +174,8 @@ export async function modesOf(
   const card = machineCard(page, machineName);
   await openRecipeIndex(card);
   const modes = await card.locator("[data-mode-option]").allTextContents();
-  // Leave the pile folded the way we found it
-  const toggle = card.locator("button[aria-expanded]");
-  if (
-    (await toggle.count()) > 0 &&
-    (await toggle.first().getAttribute("aria-expanded")) === "true"
-  ) {
-    await toggle.first().click();
-  }
+  // Leave the drawer closed the way we found it
+  await closeRecipeIndex(page, card);
   return modes;
 }
 

--- a/tests/market.spec.ts
+++ b/tests/market.spec.ts
@@ -1,5 +1,11 @@
 import { expect, Page, test } from "@playwright/test";
-import { modesOf, selectMode } from "./machine-panel";
+import {
+  closeRecipeIndex,
+  machineCard,
+  modesOf,
+  openRecipeIndex,
+  selectMode,
+} from "./machine-panel";
 import {
   advanceTicks,
   checkOutAndLeaveStore,
@@ -397,9 +403,13 @@ test.describe("Selling, supplies, and sound", () => {
         "Makeshift Workbench",
         "Build Rustic Pallet Shelf",
       );
-      // The shortfall reads right on the pulled drawing's title block —
-      // there is no separate supplies row or run hint any more
+      // The shortfall reads right on the pulled drawing's title block,
+      // set out in the plan drawer (which opens back onto the pulled
+      // drawing) — there is no separate supplies row or run hint
+      const card = machineCard(page, "Makeshift Workbench");
+      await openRecipeIndex(card);
       await expect(page.getByText("8 nails (have 0)")).toBeVisible();
+      await closeRecipeIndex(page, card);
       // The sidebar supply cabinet stays hidden while everything is at zero
       await expect(page.getByText("Supplies", { exact: true })).toBeHidden();
     });
@@ -421,8 +431,12 @@ test.describe("Selling, supplies, and sound", () => {
       await suppliesCard.getByRole("button", { name: "Supplies" }).click();
       await expect(suppliesCard.getByText("Nails")).toBeVisible();
       await expect(suppliesCard.getByText("8", { exact: true })).toBeVisible();
-      // And the recipe's shortfall line clears
+      // And the shortfall line on the pulled drawing clears — reopen the
+      // plan drawer to read it
+      const card = machineCard(page, "Makeshift Workbench");
+      await openRecipeIndex(card);
       await expect(page.getByText("8 nails (have 8)")).toBeVisible();
+      await closeRecipeIndex(page, card);
     });
 
     await test.step("the store's supplies aisle sells packs", async () => {

--- a/tests/stations.spec.ts
+++ b/tests/stations.spec.ts
@@ -591,14 +591,22 @@ test.describe("Stations", () => {
 
     await test.step("the planter box reads its screw cost against the tin", async () => {
       await selectMode(page, "Makeshift Workbench", "Build Rustic Planter Box");
-      await expect(page.getByText("6 screws (have 50)")).toBeVisible();
-      // Selecting a plan pulls its sheet to the top of the blueprint
-      // stack — the drawing pinned over the bench IS the selection
+      // The pulled drawing's name rides the corner chip; its sheet, with
+      // the screw bill read against the tin, is set out in the plan
+      // drawer (which opens back onto the pulled drawing)
+      await expect(page.getByTestId("blueprint-corner")).toContainText(
+        "Build Rustic Planter Box",
+      );
+      const card = stationCard(page, "Makeshift Workbench");
+      await openRecipeIndex(card);
       await expect(
         page
           .getByTestId("blueprint-sheet")
           .getByText("Build Rustic Planter Box"),
       ).toBeVisible();
+      await expect(page.getByText("6 screws (have 50)")).toBeVisible();
+      // A drawing that's already out offers its way back to the pile
+      await expect(page.getByTestId("put-back-plan")).toBeVisible();
     });
 
     await test.step("plans quote shop time, never ticks", async () => {


### PR DESCRIPTION
Implements #197 (Plans UI Overhaul).

## What changed

**The plan drawer** (`PlanBrowser.tsx`): Q (or clicking the corner pile) spreads a most-of-screen browser across the bench view — manila category tabs down the left, drawings as blueprint thumbnails grouped under category dividers, each with its schematic, duration, and a READY/SHORT rubber stamp. Clicking a drawing sets it out full-size on the right (schematic, margin note, title block); **Pull this drawing** selects the plan and closes the drawer. Arrows + Enter navigate, Esc closes. The corner keeps a small chip naming the pulled drawing (plus the per-run settings strip) with a ✕ to put it back.

**Plan registry** (`bench-work/plan-registry.ts`): all assembly builds gathered from the bench list, hammer, and drill, filed under five categories (Rustic Projects, Fine Goods, Furniture, Shop Furniture, Jigs) with one handwritten margin note each. The drawer lists by **skill**, not by mounted tools — a build whose driver is in the drawers shows with the tool as its shortfall instead of vanishing — and `selectedBenchPlan` resolves through the registry so a pulled plan survives its tool being unmounted.

**Readiness** (`bench-work/plan-readiness.ts`): the title block reads the whole bill against shop-wide stock (floor piles, machine bays/shelves, hands, truck bed) — per-requirement need/have rows, the existing consumables/clamps treatment, and a tool line ("Hammer — on this bench / in the shop, mount it here / none in the shop"). READY means the build can start at this bench right now.

**Unselect**: new `clearMachineOperationAction` — put-back buttons in the drawer and on the corner chip; ghosts leave the bench with the drawing.

**Q**: `cycle-operation` is gone; Q is `open-plan-browser`, registered by the corner (bench view only, as before).

**Progression**: a fresh save's drawer holds **only the rustic shelf**. The rustic frame, planter box, and step stool moved to `rusticProjects`; the four worktables, storage rack, tool drawers, and material shelf sit behind a new early **Shop Furniture** skill under Rustic Carpentry.

**Copy**: Welcome article, Workbenches article (new Plans section), and the tutorial's build-shelf card updated to the drawer; `docs/bench-work.md` updated where it described Q and the pile.

## Tests

- New unit tests: registry completeness/ordering/notes, only-the-shelf-at-start, readiness rows and tool status (`plan-registry.test.ts`)
- Spec helpers (`tests/machine-panel.ts`) updated to the drawer contract (`aria-expanded` chip, `data-mode-option` names, `pull-plan` commit); bench/stations/market specs updated to the new flow
- `npm run tsc` clean; unit tier 1063/1063; full E2E suite 7/7 green
- Verified in the browser: drawer renders correctly at 1440×900, pull/put-back round-trips state

🤖 Generated with [Claude Code](https://claude.com/claude-code)