### PR TITLE
Explain blocked pickups on the hint chips instead of going quiet

### DIFF
--- a/src/components/shop-overlay/PlayerPrompt.tsx
+++ b/src/components/shop-overlay/PlayerPrompt.tsx
@@ -13,10 +13,16 @@ import { canisterFillFraction, carryingShopVac } from "../../game/ShopVac";
 import { MaterialPile } from "../../game/GameState";
 import { getMaterialFullName } from "../../game/material-helpers";
 import { liveSettingParameter } from "../../game/machine-helpers";
-import { materialSources, resolveInteract } from "../../game/interact";
+import { explainUnpackRefusal } from "../../game/game-actions/machine-actions";
+import {
+  broomWithinReach,
+  materialSources,
+  resolveInteract,
+  takeBlockedReason,
+} from "../../game/interact";
 import { timeSpeed } from "../../game/time-flow";
 import { chebyshevDistance } from "../../game/Vectors";
-import { HintList, HintRow } from "../shortcuts/HintList";
+import { HintList, HintRow, ReasonRow } from "../shortcuts/HintList";
 import { ShortcutKeys } from "../shortcuts/Kbd";
 import { useTargetedMachine } from "../TargetedMachineContext";
 import { useGameState } from "../useGameState";
@@ -57,6 +63,17 @@ export const PlayerPrompt: React.FC = () => {
     ? null
     : resolveInteract(gameState, targetedMachine, pileOffset);
 
+  // Where the pickup chip would land if the hands were free: the top of
+  // the reachable ring's floor pieces. The chip still shows there, naming
+  // the piece — its verb row just becomes the reason the verb is off.
+  const takeBlocked = carried ? null : takeBlockedReason(gameState);
+  const blockedPile =
+    takeBlocked != null
+      ? (materialSources(gameState, targetedMachine, true).find(
+          (source) => source.kind === "floor-pile",
+        )?.pile ?? null)
+      : null;
+
   // Whether R belongs to the targeted machine's rotate setting — the same
   // test the keyboard bindings split the key on, so the rummage hint only
   // shows when R would actually rummage.
@@ -89,10 +106,20 @@ export const PlayerPrompt: React.FC = () => {
     }
   } else {
     if (crateUnderfoot) {
+      // The unpack key wants completely empty hands — offered only when
+      // it would work, and the chip says why when it wouldn't.
+      const unpackRefusal = explainUnpackRefusal(gameState);
       rows.push(
-        <HintRow key="unpack" keys={<ShortcutKeys shortcut="carry-machine" />}>
-          unpack {MACHINE_TYPES[crateUnderfoot.machine.machineTypeId].name}
-        </HintRow>,
+        unpackRefusal ? (
+          <ReasonRow key="unpack">{unpackRefusal}</ReasonRow>
+        ) : (
+          <HintRow
+            key="unpack"
+            keys={<ShortcutKeys shortcut="carry-machine" />}
+          >
+            unpack {MACHINE_TYPES[crateUnderfoot.machine.machineTypeId].name}
+          </HintRow>
+        ),
       );
     }
     // The truck's bed wears its own chips, pinned over the tailgate
@@ -103,6 +130,18 @@ export const PlayerPrompt: React.FC = () => {
           pick up broom
         </HintRow>,
       );
+    } else if (broomWithinReach(gameState)) {
+      // The broom wants completely empty hands, a stricter bar than the
+      // pickup verbs' — carrying even one board hides the offer, so say
+      // why instead of going quiet.
+      const broomRefusal = carryingShopVac(gameState)
+        ? "set the vac down to take the broom"
+        : gameState.player.inventory.length > 0
+          ? "empty your hands to take the broom"
+          : null;
+      if (broomRefusal) {
+        rows.push(<ReasonRow key="broom-blocked">{broomRefusal}</ReasonRow>);
+      }
     }
     // No chip for putting things down: it followed the player to every
     // cell, which read as a strobe. The hands strip carries the F hint
@@ -175,10 +214,18 @@ export const PlayerPrompt: React.FC = () => {
       );
     }
     if (standingOnVac && !draggingVac) {
+      // The hose takes a hand — the toggle refuses while the broom's in
+      // it, so the chip explains instead of offering a dead key.
       rows.push(
-        <HintRow key="grab-vac" keys={<ShortcutKeys shortcut="vac-toggle" />}>
-          grab vac
-        </HintRow>,
+        holdingBroom(gameState) ? (
+          <ReasonRow key="grab-vac">
+            put the broom down to grab the vac
+          </ReasonRow>
+        ) : (
+          <HintRow key="grab-vac" keys={<ShortcutKeys shortcut="vac-toggle" />}>
+            grab vac
+          </HintRow>
+        ),
       );
     }
     // The wait key earns its chip when there's something to wait *for*:
@@ -218,6 +265,22 @@ export const PlayerPrompt: React.FC = () => {
           sourceCount={materialSources(gameState, targetedMachine).length}
           rotateSettingLive={rotateSettingLive}
         />
+      )}
+      {/* Blocked hands: the chip still sits on the piece it would take,
+          named as usual, with the reason where the verb would be */}
+      {blockedPile && takeBlocked && (
+        <PointAnchored
+          point={blockedPile.position}
+          placement="above"
+          testId="blocked-pickup-chip"
+        >
+          <HintList>
+            <HintRow className="text-paper-manila/60">
+              {getMaterialFullName(blockedPile.material)}
+            </HintRow>
+            <ReasonRow>{takeBlocked}</ReasonRow>
+          </HintList>
+        </PointAnchored>
       )}
       {rows.length > 0 && (
         <CellAnchored cell={gameState.player.position}>

--- a/src/components/shop-overlay/StandPrompt.tsx
+++ b/src/components/shop-overlay/StandPrompt.tsx
@@ -1,8 +1,12 @@
 import React, { useContext } from "react";
-import { interactLabel, resolveInteract } from "../../game/interact";
+import {
+  interactLabel,
+  resolveInteract,
+  takeBlockedReason,
+} from "../../game/interact";
 import { atStand, isSellable, standRect } from "../../game/stand";
 import { PIXELS_PER_CELL } from "../shop-view/shop-scale";
-import { HintList, HintRow } from "../shortcuts/HintList";
+import { HintList, HintRow, ReasonRow } from "../shortcuts/HintList";
 import { ShortcutKeys } from "../shortcuts/Kbd";
 import { useTargetedMachine } from "../TargetedMachineContext";
 import { useGameState } from "../useGameState";
@@ -41,6 +45,13 @@ export const StandPrompt: React.FC<{ canvasWidth: number }> = ({
         {interact.count > 1 && ` (${interact.count})`}
       </HintRow>,
     );
+  } else if (gameState.stand.length > 0) {
+    // Stock on the table but the hands can't take it back — say why
+    // instead of letting the chip go quiet about it.
+    const takeBlocked = takeBlockedReason(gameState);
+    if (takeBlocked) {
+      rows.push(<ReasonRow key="take-blocked">{takeBlocked}</ReasonRow>);
+    }
   }
   if (sellableInHand) {
     rows.push(

--- a/src/components/shop-overlay/TruckPrompt.tsx
+++ b/src/components/shop-overlay/TruckPrompt.tsx
@@ -20,12 +20,17 @@ import {
   truckCabRect,
 } from "../../game/lot";
 import { MACHINE_TYPES } from "../../game/Machine";
-import { interactLabel, resolveInteract } from "../../game/interact";
+import { explainUnpackRefusal } from "../../game/game-actions/machine-actions";
+import {
+  interactLabel,
+  resolveInteract,
+  takeBlockedReason,
+} from "../../game/interact";
 import { ShortcutId } from "../../game/shortcuts";
 import { classNames } from "../../utils/classNames";
 import { mod } from "../../utils/mathUtils";
 import { PIXELS_PER_CELL } from "../shop-view/shop-scale";
-import { HintList, HintRow } from "../shortcuts/HintList";
+import { HintList, HintRow, ReasonRow } from "../shortcuts/HintList";
 import { Kbd, ShortcutKeys } from "../shortcuts/Kbd";
 import { useShortcut } from "../shortcuts/ShortcutProvider";
 import { useTargetedMachine } from "../TargetedMachineContext";
@@ -95,6 +100,13 @@ export const TruckBedPrompt: React.FC<{ canvasWidth: number }> = ({
         {interact.count > 1 && ` (${interact.count})`}
       </HintRow>,
     );
+  } else if (gameState.truck.bed.length > 0) {
+    // Cargo in the bed but the hands can't lift it out — say why
+    // instead of letting the chip go quiet about it.
+    const takeBlocked = takeBlockedReason(gameState);
+    if (takeBlocked) {
+      rows.push(<ReasonRow key="take-blocked">{takeBlocked}</ReasonRow>);
+    }
   }
   if (holding) {
     rows.push(
@@ -105,11 +117,18 @@ export const TruckBedPrompt: React.FC<{ canvasWidth: number }> = ({
       </HintRow>,
     );
   }
-  if (gameState.truck.crates.length > 0 && !holding) {
+  if (gameState.truck.crates.length > 0) {
+    // Same bar as the shop-floor crate: unpacking wants completely empty
+    // hands, and the chip says so rather than dropping the row.
+    const unpackRefusal = explainUnpackRefusal(gameState);
     rows.push(
-      <HintRow key="unpack" keys={<ShortcutKeys shortcut="carry-machine" />}>
-        unpack {MACHINE_TYPES[gameState.truck.crates[0].machineTypeId].name}
-      </HintRow>,
+      unpackRefusal ? (
+        <ReasonRow key="unpack">{unpackRefusal}</ReasonRow>
+      ) : (
+        <HintRow key="unpack" keys={<ShortcutKeys shortcut="carry-machine" />}>
+          unpack {MACHINE_TYPES[gameState.truck.crates[0].machineTypeId].name}
+        </HintRow>
+      ),
     );
   }
   if (rows.length === 0) {
@@ -301,10 +320,12 @@ export const TruckPrompt: React.FC<{
   const cabTop = cab.min[1] * cellPx;
   // Closed: just the chip, the same weight as every other hint — and
   // only when E would actually open the cab (something else in reach
-  // may claim the key first).
+  // may claim the key first). With a machine on the shoulders nothing
+  // resolves at all, so the chip carries the reason instead: the card's
+  // own "set it down first" advice, brought out where it can be read.
   if (!truckMenuOpen) {
     const interact = resolveInteract(gameState, targetedMachine);
-    if (interact?.kind !== "truck-cab") {
+    if (interact?.kind !== "truck-cab" && !carried) {
       return null;
     }
     return (
@@ -318,7 +339,16 @@ export const TruckPrompt: React.FC<{
       >
         <HintList testId="truck-cab-chips">
           <HintRow className="text-paper-manila/60">The truck</HintRow>
-          <HintRow keys={<ShortcutKeys shortcut="pick-up" />}>head out</HintRow>
+          {carried ? (
+            <ReasonRow>
+              set the {MACHINE_TYPES[carried.machineTypeId].name} down to head
+              out
+            </ReasonRow>
+          ) : (
+            <HintRow keys={<ShortcutKeys shortcut="pick-up" />}>
+              head out
+            </HintRow>
+          )}
         </HintList>
       </div>
     );

--- a/src/components/shortcuts/HintList.tsx
+++ b/src/components/shortcuts/HintList.tsx
@@ -62,3 +62,18 @@ export const HintRow: React.FC<{
       <span>{children}</span>
     </li>
   );
+
+/**
+ * A key-less row explaining why a verb isn't on offer right now — "arms
+ * full" where "pick up" would sit. Muted, sentence-case italic so it
+ * reads as a note rather than a control, and allowed to wrap since a
+ * reason can run longer than a verb. The same dress the feed-refusal
+ * advice wears (MachineChips), so every "here's why not" reads alike.
+ */
+export const ReasonRow: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => (
+  <HintRow className="max-w-56 whitespace-normal normal-case italic tracking-normal text-paper-manila/70">
+    {children}
+  </HintRow>
+);

--- a/src/components/station/MachineChips.tsx
+++ b/src/components/station/MachineChips.tsx
@@ -3,6 +3,7 @@ import {
   interactLabel,
   materialSources,
   resolveInteract,
+  takeBlockedReason,
 } from "../../game/interact";
 import {
   hasFloorControls,
@@ -27,7 +28,7 @@ import {
 import { getMaterialName } from "../../game/material-helpers";
 import { hasStationSheet } from "./station-helpers";
 import { availableOperations } from "../../game/skill-helpers";
-import { HintList, HintRow } from "../shortcuts/HintList";
+import { HintList, HintRow, ReasonRow } from "../shortcuts/HintList";
 import { ShortcutKeys } from "../shortcuts/Kbd";
 import { useTargetedMachine } from "../TargetedMachineContext";
 import { useGameState } from "../useGameState";
@@ -68,6 +69,19 @@ export const MachineChips: React.FC<{ machine: Machine }> = ({ machine }) => {
     isSameMachine(interact.machine.state, machine.state)
       ? interact
       : null;
+
+  // Blocked hands (an armload, the broom) hide the take verbs from the
+  // resolver entirely — so when this machine holds stock the chips would
+  // otherwise offer, say why the offer is gone instead of going quiet.
+  const takeBlocked = takeBlockedReason(gameState);
+  const blockedTakeHere =
+    takeBlocked != null &&
+    interactHere == null &&
+    materialSources(gameState, machine, true).some(
+      (source) =>
+        source.kind !== "floor-pile" &&
+        isSameMachine(source.machine.state, machine.state),
+    );
 
   // With more material in reach than this machine's stock — pieces on
   // the floor beside the bench — R steps E through the whole ring, and
@@ -172,6 +186,7 @@ export const MachineChips: React.FC<{ machine: Machine }> = ({ machine }) => {
           {interactLabel(interactHere)}
         </HintRow>
       )}
+      {blockedTakeHere && <ReasonRow>{takeBlocked}</ReasonRow>}
       {rummageable && (
         <HintRow
           className="text-paper-manila/70"
@@ -198,11 +213,7 @@ export const MachineChips: React.FC<{ machine: Machine }> = ({ machine }) => {
           {(runOperation?.name ?? machine.type.feedVerb ?? "run").toLowerCase()}
         </HintRow>
       )}
-      {refusal && (
-        <HintRow className="max-w-56 whitespace-normal normal-case italic tracking-normal text-paper-manila/70">
-          {refusal}
-        </HintRow>
-      )}
+      {refusal && <ReasonRow>{refusal}</ReasonRow>}
       {isTargeted(machine) &&
         settings.map((param) => {
           const value =
@@ -299,15 +310,25 @@ function machineSettings(
 
 /**
  * Finished stock waiting at the outfeed side of a feed-through machine,
- * offered while the player stands at its outfeed cell.
+ * offered while the player stands at its outfeed cell — or, with the
+ * hands committed elsewhere, the reason the take is off, so the chip
+ * never offers a key the resolver would ignore.
  */
-export const OutfeedChips: React.FC<{ machine: Machine }> = ({ machine }) => (
-  <HintList>
-    <HintRow className="text-paper-manila/60">
-      {machine.type.name} · outfeed
-    </HintRow>
-    <HintRow keys={<ShortcutKeys shortcut="pick-up" />}>
-      take ({machine.outputMaterials.length})
-    </HintRow>
-  </HintList>
-);
+export const OutfeedChips: React.FC<{ machine: Machine }> = ({ machine }) => {
+  const gameState = useGameState();
+  const takeBlocked = takeBlockedReason(gameState);
+  return (
+    <HintList>
+      <HintRow className="text-paper-manila/60">
+        {machine.type.name} · outfeed
+      </HintRow>
+      {takeBlocked ? (
+        <ReasonRow>{takeBlocked}</ReasonRow>
+      ) : (
+        <HintRow keys={<ShortcutKeys shortcut="pick-up" />}>
+          take ({machine.outputMaterials.length})
+        </HintRow>
+      )}
+    </HintList>
+  );
+};

--- a/src/game/game-actions/machine-actions.test.ts
+++ b/src/game/game-actions/machine-actions.test.ts
@@ -8,6 +8,7 @@ import {
   canPutDownCarriedMachine,
   carriedMachinePlacement,
   deliverMachineCrate,
+  explainUnpackRefusal,
   freshMachineState,
   pickUpCrateAction,
   pickUpMachineAction,
@@ -107,6 +108,33 @@ describe("pickUpCrateAction", () => {
       player: { ...initialGameState.player, position: [0, 0] },
     });
     assert.strictEqual(pickUpCrateAction()(state), state);
+  });
+});
+
+describe("explainUnpackRefusal", () => {
+  it("has nothing to say with empty hands", () => {
+    assert.strictEqual(explainUnpackRefusal(initialGameState), null);
+  });
+
+  it("agrees with the action about an armload", () => {
+    // The same test the unpack actions run, so the chip's reason and the
+    // key's refusal can never drift apart.
+    const holding = stateWith({
+      player: { ...initialGameState.player, inventory: [board("pine", 12)] },
+    });
+    assert.strictEqual(
+      explainUnpackRefusal(holding),
+      "empty your hands to unpack",
+    );
+    assert.strictEqual(pickUpCrateAction()(holding), holding);
+  });
+
+  it("names the vac when it's the thing in hand", () => {
+    const dragging = stateWith({ shopVac: { position: null, canister: {} } });
+    assert.strictEqual(
+      explainUnpackRefusal(dragging),
+      "set the vac down to unpack",
+    );
   });
 });
 

--- a/src/game/game-actions/machine-actions.ts
+++ b/src/game/game-actions/machine-actions.ts
@@ -228,6 +228,23 @@ function handsFree(gameState: GameState): boolean {
   );
 }
 
+/**
+ * Why the crate at hand can't be hoisted right now, for the chip to say
+ * in place of "unpack" — the same test the unpack actions run (here and
+ * at the truck's bed), so the chip and the key always agree. Null when
+ * unpacking would work; the carried-machine case never asks (no chips
+ * show with a machine on the shoulders).
+ */
+export function explainUnpackRefusal(gameState: GameState): string | null {
+  if (carryingShopVac(gameState)) {
+    return "set the vac down to unpack";
+  }
+  if (gameState.player.inventory.length > 0) {
+    return "empty your hands to unpack";
+  }
+  return null;
+}
+
 /*
  * Carrying machines IS shop-layout management — there is no separate
  * layout editor. One contextual key (B) three-way toggles: put down what

--- a/src/game/interact.test.ts
+++ b/src/game/interact.test.ts
@@ -4,7 +4,13 @@ import { board } from "./board-helpers";
 import { GameState, MaterialPile } from "./GameState";
 import { getMachines, Machine, MachineState } from "./Machine";
 import { initialGameState } from "./initialGameState";
-import { interactLabel, offsetForSource, resolveInteract } from "./interact";
+import {
+  interactLabel,
+  materialSources,
+  offsetForSource,
+  resolveInteract,
+  takeBlockedReason,
+} from "./interact";
 import { Board } from "./Materials";
 import { HAND_CAPACITY } from "./Person";
 
@@ -157,6 +163,59 @@ describe("resolveInteract", () => {
       resolveInteract(state, bench, -1)?.kind,
       "pick-up-floor",
     );
+  });
+});
+
+describe("takeBlockedReason", () => {
+  function fullHanded(gameState: GameState): GameState {
+    return {
+      ...gameState,
+      player: {
+        ...gameState.player,
+        inventory: Array.from({ length: HAND_CAPACITY }, () =>
+          board("pine", 12),
+        ),
+      },
+    };
+  }
+
+  it("has nothing to say while the hands could take something", () => {
+    assert.strictEqual(takeBlockedReason(shopWithPiles()), null);
+  });
+
+  it("says the arms are full at capacity", () => {
+    assert.strictEqual(
+      takeBlockedReason(fullHanded(shopWithPiles())),
+      "arms full",
+    );
+  });
+
+  it("names the broom when it's the thing committing the hands", () => {
+    const sweeping: GameState = {
+      ...shopWithPiles(),
+      broomOwned: true,
+      broomPosition: null,
+    };
+    assert.strictEqual(takeBlockedReason(sweeping), "put the broom down first");
+  });
+
+  it("names the vac hose when it's the thing committing the hands", () => {
+    const dragging: GameState = {
+      ...shopWithPiles(),
+      shopVac: { position: null, canister: {} },
+    };
+    assert.strictEqual(takeBlockedReason(dragging), "set the vac down first");
+  });
+
+  it("still lists what a blocked take would land on when told to ignore the hands", () => {
+    // The chips use this to put the explanation where the verb would
+    // have been — on the piece the free-handed press would grab.
+    const underfoot = pileAt([5.5, 5.5]);
+    const state = fullHanded(shopWithPiles(underfoot));
+    assert.strictEqual(materialSources(state, undefined).length, 0);
+    const ignoring = materialSources(state, undefined, true);
+    assert.strictEqual(ignoring.length, 1);
+    assert.strictEqual(ignoring[0].kind, "floor-pile");
   });
 });
 

--- a/src/game/interact.ts
+++ b/src/game/interact.ts
@@ -70,14 +70,34 @@ export function materialSourceKey(source: MaterialSource): string {
 }
 
 /**
+ * Why the material verbs (take, pick up) are off right now: a tool
+ * committing the hands, or arms already at capacity. Null when the hands
+ * could take something. The chips show this text in place of the verb
+ * they can't offer, so a full-handed player standing over stock reads
+ * "arms full" instead of silence.
+ */
+export function takeBlockedReason(gameState: GameState): string | null {
+  switch (heldTool(gameState)) {
+    case "broom":
+      return "put the broom down first";
+    case "vacHose":
+      return "set the vac down first";
+  }
+  return handSpaceLeft(gameState.player) > 0 ? null : "arms full";
+}
+
+/**
  * Every material source in reach, in priority order: outfeeds, then
  * loaded bays, then the floor's pieces newest-first. Empty when the
  * hands aren't free to take anything (a held tool, full arms, a carried
- * machine, or the player away).
+ * machine, or the player away) — unless `ignoreHands`, which the chips
+ * use to find what a blocked take *would* land on, so the explanation
+ * can sit where the verb would have.
  */
 export function materialSources(
   gameState: GameState,
   targetedMachine: Machine | undefined,
+  ignoreHands = false,
 ): ReadonlyArray<MaterialSource> {
   if (gameState.player.away || gameState.player.carriedMachine != null) {
     return [];
@@ -86,9 +106,7 @@ export function materialSources(
   // A tool in hand commits the hands: material verbs (take, unload, pick
   // up the floor) step aside until it's set down. Full arms step the same
   // verbs aside: the chip never offers a pickup the action would refuse.
-  const handsFree =
-    heldTool(gameState) === null && handSpaceLeft(gameState.player) > 0;
-  if (!handsFree) return [];
+  if (!ignoreHands && takeBlockedReason(gameState) !== null) return [];
 
   const cellMap = CellMap.fromGameState(gameState);
   const cell = cellMap.at(gameState.player.position);
@@ -161,6 +179,16 @@ export function offsetForSource(
   return index === -1 ? null : index;
 }
 
+/** The leaning broom is a step away — where the pick-up offer (or the
+ * note explaining why the hands can't take it) belongs. */
+export function broomWithinReach(gameState: GameState): boolean {
+  return (
+    gameState.broomOwned &&
+    gameState.broomPosition !== null &&
+    chebyshevDistance(gameState.broomPosition, gameState.player.position) <= 1
+  );
+}
+
 function dedupeMachines(machines: ReadonlyArray<Machine>): Machine[] {
   const seen = new Set<string>();
   return machines.filter((machine) => {
@@ -218,11 +246,9 @@ export function resolveInteract(
   // (and a free shoulder). Floor pickups outrank it so a pile lying at
   // the broom's feet — the dustpan moment — still gets E first.
   if (
-    gameState.broomOwned &&
+    broomWithinReach(gameState) &&
     handsFree &&
-    gameState.player.inventory.length === 0 &&
-    gameState.broomPosition !== null &&
-    chebyshevDistance(gameState.broomPosition, gameState.player.position) <= 1
+    gameState.player.inventory.length === 0
   ) {
     return { kind: "pick-up-broom" };
   }

--- a/tests/floor.spec.ts
+++ b/tests/floor.spec.ts
@@ -451,6 +451,43 @@ test.describe("Shop floor", () => {
       const southStance = await chip.boundingBox();
       expect(southStance!.x).toBeCloseTo(northStance!.x, 0);
       expect(southStance!.y).toBeCloseTo(northStance!.y, 0);
+      await test.step("with the arms at capacity the chip explains instead of vanishing", async () => {
+        // The verb row can't be offered (the action would refuse), so
+        // the chip on the piece says why — issue #198.
+        await page.evaluate(() => {
+          window.__UPDATE_GAME_STATE__((state: any) => ({
+            ...state,
+            player: {
+              ...state.player,
+              inventory: Array.from({ length: 4 }, (_, i) => ({
+                id: `e2e-armload-${i}`,
+                type: "board",
+                species: "pine",
+                length: 12,
+                width: 4,
+                thickness: 1,
+                surface: "rough",
+                jointedFaces: 0,
+                jointedEdges: 0,
+              })),
+            },
+          }));
+        });
+        const blocked = page.getByTestId("blocked-pickup-chip");
+        await expect(blocked).toContainText(/Pine/i);
+        await expect(blocked).toContainText("arms full");
+        await expect(page.getByTestId("pickup-chip")).toHaveCount(0);
+        // Hands emptied again, the verb comes back
+        await page.evaluate(() => {
+          window.__UPDATE_GAME_STATE__((state: any) => ({
+            ...state,
+            player: { ...state.player, inventory: [] },
+          }));
+        });
+        await expect(page.getByTestId("pickup-chip").first()).toBeVisible();
+        await expect(blocked).toHaveCount(0);
+      });
+
       // Clear the floor so the board doesn't shadow the broom steps below
       await page.evaluate(() => {
         window.__UPDATE_GAME_STATE__((state: any) => ({


### PR DESCRIPTION
Implements #198: when the hands can't take something, the hint chips now say why instead of silently dropping the verb.

## What changed

- **New `takeBlockedReason`** (`src/game/interact.ts`): one source for the reason text — "arms full", "put the broom down first", "set the vac down first" — and `materialSources` grew an `ignoreHands` mode so the chips can find what a blocked take *would* land on.
- **Blocked floor pickup** keeps a chip on the piece it would grab, named as usual, with the reason where the "pick up" verb would sit (`PlayerPrompt`).
- **Machine take rows, outfeed chips, the truck bed, and the stand** show the same reason in place of the take row (`MachineChips`, `OutfeedChips`, `TruckBedPrompt`, `StandPrompt`).
- **The broom** explains its stricter completely-empty-hands bar ("empty your hands to take the broom").
- **The truck cab** wears "set the X down to head out" while a machine rides the shoulders — previously the chip vanished and the trip card's own advice was unreachable.
- **Two lying chips fixed**: "grab vac" showed while holding the broom though the toggle refuses; "unpack" showed over crates (floor and truck bed) that the armload-gated action would never hoist. Both now show the reason via a new `explainUnpackRefusal` shared with the actions' own gate.
- All reasons render through a shared `ReasonRow` (`HintList.tsx`) — the same muted italic dress the feed-refusal advice already wore, now reused for it too.

## Deliberately not done

Machines don't wear carry-refusal rows ("unload it first"): a loaded bench is loaded all day, so the row would be permanent ambient noise rather than a teaching moment. Noted in #198.

The new walkable store view (in flight on local main) has its own interact layer — worth the same audit once it lands.

## Testing

- New unit tests for `takeBlockedReason`, the `ignoreHands` mode, and `explainUnpackRefusal` (agreement with the action asserted directly)
- New `floor.spec.ts` step: arms at capacity → the blocked chip names the piece and says "arms full", pickup chip absent; hands emptied → verb returns
- `npm run tsc`, all 1081 unit tests, and all 7 Playwright specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)